### PR TITLE
Deal with (=ignore) a former user 

### DIFF
--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -248,7 +248,10 @@ class TypedObject(GenericObject):
         if type_name is None:
             logger.warning(f'Missing type in data {value}. Most likely a User object without type')
             msg = f"Missing 'type' in data {value}"
-            raise ValueError(msg)
+            if value['object'] == 'user':
+                type_name = 'unknown'
+            else:
+                raise ValueError(msg)
 
         sub_cls = cls._typemap.get(type_name)
 


### PR DESCRIPTION

## Description
In https://github.com/ultimate-notion/ultimate-notion/issues/39 a Person is a former user. It has no type and this crashes the pydantic model validation


### Types of change
Ignore this case by returning the type "unknown" when user has no type

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
```
FAILED tests/test_text.py::test_mention - ultimate_notion.utils.EmptyListError: list is empty
FAILED tests/test_text.py::test_rich_text_bases - ultimate_notion.utils.EmptyListError: list is empty
```
(those 2 tests also failed on the main branch)

- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
