### PR TITLE
Schema create uses itself instead of `db.schema`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,4 @@
 * [Florian Wilhelm](https://github.com/florianwilhelm)
 * [al1p-R](https://github.com/al1p-R)
 * [Tzumx](https://github.com/Tzumx)
+* [yonihik](https://github.com/yonihik)

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -315,7 +315,7 @@ class Schema(metaclass=SchemaType):
     @classmethod
     def create(cls, **kwargs) -> Page:
         """Create a page using this schema with a bound database."""
-        return cls.get_db().create_page(**kwargs)
+        return cls.get_db().create_page(_schema=cls, **kwargs)
 
     @classmethod
     def get_props(cls) -> list[Property]:


### PR DESCRIPTION
## Description
<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number for example: Fixes #1234. See also #3456.
If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
when creating a page using an existing schema, we are preparing the properties using the database schema, which may not be accurate(since it infers the attributes from the property names, thus it may infer the same attribute to multiple properties)
since we already have a schema, we can use it directly by simply passing it to the database when creating the page :)

### Types of change
bugfix and slight enhancement

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
