### PR TITLE
New concept for handling the attributes for the properties of a schema

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,181 @@
+# Ultimate Notion Copilot Instructions
+
+## Project Overview
+
+Ultimate Notion is a high-level Python client for the Notion API that provides a Pythonic, object-oriented interface built on top of `notion-sdk-py`. The architecture consists of two main layers:
+
+1. **Low-level obj_api**: Direct Pydantic models mapping Notion API responses (`src/ultimate_notion/obj_api/`)
+2. **High-level API**: User-friendly wrapper classes (`src/ultimate_notion/`)
+
+## CRITICAL: Python Command Execution
+
+🚨 **ALWAYS USE HATCH FOR PYTHON COMMANDS IN VSCODE** 🚨
+
+- **NEVER** use `python` directly in terminal commands
+- **NEVER** use `/path/to/python` directly
+- **ALWAYS** use `hatch run vscode:PYTHON_COMMAND` format
+
+Examples of CORRECT usage:
+- `hatch run vscode:python script.py` (not `python script.py`)
+- `hatch run vscode:mypy src/file.py` (not `mypy src/file.py`)
+- `hatch run vscode:pytest tests/` (not `pytest tests/`)
+- `hatch run vscode:pip install package` (not `pip install package`)
+
+This ensures the correct virtual environment and dependencies are used.
+
+## Core Architecture Patterns
+
+### Two-Layer API Design
+- **obj_api layer**: Pydantic models in `src/ultimate_notion/obj_api/` directly mirror Notion API JSON structures
+- **High-level layer**: Wrapper classes in `src/ultimate_notion/` provide Pythonic interfaces
+- Bridge pattern: `Wrapper[GT]` class in `core.py` connects both layers via `obj_ref` attribute
+
+### Polymorphic Object System
+All obj_api classes inherit from base types with automatic type resolution:
+- `TypedObject[T]` - polymorphic base with `type` field (blocks, properties, etc.)
+- `NotionObject` - top-level resources with `object` field (pages, databases, users)
+- `GenericObject` - basic Pydantic model for nested data
+
+Example pattern:
+```python
+class PropertyValue(TypedObject[Any], polymorphic_base=True):
+    # Base class automatically resolves to correct subtype
+
+class Title(PropertyValue, type='title'):
+    # Automatically registered in _typemap for 'title' type
+```
+
+### UnsetType Pattern
+Use `Unset` sentinel value for optional API fields where `None` has semantic meaning:
+```python
+from ultimate_notion.obj_api.core import Unset, UnsetType
+
+class SomeObject(GenericObject):
+    optional_field: str | UnsetType = Unset  # vs None which means "delete"
+```
+
+## Key Development Workflows
+
+### Running Python Commands (MANDATORY FORMAT)
+- `hatch run vscode:python script.py` - Run Python scripts
+- `hatch run vscode:mypy file.py` - Type checking
+- `hatch run vscode:pytest tests/` - Run tests
+- `hatch run vscode:pip install package` - Install packages
+
+### Testing with VCR.py
+- `hatch run test` - Run tests with VCR recording
+- `hatch run vcr-only` - Offline tests using existing cassettes
+- `hatch run vcr-rewrite` - Regenerate all VCR cassettes
+- `hatch run debug` - Debug tests with pdb
+
+### Linting and Formatting (MANDATORY FOR ALL CHANGES)
+- `hatch run lint:all` - Run mypy + ruff checks (ALWAYS RUN BEFORE SUBMITTING)
+- `hatch run lint:fix` - Auto-fix ruff issues
+- Uses ruff for formatting (single quotes, 120 char line length)
+
+### Environment Management
+- `hatch run upgrade-all` - Upgrade all dependencies
+- `hatch run upgrade-pkg <package>` - Upgrade specific package
+- Environment files in `locks/` directory
+
+## REMEMBER: NEVER USE BARE PYTHON COMMANDS
+
+❌ **WRONG:**
+- `python script.py`
+- `mypy file.py`
+- `pytest tests/`
+- `pip install package`
+
+✅ **CORRECT:**
+- `hatch run vscode:python script.py`
+- `hatch run vscode:mypy file.py`
+- `hatch run vscode:pytest tests/`
+- `hatch run vscode:pip install package`
+
+## Critical Implementation Patterns
+
+### Session Management
+- Single active session via `get_active_session()`
+- Object caching in `Session.cache` by UUID to avoid duplicate API calls
+- Always use context manager: `with uno.Session() as notion:`
+
+### Object Wrapping
+When creating wrapper classes, follow the pattern:
+```python
+class HighLevelObject(Wrapper[LowLevelObject], wraps=LowLevelObject):
+    def __init__(self, ...):
+        # High-level construction logic
+        super().__init__(...)  # Calls LowLevelObject.build()
+```
+
+### Property Value Handling
+- Property values use `PropertyValue.build()` for construction
+- Type mapping via `_type_value_map` class variable
+- Always serialize via `serialize_for_api()` to remove Unset values
+
+### Error Handling
+- Custom exceptions in `errors.py` inherit from base classes
+- Session errors, API usage errors, and object-specific errors
+- Use proper error messages with context
+
+## File Organization
+
+### Core Infrastructure
+- `session.py` - API client and object caching
+- `core.py` - Base wrapper classes and session management
+- `config.py` - Configuration handling with TOML files
+
+### Object Model
+- `obj_api/core.py` - Base Pydantic models with polymorphism
+- `obj_api/objects.py` - Shared object types (users, references, etc.)
+- `obj_api/blocks.py` - Block types (pages, databases, content blocks)
+- `obj_api/props.py` - Property value types
+- `obj_api/schema.py` - Database schema/property definitions
+
+### High-Level API
+- `page.py`, `database.py`, `blocks.py` - Main user-facing objects
+- `schema.py` - Database schema with property classes
+- `query.py` - Database querying with conditions
+- `rich_text.py` - Text formatting and mentions
+
+## Dependencies and Constraints
+
+### Required Dependencies
+- `pydantic ~=2.0` - Core data modeling
+- `notion-client ~=2.4` - Low-level Notion API client
+- `pendulum ~=3.0` - Date/time handling (not datetime)
+
+### Optional Features
+- `[google]` - Google Tasks sync adapter
+- `[pandas]` - DataFrame export
+- `[polars]` - Polars DataFrame export
+
+### Environment Variables
+- `NOTION_TOKEN` - Required for API access
+- `ULTIMATE_NOTION_CONFIG` - Path to config.toml file
+- `ULTIMATE_NOTION_DEBUG` - Enable debug logging
+
+## Common Gotchas
+
+### VCR Testing
+- Never use `datetime.now()` in tests - breaks VCR replay
+- Module-scoped fixtures only record on first test execution
+- Delete cassettes in `tests/cassettes/` to regenerate
+
+### Pydantic Model Updates
+- Use `model_rebuild(force=True)` after changing field defaults
+- Call `_set_field_default()` to modify inherited field values
+
+### Type Resolution
+- Polymorphic classes need `polymorphic_base=True` parameter
+- Missing 'type' field causes resolution errors in TypedObject subclasses
+- obj_api models auto-register in `_typemap` during class creation
+
+## Testing Patterns
+
+- Fixtures in `conftest.py` use module scope for API efficiency
+- Mock external services, use VCR for Notion API
+- Test both obj_api and high-level API layers
+- Use `pytest-recording` for VCR cassette management
+- **MANDATORY**: Always run `hatch run lint:all` before submitting changes to ensure code quality
+- **REMEMBER**: Use `hatch run vscode:pytest` not bare `pytest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Chg: `create_db` has a `title` parameter to set a title if no schema is used or needs to be overwritten.
 - Chg: Removed `from_dict` class method of `Schema` since this can now be more easily done manually.
 - Chg: Unify `Property` and `PropertyType` to simplify declarative approach to schemas.
+- Fix: Possible collision of attribute names in `Page` and `Schema`.
+- Fix: Wrong equality check between properties as well as property values.
 
 ## Version 0.8, 2025-06-23
 

--- a/docs/usage/db_advanced.md
+++ b/docs/usage/db_advanced.md
@@ -106,17 +106,20 @@ employee_db.schema['Level'].options = [
 employee_db.schema.hiring_date = uno.PropType.Text()
 employee_db.schema.hiring_date.name = 'Hiring Date as String'
 employee_db.schema['Hiring Date as String'].name = 'Hiring Date'
+employee_db.schema.hiring_date.attr_name = 'hiring_date_as_str'
+assert employee_db.schema.hiring_date_as_str == uno.PropType.Text()
 ```
 
 This changes the salary property to a formula type, adds a partner level to the level property, changes
 the hiring date first to a text type and the name of it. This is then then followed by setting the name back
-using property access.
+using property access. It also shows how `attr_name` can be used to set the actual attribute name of the schema
+object to `hiring_date_as_str`.
 
 Of course, we can also delete properties:
 
 ```python
 del employee_db.schema['Salary']
-employee_db.schema.hiring_date.delete()
+employee_db.schema.hiring_date_as_str.delete()
 ```
 
 Again using the dictionary and the property approach.

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -11,6 +11,7 @@ from typing_extensions import Self
 
 from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
+from ultimate_notion.obj_api.core import raise_unset
 
 GT = TypeVar('GT', bound=obj_core.GenericObject)  # ToDo: Use new syntax when requires-python >= 3.12
 
@@ -103,12 +104,12 @@ class NotionObject(Wrapper[NO], ABC, wraps=obj_core.NotionObject):
     @property
     def id(self) -> UUID | str:
         """Return the ID of the block."""
-        return self.obj_ref.id
+        return raise_unset(self.obj_ref.id)
 
     @property
     def in_notion(self) -> bool:
         """Return whether the block was created in Notion."""
-        return self.obj_ref.id is not None
+        return self.obj_ref.id != obj_core.Unset
 
 
 NE = TypeVar('NE', bound=obj_core.NotionEntity)  # ToDo: Use new syntax when requires-python >= 3.12
@@ -130,23 +131,24 @@ class NotionEntity(NotionObject[NE], ABC, wraps=obj_core.NotionEntity):
     @property
     def id(self) -> UUID:
         """Return the ID of the entity."""
-        return self.obj_ref.id
+        return raise_unset(self.obj_ref.id)
 
     @property
     def created_time(self) -> dt.datetime:
         """Return the time when the block was created."""
-        return self.obj_ref.created_time
+        return raise_unset(self.obj_ref.created_time)
 
     @property
     def created_by(self) -> User:
         """Return the user who created the block."""
         session = get_active_session()
-        return session.get_user(self.obj_ref.created_by.id, raise_on_unknown=False)
+        created_by = raise_unset(self.obj_ref.created_by)
+        return session.get_user(raise_unset(created_by.id), raise_on_unknown=False)
 
     @property
     def last_edited_time(self) -> dt.datetime:
         """Return the time when the block was last edited."""
-        return self.obj_ref.last_edited_time
+        return raise_unset(self.obj_ref.last_edited_time)
 
     @property
     def parent(self) -> NotionEntity | None:

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -21,18 +21,6 @@ if TYPE_CHECKING:
     from ultimate_notion.user import User
 
 
-class NoDefaultType:
-    """Sentinel type for missing default values."""
-
-    __slots__ = ()
-
-    def __repr__(self) -> str:
-        return '<NoDefault>'
-
-
-NoDefault = NoDefaultType()
-
-
 class ObjRefWrapper(Protocol[GT]):
     """Wrapper for objects that have an obj_ref attribute.
 

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -21,6 +21,18 @@ if TYPE_CHECKING:
     from ultimate_notion.user import User
 
 
+class NoDefaultType:
+    """Sentinel type for missing default values."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return '<NoDefault>'
+
+
+NoDefault = NoDefaultType()
+
+
 class ObjRefWrapper(Protocol[GT]):
     """Wrapper for objects that have an obj_ref attribute.
 

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -15,7 +15,7 @@ from ultimate_notion.file import FileInfo
 from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.page import Page
 from ultimate_notion.query import Query
-from ultimate_notion.rich_text import Text, camel_case, snake_case
+from ultimate_notion.rich_text import Text, camel_case
 from ultimate_notion.schema import Property, Schema
 from ultimate_notion.view import View
 
@@ -107,7 +107,7 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
         """Reflection about the database schema."""
         title = str(self)
         cls_name = f'{camel_case(title)}Schema'
-        attrs = {snake_case(k): Property.wrap_obj_ref(v) for k, v in obj_ref.properties.items()}
+        attrs = {'_props': [Property.wrap_obj_ref(v) for v in obj_ref.properties.values()]}
         schema: type[Schema] = type(cls_name, (Schema,), attrs, db_title=title)
         schema.bind_db(self)
         return schema
@@ -196,7 +196,7 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
         attr_to_name = {prop.attr_name: prop.name for prop in self.schema.get_props()}
         if not set(kwargs).issubset(set(attr_to_name)):
             add_kwargs = set(kwargs) - set(attr_to_name)
-            msg = f'kwargs {", ".join(add_kwargs)} not defined in schema'
+            msg = f'Attributes {", ".join(add_kwargs)} not defined for properties in schema {self.__class__.__name__}'
             raise SchemaError(msg)
         if ro_props := set(kwargs) & {prop.attr_name for prop in self.schema.get_ro_props()}:
             msg = f'Read-only properties {", ".join(ro_props)} cannot be set'

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -109,13 +109,13 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
         cls_name = f'{camel_case(title)}Schema'
         attrs = {'_props': [Property.wrap_obj_ref(v) for v in obj_ref.properties.values()]}
         schema: type[Schema] = type(cls_name, (Schema,), attrs, db_title=title)
-        schema.bind_db(self)
+        schema._bind_db(self)
         return schema
 
     def _set_schema(self, schema: type[Schema], *, during_init: bool) -> None:
         """Set a custom schema in order to change the Python variables names."""
         self.schema.assert_consistency_with(schema, during_init=during_init)
-        schema.bind_db(self)
+        schema._bind_db(self)
         self._schema = schema
 
     @property

--- a/src/ultimate_notion/obj_api/__init__.py
+++ b/src/ultimate_notion/obj_api/__init__.py
@@ -86,3 +86,5 @@ __all__ = ['NotionAPI', 'create_notion_client']
 #       Idea: Use a sentinel value, e.g. API_RESPONSE = object() as default value for fields that are only given
 #       by the API and not sent to the API. This way we can differentiate between the two cases.
 #       Maybe use T_UNSET und UNSET like in endpoints already used.
+# ToDo: This would also allow to have a in GenericObject an __eq__ that ignores unset fields by the Notion API.
+# .      recuding code in SelectOption, Relation and Rollup.

--- a/src/ultimate_notion/obj_api/__init__.py
+++ b/src/ultimate_notion/obj_api/__init__.py
@@ -80,11 +80,3 @@ def create_notion_client(cfg: Config, **kwargs: Any) -> notion_client.Client:
 
 
 __all__ = ['NotionAPI', 'create_notion_client']
-
-# ToDo: Recheck every model if `= None` really is needed. Maybe come up with an even smarter way
-#       to differentiate between a model for sending and receiving data.
-#       Idea: Use a sentinel value, e.g. API_RESPONSE = object() as default value for fields that are only given
-#       by the API and not sent to the API. This way we can differentiate between the two cases.
-#       Maybe use T_UNSET und UNSET like in endpoints already used.
-# ToDo: This would also allow to have a in GenericObject an __eq__ that ignores unset fields by the Notion API.
-# .      recuding code in SelectOption, Relation and Rollup.

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -1,6 +1,17 @@
 """Wrapper for Notion API blocks.
 
 Blocks are the base for all Notion content.
+
+For validation the Pydantic model fields specify if a field is optional or not.
+Some fields are always set, e.g. `id`, when retrieving an object but must not be set
+when sending the object to the Notion API in order to create the object.
+To model this behavior, the default sentinel value `Unset` is used for those objects, e.g.
+```
+class SelectOption(GenericObject)
+    id: str | UnsetType = Unset
+```
+Be aware that this is important when updating to differentiate between the actual set
+values from default/unset values.
 """
 
 from __future__ import annotations

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -28,6 +28,19 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+
+class UnsetType:
+    """Sentinel type for missing default values."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return '<Unset>'
+
+
+Unset: UnsetType = UnsetType()
+
+
 BASE_URL_PATTERN = r'https://(www.)?notion.so/'
 UUID_PATTERN = r'[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}'
 

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -6,7 +6,7 @@ import builtins
 import logging
 import re
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, NoReturn, TypeVar, cast, overload
 from uuid import UUID
 
 from pydantic import (
@@ -85,6 +85,10 @@ class UnsetType(BaseModel):
 Unset: UnsetType = UnsetType()
 
 
+@overload
+def raise_unset(obj: UnsetType) -> NoReturn: ...
+@overload
+def raise_unset(obj: T) -> T: ...
 def raise_unset(obj: T | UnsetType) -> T:
     """Raise an error if the object is unset."""
     if isinstance(obj, UnsetType):
@@ -191,7 +195,7 @@ class UniqueObject(GenericObject):
     This is the base class for all Notion objects that have a unique identifier, i.e. `id`.
     """
 
-    id: UUID | str = Field(union_mode='left_to_right', default=None)  # type: ignore
+    id: UUID | str | UnsetType = Field(union_mode='left_to_right', default=Unset)
     """`id` is an `UUID` if possible or a string (possibly not unique) depending on the object"""
 
     def __hash__(self) -> int:
@@ -257,13 +261,13 @@ class NotionObject(UniqueObject):
 class NotionEntity(NotionObject):
     """A materialized entity, which was created by a user."""
 
-    id: UUID = None  # type: ignore
-    parent: SerializeAsAny[ParentRef] = None  # type: ignore
+    id: UUID | UnsetType = Unset
+    parent: SerializeAsAny[ParentRef] | UnsetType = Unset
 
-    created_time: datetime = None  # type: ignore
-    created_by: UserRef = None  # type: ignore
+    created_time: datetime | UnsetType = Unset
+    created_by: UserRef | UnsetType = Unset
 
-    last_edited_time: datetime = None  # type: ignore
+    last_edited_time: datetime | UnsetType = Unset
 
 
 class TypedObject(GenericObject, Generic[T]):

--- a/src/ultimate_notion/obj_api/endpoints.py
+++ b/src/ultimate_notion/obj_api/endpoints.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 from pydantic import SerializeAsAny, TypeAdapter
 
 from ultimate_notion.obj_api.blocks import Block, Database, FileBase, Page
+from ultimate_notion.obj_api.core import Unset, UnsetType
 from ultimate_notion.obj_api.iterator import EndpointIterator, PropertyItemList
 from ultimate_notion.obj_api.objects import (
     Comment,
@@ -46,8 +47,6 @@ if TYPE_CHECKING:
     from notion_client.api_endpoints import UsersEndpoint as NCUsersEndpoint
 
 _logger = logging.getLogger(__name__)
-T_UNSET: TypeAlias = Literal['UNSET']
-UNSET: T_UNSET = 'UNSET'
 
 
 class NotionAPI:
@@ -401,9 +400,9 @@ class PagesEndpoint(Endpoint):
         self,
         page: Page,
         *,
-        cover: FileObject | T_UNSET | None = UNSET,
-        icon: FileObject | EmojiObject | CustomEmojiObject | T_UNSET | None = UNSET,
-        in_trash: bool | T_UNSET = UNSET,
+        cover: FileObject | UnsetType | None = Unset,
+        icon: FileObject | EmojiObject | CustomEmojiObject | UnsetType | None = Unset,
+        in_trash: bool | UnsetType = Unset,
     ) -> Page:
         """Set specific page attributes (such as cover, icon, etc.) on the server.
 
@@ -414,7 +413,7 @@ class PagesEndpoint(Endpoint):
         page_id = PageRef.build(page).page_id
         props: dict[str, Any] = {}
 
-        if cover is not UNSET:
+        if cover is not Unset:
             if cover is None:
                 _logger.debug(f'Removing cover from page with id `{page_id}`.')
                 props['cover'] = None
@@ -422,7 +421,7 @@ class PagesEndpoint(Endpoint):
                 _logger.debug(f'Setting cover on page with id `{page_id}`.')
                 props['cover'] = cover.serialize_for_api()  # type: ignore[union-attr]
 
-        if icon is not UNSET:
+        if icon is not Unset:
             if icon is None:
                 _logger.debug(f'Removing icon from page with id `{page_id}`.')
                 props['icon'] = None
@@ -430,7 +429,7 @@ class PagesEndpoint(Endpoint):
                 _logger.debug(f'Setting icon on page with id `{page_id}`.')
                 props['icon'] = icon.serialize_for_api()  # type: ignore[union-attr]
 
-        if in_trash is not UNSET:
+        if in_trash is not Unset:
             if in_trash:
                 _logger.debug(f'Deleting page with id `{page_id}`.')
                 props['archived'] = True

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -47,6 +47,18 @@ class SelectOption(GenericObject):
         """Create a `SelectOption` object from the given name and color."""
         return cls.model_construct(name=name, color=color)
 
+    def __eq__(self, other: object) -> bool:
+        """Compare SelectOption objects by all attributes except id."""
+        if not isinstance(other, SelectOption):
+            return False
+        return self.name == other.name and self.color == other.color and self.description == other.description
+
+    def __hash__(self) -> int:
+        """Return a hash of the SelectOption based on name, color, and description."""
+        # Convert description list to tuple for hashing if it exists
+        desc_tuple = tuple(self.description) if self.description else None
+        return hash((self.name, self.color, desc_tuple))
+
 
 class SelectGroup(GenericObject):
     """Group of options for status objects."""

--- a/src/ultimate_notion/obj_api/props.py
+++ b/src/ultimate_notion/obj_api/props.py
@@ -66,8 +66,7 @@ class PropertyValue(TypedObject[Any], polymorphic_base=True):
 
     def serialize_for_api(self) -> dict[str, Any]:
         """Serialize the object for sending it to the Notion API."""
-        # We include "null" values as those are used to delete properties
-        dump_dct = self.model_dump(mode='json', exclude_none=True, by_alias=True)
+        dump_dct = super().serialize_for_api()
         dump_dct.setdefault(dump_dct['type'], None)
         return dump_dct
 

--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -11,7 +11,7 @@ from ultimate_notion.rich_text import Text
 class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     """Option for select & multi-select property."""
 
-    def __init__(self, name: str, *, color: Color | str | None = None) -> None:
+    def __init__(self, name: str, *, color: Color | str = Color.DEFAULT) -> None:
         if isinstance(color, str):
             color = Color(color)
         super().__init__(name, color=color)

--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -11,7 +11,7 @@ from ultimate_notion.rich_text import Text
 class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     """Option for select & multi-select property."""
 
-    def __init__(self, name: str, *, color: Color | str | None = None):
+    def __init__(self, name: str, *, color: Color | str | None = None) -> None:
         if isinstance(color, str):
             color = Color(color)
         super().__init__(name, color=color)

--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ultimate_notion.core import Wrapper, get_repr
 from ultimate_notion.obj_api import objects as objs
+from ultimate_notion.obj_api.core import Unset, UnsetType, raise_unset
 from ultimate_notion.obj_api.enums import Color
 from ultimate_notion.rich_text import Text
 
@@ -11,7 +12,7 @@ from ultimate_notion.rich_text import Text
 class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     """Option for select & multi-select property."""
 
-    def __init__(self, name: str, *, color: Color | str = Color.DEFAULT) -> None:
+    def __init__(self, name: str, *, color: Color | str | UnsetType = Unset) -> None:
         if isinstance(color, str):
             color = Color(color)
         super().__init__(name, color=color)
@@ -24,8 +25,7 @@ class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Option):
-            # We do not compare the id, as it is not always set
-            res = (self.name == other.name) & (self.color == other.color) & (self.description == other.description)
+            res = self.obj_ref == other.obj_ref
         elif isinstance(other, str):
             res = self.name == other
         elif other is None:
@@ -41,7 +41,7 @@ class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     @property
     def id(self) -> str:
         """ID of the option."""
-        return self.obj_ref.id
+        return raise_unset(self.obj_ref.id)
 
     @property
     def name(self) -> str:
@@ -51,10 +51,9 @@ class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     @property
     def color(self) -> Color:
         """Color of the option."""
-        if color := self.obj_ref.color:
-            return color
-        else:
-            # for uninitialized options, return default color
+        try:
+            return raise_unset(self.obj_ref.color)
+        except ValueError:  # i.e. unset value
             return Color.DEFAULT
 
     @property

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -16,6 +16,7 @@ from ultimate_notion.file import FileInfo
 from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api import props as obj_props
+from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.props import MAX_ITEMS_PER_PROPERTY
 from ultimate_notion.props import PropertyValue, Title
 from ultimate_notion.rich_text import Text, render_md
@@ -159,7 +160,7 @@ class Page(
     @property
     def url(self) -> str:
         """Return the URL of this page."""
-        return self.obj_ref.url
+        return raise_unset(self.obj_ref.url)
 
     @property
     def public_url(self) -> str | None:
@@ -346,7 +347,7 @@ class Page(
     def reload(self) -> Self:
         """Reload this page."""
         session = get_active_session()
-        self.obj_ref = session.api.pages.retrieve(self.obj_ref.id)
+        self.obj_ref = session.api.pages.retrieve(self.id)
         self._children = None  # forces a new retrieval of children next time
         self._comments = None  # forces a new retrieval of comments next time
         return self

--- a/src/ultimate_notion/props.py
+++ b/src/ultimate_notion/props.py
@@ -59,9 +59,7 @@ class PropertyValue(Wrapper[T], ABC, wraps=obj_props.PropertyValue):  # noqa: PL
         if not isinstance(other, PropertyValue):
             return NotImplemented
         other_obj_ref = cast(T, other.obj_ref)
-        # ToDo: FIXME, this is a serious bug! The next line is correct
-        # return (self.obj_ref.type == other_obj_ref.type) and (self.obj_ref.value == other_obj_ref.value)
-        return (self.obj_ref.type == other_obj_ref.type) and (self.obj_ref.value == self.obj_ref.value)
+        return (self.obj_ref.type == other_obj_ref.type) and (self.obj_ref.value == other_obj_ref.value)
 
     @property
     @abstractmethod

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -275,7 +275,7 @@ class SchemaType(ABCMeta):
         if isinstance(prop_type, Relation) and (prop_type._two_way_prop is not None):
             prop_type._rename_two_way_prop(prop if isinstance(prop := prop_type._two_way_prop, str) else prop.name)
 
-    def __getattr__(cls: type[Schema], name: str) -> Property:  # type: ignore
+    def __getattr__(cls: type[Schema], name: str) -> Property:  # type: ignore[misc]
         attr_name_props = SList([prop for prop in cls.get_props() if prop._attr_name == name])
         try:
             return attr_name_props.item()

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -33,7 +33,7 @@ from typing_extensions import Self
 
 import ultimate_notion.obj_api.schema as obj_schema
 from ultimate_notion import rich_text
-from ultimate_notion.core import NoDefault, Wrapper, get_active_session, get_repr
+from ultimate_notion.core import Wrapper, get_active_session, get_repr
 from ultimate_notion.errors import (
     EmptyListError,
     InvalidAPIUsageError,
@@ -44,14 +44,15 @@ from ultimate_notion.errors import (
     SchemaError,
     SchemaNotBoundError,
 )
+from ultimate_notion.obj_api.core import Unset
 from ultimate_notion.obj_api.schema import AggFunc, NumberFormat
 from ultimate_notion.option import Option, OptionGroup, OptionNS, check_for_updates
 from ultimate_notion.props import PropertyValue
 from ultimate_notion.utils import SList, dict_diff_str, is_notebook
 
 if TYPE_CHECKING:
-    from ultimate_notion.core import NoDefaultType
     from ultimate_notion.database import Database
+    from ultimate_notion.obj_api.core import UnsetType
     from ultimate_notion.page import Page
 
 T = TypeVar('T')
@@ -383,18 +384,18 @@ class Schema(metaclass=SchemaType):
 
     @overload
     @classmethod
-    def get_prop(cls, prop_name: str, *, default: NoDefaultType = ...) -> Property: ...
+    def get_prop(cls, prop_name: str, *, default: UnsetType = ...) -> Property: ...
     @overload
     @classmethod
     def get_prop(cls, prop_name: str, *, default: T) -> Property | T: ...
 
     @classmethod
-    def get_prop(cls, prop_name: str, *, default: object = NoDefault) -> Property | T:
+    def get_prop(cls, prop_name: str, *, default: object = Unset) -> Property | T:
         """Get a specific property from this schema assuming that property names are unique."""
         try:
             return SList([prop for prop in cls.get_props() if prop.name == prop_name]).item()
         except EmptyListError as e:
-            if default is NoDefault:
+            if default is Unset:
                 if cls.is_bound():
                     msg = f'Property `{prop_name}` not found in schema of `{cls._database}`.'
                 else:

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -166,7 +166,7 @@ class Session:
         if title is not None:
             title = Text(title)
         elif title is None and schema is not None:
-            title = schema.db_title
+            title = schema._db_title
 
         db_schema: type[Schema] = cast(type[Schema], DefaultSchema) if schema is None else schema
         _logger.info(f'Creating database `{title or "<NoTitle>"}` in page `{parent.title}` with schema:\n{db_schema}')
@@ -178,8 +178,8 @@ class Session:
         db: Database = Database.wrap_obj_ref(db_obj)
 
         if schema:
-            if schema.db_desc:
-                self.api.databases.update(db_obj, description=schema.db_desc.obj_ref)
+            if schema._db_desc:
+                self.api.databases.update(db_obj, description=schema._db_desc.obj_ref)
             db._set_schema(schema, during_init=True)  # schema is thus bound to the database
             schema._init_self_refs()
             schema._init_self_ref_rollups()
@@ -230,10 +230,10 @@ class Session:
 
     def get_or_create_db(self, parent: Page, schema: type[Schema]) -> Database:
         """Get or create the database."""
-        dbs = SList(db for db in self.search_db(schema.db_title) if db.parent == parent)
+        dbs = SList(db for db in self.search_db(schema._db_title) if db.parent == parent)
         if len(dbs) == 0:
             db = self.create_db(parent, schema=schema)
-            while not [db for db in self.search_db(schema.db_title) if db.parent == parent]:
+            while not [db for db in self.search_db(schema._db_title) if db.parent == parent]:
                 _logger.info(f'Waiting for database `{db.title}` to be fully created.')
                 time.sleep(1)
             return db

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -20,6 +20,7 @@ from ultimate_notion.errors import SessionError, UnknownPageError, UnknownUserEr
 from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.obj_api import create_notion_client
 from ultimate_notion.obj_api import query as obj_query
+from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.endpoints import NotionAPI
 from ultimate_notion.obj_api.objects import UnknownUser as UnknownUserObj
 from ultimate_notion.obj_api.objects import get_uuid
@@ -208,7 +209,10 @@ class Session:
         query: obj_query.SearchQueryBuilder[obj_blocks.Database] = self.api.search(db_name).filter(db_only=True)
         if reverse:
             query.sort(ascending=True)
-        dbs = [cast(Database, self.cache.setdefault(db.id, Database.wrap_obj_ref(db))) for db in query.execute()]
+        dbs = [
+            cast(Database, self.cache.setdefault(raise_unset(db.id), Database.wrap_obj_ref(db)))
+            for db in query.execute()
+        ]
         if exact and db_name is not None:
             dbs = [db for db in dbs if db.title == db_name]
         if not deleted:
@@ -255,7 +259,8 @@ class Session:
         if reverse:
             query.sort(ascending=True)
         pages = [
-            cast(Page, self.cache.setdefault(page_obj.id, Page.wrap_obj_ref(page_obj))) for page_obj in query.execute()
+            cast(Page, self.cache.setdefault(raise_unset(page_obj.id), Page.wrap_obj_ref(page_obj)))
+            for page_obj in query.execute()
         ]
         if exact and title is not None:
             pages = [page for page in pages if page.title == title]

--- a/tests/cassettes/test_schema/test_add_del_update_prop.yaml
+++ b/tests/cassettes/test_schema/test_add_del_update_prop.yaml
@@ -34,14 +34,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
-      Prop-Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%40%3DhI","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"7bb431b5-446c-45e8-8b0a-3f572f7401f4","name":"Cat1","color":"default","description":null},{"id":"cbe67030-a6d2-41cc-96f7-15a38001cf00","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"%5DbuZ","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"842c5532-5413-411d-b55f-79a47ee5cd5c"}'
+      Prop-Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"vz%5Dp","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"9fd6b412-8561-43c3-a997-c60b1ed6f4cc","name":"Cat1","color":"default","description":null},{"id":"484ad9c1-a589-48a0-ad68-570a2c8918a3","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"w%3A%7Cy","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"b0d684e1-32e2-4aaa-9efa-ff9ec2a9e053"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900518afb4170a-AMS
+      - 970111b9f850694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -51,10 +51,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=8LUkZc2gd6CsHaLcrS7mt_TeplxWIgpG8JreHB8zxqw-1754163343-1.0.1.1-Rxo6q4jydUJh86o1apPn2suW1ut_hv7oI4TddHX_g4V6nzeHQ3pRLYaIuHo.JbHKPF2Ii17oacQrZHwVF_MnabNwMnjRAI4q0bpqdxfD3Y8;
-        path=/; expires=Sat, 02-Aug-25 20:05:43 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=C.PFbt3E0cRZq7LYkHoqX7VFDOaSe55gfKZKAb3Abmk-1755348751-1.0.1.1-TBt8Huga7sIgWriIJQSCUxLB0RzmRyf9A2LbgZZf5YALYOU9Ss47tvrhKLbxLsZgHS85cxex5KUNvAHsqIQpmvBp5WsBzH5q9q9qfBFYLhQ;
+        path=/; expires=Sat, 16-Aug-25 13:22:31 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=T8SogroAaEuoascmBEcVCVWjxTFfI65Dh494AnA2hyQ-1754163343272-0.0.1.1-604800000;
+      - _cfuvid=xbd2M0nP3LJWXitSkkpVtAQ5hOPp3Zyuz.D5BWxPQaY-1755348751241-0.0.1.1-604800000;
         path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -77,7 +77,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 842c5532-5413-411d-b55f-79a47ee5cd5c
+      - b0d684e1-32e2-4aaa-9efa-ff9ec2a9e053
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -111,18 +111,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Tags":{"id":"%40%3DhI","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"7bb431b5-446c-45e8-8b0a-3f572f7401f4","name":"Cat1","color":"default","description":null},{"id":"cbe67030-a6d2-41cc-96f7-15a38001cf00","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"%5DbuZ","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"abae217e-52e1-4a0c-80dc-fccf1382a954"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"vz%5Dp","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"9fd6b412-8561-43c3-a997-c60b1ed6f4cc","name":"Cat1","color":"default","description":null},{"id":"484ad9c1-a589-48a0-ad68-570a2c8918a3","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"w%3A%7Cy","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"789edbbf-b047-4a32-83ad-5aa524833981"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 969005203e20170a-AMS
+      - 970111c01c5c694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -152,7 +152,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - abae217e-52e1-4a0c-80dc-fccf1382a954
+      - 789edbbf-b047-4a32-83ad-5aa524833981
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -183,18 +183,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Tags":{"id":"%40%3DhI","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"7bb431b5-446c-45e8-8b0a-3f572f7401f4","name":"Cat1","color":"default","description":null},{"id":"cbe67030-a6d2-41cc-96f7-15a38001cf00","name":"Cat2","color":"red","description":null}]}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"385bbcb4-c66a-4f03-805f-ceaf4e9932a2"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"vz%5Dp","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"9fd6b412-8561-43c3-a997-c60b1ed6f4cc","name":"Cat1","color":"default","description":null},{"id":"484ad9c1-a589-48a0-ad68-570a2c8918a3","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"d739a8d0-9596-48c2-a4f8-8147e03ee906"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900529af5f170a-AMS
+      - 970111c29dce694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -224,7 +224,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 385bbcb4-c66a-4f03-805f-ceaf4e9932a2
+      - d739a8d0-9596-48c2-a4f8-8147e03ee906
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -251,18 +251,18 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Tags":{"id":"%40%3DhI","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"7bb431b5-446c-45e8-8b0a-3f572f7401f4","name":"Cat1","color":"default","description":null},{"id":"cbe67030-a6d2-41cc-96f7-15a38001cf00","name":"Cat2","color":"red","description":null}]}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"409c0330-e082-489d-b3c3-5558ab74f0e0"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"vz%5Dp","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"9fd6b412-8561-43c3-a997-c60b1ed6f4cc","name":"Cat1","color":"default","description":null},{"id":"484ad9c1-a589-48a0-ad68-570a2c8918a3","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"0ea90db0-0571-4446-8ae4-2832e6f876be"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 969005318fcb170a-AMS
+      - 970111c53f11694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -292,7 +292,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 409c0330-e082-489d-b3c3-5558ab74f0e0
+      - 0ea90db0-0571-4446-8ae4-2832e6f876be
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -323,18 +323,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"2f2edaaa-112c-46b7-9a26-413cced8a564"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"31bdd5fb-83dc-495d-849f-895540395b83"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 969005346e0b170a-AMS
+      - 970111c6cfeb694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -364,7 +364,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 2f2edaaa-112c-46b7-9a26-413cced8a564
+      - 31bdd5fb-83dc-495d-849f-895540395b83
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -391,18 +391,18 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"a59962d5-8263-4c1d-a58d-ae78f98bfb38"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"b94b18ad-7443-4ee4-aeba-2b9039ac30a4"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 969005380cd9170a-AMS
+      - 970111c999b1694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -432,7 +432,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a59962d5-8263-4c1d-a58d-ae78f98bfb38
+      - b94b18ad-7443-4ee4-aeba-2b9039ac30a4
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -463,18 +463,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"dcd9499d-f1e1-4248-be08-0b7d0292545c"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Number":{"id":"Q%7B~%3C","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"28b4fe78-9b3c-48b8-a36f-a72bca97a4da"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9690053a1909170a-AMS
+      - 970111cb6b25694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -504,7 +504,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - dcd9499d-f1e1-4248-be08-0b7d0292545c
+      - 28b4fe78-9b3c-48b8-a36f-a72bca97a4da
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -531,18 +531,18 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"b3a1c913-e063-4d5f-b4bc-f9400cbc27ef"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Number":{"id":"Q%7B~%3C","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"c283a9bb-7184-42ef-9e04-d398d986e487"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900540ad5c170a-AMS
+      - 970111cecd33694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -572,7 +572,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - b3a1c913-e063-4d5f-b4bc-f9400cbc27ef
+      - c283a9bb-7184-42ef-9e04-d398d986e487
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -603,18 +603,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"a41db655-d2f6-4852-b9d3-6b76ecdcbef1"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Number":{"id":"Q%7B~%3C","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"e5ad96d6-c4c9-4d68-b229-c90a00c94837"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900546883c170a-AMS
+      - 970111d0ae79694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -644,7 +644,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a41db655-d2f6-4852-b9d3-6b76ecdcbef1
+      - e5ad96d6-c4c9-4d68-b229-c90a00c94837
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -671,18 +671,18 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"995d60b3-743d-40ab-b0c7-48ce23f88320"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Number":{"id":"Q%7B~%3C","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"4eda28bc-b263-4300-a91a-23c131840560"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900549eee3170a-AMS
+      - 970111ff6f4f694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -712,7 +712,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 995d60b3-743d-40ab-b0c7-48ce23f88320
+      - 4eda28bc-b263-4300-a91a-23c131840560
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -749,14 +749,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"243974f3-b388-8173-903e-cd80a7f85c57","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-81f4-9118-e1451daa7e2a","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
-      Prop-Test","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b3888173903ecd80a7f85c57","public_url":null,"archived":false,"in_trash":false,"request_id":"54d2b14a-c18b-4574-a8f4-d0fd79d34d6b"}'
+      Prop-Test","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881f49118e1451daa7e2a","public_url":null,"archived":false,"in_trash":false,"request_id":"96f65b0c-b4e5-492c-9012-6158cb9f93f6"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9690055b59d7170a-AMS
+      - 97011205db92694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -786,7 +786,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 54d2b14a-c18b-4574-a8f4-d0fd79d34d6b
+      - 96f65b0c-b4e5-492c-9012-6158cb9f93f6
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -821,18 +821,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-8173-903e-cd80a7f85c57
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81f4-9118-e1451daa7e2a
   response:
-    content: '{"object":"database","id":"243974f3-b388-8173-903e-cd80a7f85c57","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-81f4-9118-e1451daa7e2a","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Target
       schema as self-reference relations lead to a Notion Internal Server Error 500","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
-      schema as self-reference relations lead to a Notion Internal Server Error 500","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b3888173903ecd80a7f85c57","public_url":null,"archived":false,"in_trash":false,"request_id":"cd64e626-4326-4714-a16a-cd8c976d1315"}'
+      schema as self-reference relations lead to a Notion Internal Server Error 500","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881f49118e1451daa7e2a","public_url":null,"archived":false,"in_trash":false,"request_id":"d1a06120-2ace-49ef-90ce-482c5f51b08a"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 969005612d49170a-AMS
+      - 970112093dba694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -862,7 +862,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - cd64e626-4326-4714-a16a-cd8c976d1315
+      - d1a06120-2ace-49ef-90ce-482c5f51b08a
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -871,7 +871,7 @@ interactions:
     status_code: 200
 - request:
     body: '{"properties": {"Relation": {"type": "relation", "relation": {"type": "dual_property",
-      "database_id": "243974f3-b388-8173-903e-cd80a7f85c57", "dual_property": {}}}}}'
+      "database_id": "251974f3-b388-81f4-9118-e1451daa7e2a", "dual_property": {}}}}}'
     headers:
       accept:
       - '*/*'
@@ -894,19 +894,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"dollar"}},"Relation":{"id":"cz%7Bu","name":"Relation","type":"relation","relation":{"database_id":"243974f3-b388-8173-903e-cd80a7f85c57","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Add/Del/Update Prop-Test (Relation)","synced_property_id":"bda%7B"}}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"79591760-0256-4bea-afbf-a9cf7cfaaf71"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Add/Del/Update Prop-Test (Relation)","synced_property_id":"itcd"}}},"Number":{"id":"Q%7B~%3C","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"c628f4c4-046b-4bb6-bcfc-c92eb1522597"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900567698a170a-AMS
+      - 97011212ccf2694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -936,7 +936,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 79591760-0256-4bea-afbf-a9cf7cfaaf71
+      - c628f4c4-046b-4bb6-bcfc-c92eb1522597
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -963,20 +963,20 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-8173-903e-cd80a7f85c57
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81f4-9118-e1451daa7e2a
   response:
-    content: '{"object":"database","id":"243974f3-b388-8173-903e-cd80a7f85c57","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-81f4-9118-e1451daa7e2a","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Target
       schema as self-reference relations lead to a Notion Internal Server Error 500","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
       schema as self-reference relations lead to a Notion Internal Server Error 500","href":null}],"is_inline":false,"properties":{"Related
-      to Add/Del/Update Prop-Test (Relation)":{"id":"bda%7B","name":"Related to Add/Del/Update
-      Prop-Test (Relation)","type":"relation","relation":{"database_id":"243974f3-b388-817c-b289-e8f5813632de","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"cz%7Bu"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b3888173903ecd80a7f85c57","public_url":null,"archived":false,"in_trash":false,"request_id":"e872b8b6-a2a8-4bbc-8c08-edfa86763bea"}'
+      to Add/Del/Update Prop-Test (Relation)":{"id":"itcd","name":"Related to Add/Del/Update
+      Prop-Test (Relation)","type":"relation","relation":{"database_id":"251974f3-b388-8108-880d-e71427f21995","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"KuFP"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881f49118e1451daa7e2a","public_url":null,"archived":false,"in_trash":false,"request_id":"07e105f8-2baf-491f-b5de-f9a59fb92eb5"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9690056cdbdd170a-AMS
+      - 970112189884694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1006,7 +1006,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - e872b8b6-a2a8-4bbc-8c08-edfa86763bea
+      - 07e105f8-2baf-491f-b5de-f9a59fb92eb5
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1038,19 +1038,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-8173-903e-cd80a7f85c57
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81f4-9118-e1451daa7e2a
   response:
-    content: '{"object":"database","id":"243974f3-b388-8173-903e-cd80a7f85c57","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-81f4-9118-e1451daa7e2a","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Target
       schema as self-reference relations lead to a Notion Internal Server Error 500","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
       schema as self-reference relations lead to a Notion Internal Server Error 500","href":null}],"is_inline":false,"properties":{"Back
-      Relation":{"id":"bda%7B","name":"Back Relation","type":"relation","relation":{"database_id":"243974f3-b388-817c-b289-e8f5813632de","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"cz%7Bu"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b3888173903ecd80a7f85c57","public_url":null,"archived":false,"in_trash":false,"request_id":"61dc0562-2010-4b09-95cf-b512e11c6d5f"}'
+      Relation":{"id":"itcd","name":"Back Relation","type":"relation","relation":{"database_id":"251974f3-b388-8108-880d-e71427f21995","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"KuFP"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881f49118e1451daa7e2a","public_url":null,"archived":false,"in_trash":false,"request_id":"015fbd60-8827-4504-bafd-87e2a8295fb9"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9690056f48bd170a-AMS
+      - 9701121a69af694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1080,83 +1080,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 61dc0562-2010-4b09-95cf-b512e11c6d5f
-      x-permitted-cross-domain-policies:
-      - none
-      x-xss-protection:
-      - '0'
-    http_version: HTTP/1.1
-    status_code: 200
-- request:
-    body: '{"properties": {"Back Relation": {"type": "relation", "id": "bda%7B", "name":
-      "Back Relation", "relation": {"type": "dual_property", "database_id": "243974f3-b388-817c-b289-e8f5813632de",
-      "dual_property": {"synced_property_name": "Relation", "synced_property_id":
-      "cz%7Bu"}}}}}'
-    headers:
-      accept:
-      - '*/*'
-      accept-encoding:
-      - gzip, deflate
-      authorization:
-      - secret...
-      connection:
-      - keep-alive
-      content-length:
-      - '277'
-      content-type:
-      - application/json
-      cookie:
-      - secret...
-      host:
-      - api.notion.com
-      notion-version:
-      - '2022-06-28'
-      user-agent:
-      - secret...
-    method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-8173-903e-cd80a7f85c57
-  response:
-    content: '{"object":"database","id":"243974f3-b388-8173-903e-cd80a7f85c57","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
-      Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
-      Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Target
-      schema as self-reference relations lead to a Notion Internal Server Error 500","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
-      schema as self-reference relations lead to a Notion Internal Server Error 500","href":null}],"is_inline":false,"properties":{"Back
-      Relation":{"id":"bda%7B","name":"Back Relation","type":"relation","relation":{"database_id":"243974f3-b388-817c-b289-e8f5813632de","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"cz%7Bu"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b3888173903ecd80a7f85c57","public_url":null,"archived":false,"in_trash":false,"request_id":"ca7c1b63-2a56-4b54-beea-47d15d85cc33"}'
-    headers:
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-Ray:
-      - 96900574bb15170a-AMS
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      alt-svc:
-      - h3=":443"; ma=86400
-      content-security-policy:
-      - default-src 'none'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      x-content-type-options:
-      - nosniff
-      x-dns-prefetch-control:
-      - 'off'
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - SAMEORIGIN
-      x-notion-request-id:
-      - ca7c1b63-2a56-4b54-beea-47d15d85cc33
+      - 015fbd60-8827-4504-bafd-87e2a8295fb9
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1183,19 +1107,19 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"dollar"}},"Relation":{"id":"cz%7Bu","name":"Relation","type":"relation","relation":{"database_id":"243974f3-b388-8173-903e-cd80a7f85c57","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"bda%7B"}}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"84833a2d-aef5-41fe-9104-d25a473c45b9"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Number":{"id":"Q%7B~%3C","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"dde1c0a8-afad-40b6-818b-c2867fee0fef"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900577995b170a-AMS
+      - 9701121d5b3a694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1225,7 +1149,80 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 84833a2d-aef5-41fe-9104-d25a473c45b9
+      - dde1c0a8-afad-40b6-818b-c2867fee0fef
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"properties": {"Number": null}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '32'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
+  response:
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+      Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
+      Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
+      for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"bd51355c-2ae6-42d3-985b-d00d34b41607"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9701121eec29694f-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - bd51355c-2ae6-42d3-985b-d00d34b41607
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1257,20 +1254,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
-      + \"!\""}},"Relation":{"id":"cz%7Bu","name":"Relation","type":"relation","relation":{"database_id":"243974f3-b388-8173-903e-cd80a7f85c57","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"bda%7B"}}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"994a370f-4f5c-4cae-be2e-73a777ad841e"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"kdww","name":"Number","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
+      + \"!\""}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"47aad15b-ddbe-4225-bece-c840fce82f79"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900579addf170a-AMS
+      - 97011221cde1694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1300,7 +1297,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 994a370f-4f5c-4cae-be2e-73a777ad841e
+      - 47aad15b-ddbe-4225-bece-c840fce82f79
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1327,20 +1324,20 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
-      + \"!\""}},"Relation":{"id":"cz%7Bu","name":"Relation","type":"relation","relation":{"database_id":"243974f3-b388-8173-903e-cd80a7f85c57","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"bda%7B"}}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"a311d2de-ca0a-4fa4-a7d5-bf17d5b6dd10"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"kdww","name":"Number","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
+      + \"!\""}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"c9f668ac-e6c4-4bb5-b6db-f440f9755425"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900582ef40170a-AMS
+      - 97011225e835694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1370,7 +1367,80 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a311d2de-ca0a-4fa4-a7d5-bf17d5b6dd10
+      - c9f668ac-e6c4-4bb5-b6db-f440f9755425
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"properties": {"Number": null}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '32'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
+  response:
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+      Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
+      Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
+      for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"ea8f6e0d-3140-4895-8018-37a6d4cdb64f"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9701122c5bf4694f-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - ea8f6e0d-3140-4895-8018-37a6d4cdb64f
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1401,19 +1471,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"percent"}},"Relation":{"id":"cz%7Bu","name":"Relation","type":"relation","relation":{"database_id":"243974f3-b388-8173-903e-cd80a7f85c57","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"bda%7B"}}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"77c33f4c-14ff-4920-a5f7-3b669401806b"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"k%7CKg","name":"Number","type":"number","number":{"format":"percent"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"549bc740-b10e-4e54-a65f-765ee8a62a7f"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96900584fb4f170a-AMS
+      - 97011237bb3b694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1443,7 +1513,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 77c33f4c-14ff-4920-a5f7-3b669401806b
+      - 549bc740-b10e-4e54-a65f-765ee8a62a7f
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1470,19 +1540,19 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/243974f3-b388-817c-b289-e8f5813632de
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8108-880d-e71427f21995
   response:
-    content: '{"object":"database","id":"243974f3-b388-817c-b289-e8f5813632de","cover":null,"icon":null,"created_time":"2025-08-02T19:35:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-02T19:35:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
+    content: '{"object":"database","id":"251974f3-b388-8108-880d-e71427f21995","cover":null,"icon":null,"created_time":"2025-08-16T12:52:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T12:52:00.000Z","title":[{"type":"text","text":{"content":"Add/Del/Update
       Prop-Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Add/Del/Update
       Prop-Test","href":null}],"description":[{"type":"text","text":{"content":"Schema
       for testing adding, deleting and updating properties","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"E%5BRE","name":"Date","type":"date","date":{}},"Number":{"id":"GPzL","name":"Number","type":"number","number":{"format":"percent"}},"Relation":{"id":"cz%7Bu","name":"Relation","type":"relation","relation":{"database_id":"243974f3-b388-8173-903e-cd80a7f85c57","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"bda%7B"}}},"Category":{"id":"iLMU","name":"Category","type":"select","select":{"options":[{"id":"e1d2f9dc-c448-4aac-b4aa-703de025ac58","name":"Cat1","color":"default","description":null},{"id":"abd804e5-0e86-4afd-ac39-2aef4d167622","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/243974f3b388817cb289e8f5813632de","public_url":null,"archived":false,"in_trash":false,"request_id":"5f8186b4-78b2-417d-ad2a-88ca0a50f313"}'
+      for testing adding, deleting and updating properties","href":null}],"is_inline":false,"properties":{"Date":{"id":"%3D%3DmP","name":"Date","type":"date","date":{}},"Relation":{"id":"KuFP","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81f4-9118-e1451daa7e2a","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"itcd"}}},"Category":{"id":"erca","name":"Category","type":"select","select":{"options":[{"id":"5da960b2-61e1-41bd-8f12-f4f9bf2f83b0","name":"Cat1","color":"default","description":null},{"id":"53b8b5cd-8f88-46c6-b3ec-75a43e3811ad","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"k%7CKg","name":"Number","type":"number","number":{"format":"percent"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888108880de71427f21995","public_url":null,"archived":false,"in_trash":false,"request_id":"4f5653ef-89b6-4e03-b420-f9a5b9c58f30"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9690058caa0e170a-AMS
+      - 9701123b0d0f694f-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1512,7 +1582,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 5f8186b4-78b2-417d-ad2a-88ca0a50f313
+      - 4f5653ef-89b6-4e03-b420-f9a5b9c58f30
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:

--- a/tests/cassettes/test_schema/test_all_createable_props_schema.yaml
+++ b/tests/cassettes/test_schema/test_all_createable_props_schema.yaml
@@ -4,7 +4,7 @@ interactions:
       "title": [{"type": "text", "plain_text": "Schema A", "annotations": {"bold":
       false, "italic": false, "strikethrough": false, "underline": false, "code":
       false, "color": "default"}, "text": {"content": "Schema A"}}], "properties":
-      {"Name": {"type": "title", "title": {}}}}'
+      {"Name": {"type": "title", "title": {}}}, "is_inline": false}'
     headers:
       accept:
       - '*/*'
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '354'
+      - '374'
       content-type:
       - application/json
       cookie:
@@ -29,14 +29,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","cover":null,"icon":null,"created_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-06-23T13:39:00.000Z","title":[{"type":"text","text":{"content":"Schema
+    content: '{"object":"database","id":"251974f3-b388-81b1-b4e1-d3b0c759a486","cover":null,"icon":null,"created_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:29:00.000Z","title":[{"type":"text","text":{"content":"Schema
       A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      A","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/21b974f3b38881149e7af0d6f68fd526","public_url":null,"archived":false,"in_trash":false,"request_id":"b2cbed2d-60d3-4b57-b231-a3146b4a58a4"}'
+      A","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881b1b4e1d3b0c759a486","public_url":null,"archived":false,"in_trash":false,"request_id":"f898058b-950d-4d72-b1cf-2622c4f5c06c"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464a0288f5d5d-FRA
+      - 97024faed81d2c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -46,9 +46,11 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=jbsAHMChX7XZ4ULIKomfqgOBTIMdbdaWPrwvaco9YhM-1750685983-1.0.1.1-MQVVrN9mGB5hAwu6pf1jWulE4jDhp_pBSOD4cjmY7aRDMW6xNxjfUh2hUAuhVgMHOWfi2OFTCiZ8BWzlUrY3GqFFK7OLUOuC5Nv_RtTiE_0;
-        path=/; expires=Mon, 23-Jun-25 14:09:43 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=GUcYosNBTMHyebTKGbrR1CkA64KAiy8FZaWDnEnW86g-1755361774-1.0.1.1-t4L3ln0WcZW6I9X1J.UcvFtsp3WtZ6QSxMGoPHsrnjIg_E7AQsZ2Tc01s_uQa8d0jGA_PnZiag6KNeMB9Vnge0egp9kR.WVgfiO7ia_ADn8;
+        path=/; expires=Sat, 16-Aug-25 16:59:34 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
+      - _cfuvid=MUzWrkhJyy2IqrsCpKQtipBuhflGMjBV5N_YvyevJb4-1755361774558-0.0.1.1-604800000;
+        path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -70,7 +72,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - b2cbed2d-60d3-4b57-b231-a3146b4a58a4
+      - f898058b-950d-4d72-b1cf-2622c4f5c06c
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -104,18 +106,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/21b974f3-b388-8114-9e7a-f0d6f68fd526
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81b1-b4e1-d3b0c759a486
   response:
-    content: '{"object":"database","id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","cover":null,"icon":null,"created_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-06-23T13:39:00.000Z","title":[{"type":"text","text":{"content":"Schema
+    content: '{"object":"database","id":"251974f3-b388-81b1-b4e1-d3b0c759a486","cover":null,"icon":null,"created_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:29:00.000Z","title":[{"type":"text","text":{"content":"Schema
       A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
       A","href":null}],"description":[{"type":"text","text":{"content":"Only used
       to create relations in Schema B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema B","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/21b974f3b38881149e7af0d6f68fd526","public_url":null,"archived":false,"in_trash":false,"request_id":"e84d95e2-3d91-4176-abe1-bddda8d27852"}'
+      used to create relations in Schema B","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881b1b4e1d3b0c759a486","public_url":null,"archived":false,"in_trash":false,"request_id":"3134e06a-46d4-44a6-91d8-ee195b8b5bf9"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464a6ccf15d5d-FRA
+      - 97024fb33b3e2c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -145,7 +147,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - e84d95e2-3d91-4176-abe1-bddda8d27852
+      - 3134e06a-46d4-44a6-91d8-ee195b8b5bf9
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -164,17 +166,18 @@ interactions:
       "formula": {"expression": "prop(\"Number\") * 2"}}, "Last edited by": {"type":
       "last_edited_by", "last_edited_by": {}}, "Last edited time": {"type": "last_edited_time",
       "last_edited_time": {}}, "Multi-select": {"type": "multi_select", "multi_select":
-      {"options": [{"name": "Option1"}, {"name": "Option2", "color": "red"}]}}, "Number":
-      {"type": "number", "number": {"format": "dollar"}}, "People": {"type": "people",
-      "people": {}}, "Phone number": {"type": "phone_number", "phone_number": {}},
-      "Relation": {"type": "relation", "relation": {"type": "single_property", "database_id":
-      "21b974f3-b388-8114-9e7a-f0d6f68fd526", "single_property": {}}}, "Relation two-way":
-      {"type": "relation", "relation": {"type": "dual_property", "database_id": "21b974f3-b388-8114-9e7a-f0d6f68fd526",
-      "dual_property": {}}}, "Rollup": {"type": "rollup", "rollup": {"function": "count",
-      "relation_property_name": "Relation", "rollup_property_name": "Name"}}, "Select":
-      {"type": "select", "select": {"options": [{"name": "Option1"}, {"name": "Option2",
-      "color": "red"}]}}, "Text": {"type": "rich_text", "rich_text": {}}, "Title":
-      {"type": "title", "title": {}}, "URL": {"type": "url", "url": {}}}}'
+      {"options": [{"name": "Option1", "color": "default"}, {"name": "Option2", "color":
+      "red"}]}}, "Number": {"type": "number", "number": {"format": "dollar"}}, "People":
+      {"type": "people", "people": {}}, "Phone number": {"type": "phone_number", "phone_number":
+      {}}, "Relation": {"type": "relation", "relation": {"type": "single_property",
+      "database_id": "251974f3-b388-81b1-b4e1-d3b0c759a486", "single_property": {}}},
+      "Relation two-way": {"type": "relation", "relation": {"type": "dual_property",
+      "database_id": "251974f3-b388-81b1-b4e1-d3b0c759a486", "dual_property": {}}},
+      "Rollup": {"type": "rollup", "rollup": {"function": "count", "relation_property_name":
+      "Relation", "rollup_property_name": "Name"}}, "Select": {"type": "select", "select":
+      {"options": [{"name": "Option1", "color": "default"}, {"name": "Option2", "color":
+      "red"}]}}, "Text": {"type": "rich_text", "rich_text": {}}, "Title": {"type":
+      "title", "title": {}}, "URL": {"type": "url", "url": {}}}, "is_inline": false}'
     headers:
       accept:
       - '*/*'
@@ -185,7 +188,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1806'
+      - '1866'
       content-type:
       - application/json
       cookie:
@@ -199,21 +202,21 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"21b974f3-b388-8102-9de0-da133c198bd2","cover":null,"icon":null,"created_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-06-23T13:39:00.000Z","title":[{"type":"text","text":{"content":"Schema
+    content: '{"object":"database","id":"251974f3-b388-819c-9ede-d573a6e1f903","cover":null,"icon":null,"created_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:29:00.000Z","title":[{"type":"text","text":{"content":"Schema
       B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
-      B","href":null}],"description":[],"is_inline":false,"properties":{"Multi-select":{"id":"%3E%3FKq","name":"Multi-select","type":"multi_select","multi_select":{"options":[{"id":"dfa3b139-ac10-4c7e-a2a7-af1791000aa3","name":"Option1","color":"default","description":null},{"id":"ae2b0773-fb3f-4443-a143-d8be454343ad","name":"Option2","color":"red","description":null}]}},"Number":{"id":"%40%3DDe","name":"Number","type":"number","number":{"format":"dollar"}},"Created
-      by":{"id":"FsFF","name":"Created by","type":"created_by","created_by":{}},"Phone
-      number":{"id":"MF~%5C","name":"Phone number","type":"phone_number","phone_number":{}},"Select":{"id":"ZwBI","name":"Select","type":"select","select":{"options":[{"id":"b0ffb5b0-0cc4-44e6-972d-f236b763c3f4","name":"Option1","color":"default","description":null},{"id":"a015c4cb-5ae0-434e-ad81-49317f42b23c","name":"Option2","color":"red","description":null}]}},"Relation":{"id":"%5E%3E%3Ch","name":"Relation","type":"relation","relation":{"database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","type":"single_property","single_property":{}}},"Files":{"id":"%5Ej%3B%7D","name":"Files","type":"files","files":{}},"People":{"id":"a_%7Bt","name":"People","type":"people","people":{}},"Rollup":{"id":"fQHD","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"^><h","function":"count"}},"URL":{"id":"iDkb","name":"URL","type":"url","url":{}},"Formula":{"id":"iVlb","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:%40%3DDe:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
-      * 2"}},"Last edited time":{"id":"ixbt","name":"Last edited time","type":"last_edited_time","last_edited_time":{}},"Created
-      time":{"id":"joyc","name":"Created time","type":"created_time","created_time":{}},"Email":{"id":"rBqh","name":"Email","type":"email","email":{}},"Last
-      edited by":{"id":"uVMR","name":"Last edited by","type":"last_edited_by","last_edited_by":{}},"Checkbox":{"id":"w_%7Dm","name":"Checkbox","type":"checkbox","checkbox":{}},"Date":{"id":"y%3ChH","name":"Date","type":"date","date":{}},"Relation
-      two-way":{"id":"z%5CWl","name":"Relation two-way","type":"relation","relation":{"database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Schema B (Relation two-way)","synced_property_id":"fZlO"}}},"Text":{"id":"%7ClYp","name":"Text","type":"rich_text","rich_text":{}},"Title":{"id":"title","name":"Title","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/21b974f3b38881029de0da133c198bd2","public_url":null,"archived":false,"in_trash":false,"request_id":"ca62c0bc-fcbd-4af6-9527-d0bbadcf83ef"}'
+      B","href":null}],"description":[],"is_inline":false,"properties":{"Files":{"id":"%3CJu%7C","name":"Files","type":"files","files":{}},"Select":{"id":"%3Cx%5CY","name":"Select","type":"select","select":{"options":[{"id":"e56b7cba-2bdf-4a0f-a4d5-07b0c9538166","name":"Option1","color":"default","description":null},{"id":"bab7d0c3-f1dd-45e7-9804-e987fba70353","name":"Option2","color":"red","description":null}]}},"Email":{"id":"%3Cx%7Ch","name":"Email","type":"email","email":{}},"Relation":{"id":"%3DS%3Fh","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486","type":"single_property","single_property":{}}},"Created
+      by":{"id":"A%5BRV","name":"Created by","type":"created_by","created_by":{}},"Formula":{"id":"IE%5B%3F","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:%7DHuf:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
+      * 2"}},"Last edited by":{"id":"S%7BAW","name":"Last edited by","type":"last_edited_by","last_edited_by":{}},"Created
+      time":{"id":"TvJN","name":"Created time","type":"created_time","created_time":{}},"Phone
+      number":{"id":"_bRw","name":"Phone number","type":"phone_number","phone_number":{}},"Text":{"id":"%60A%3Bc","name":"Text","type":"rich_text","rich_text":{}},"People":{"id":"aGA%7B","name":"People","type":"people","people":{}},"Date":{"id":"l%3Co%5E","name":"Date","type":"date","date":{}},"Checkbox":{"id":"uoaq","name":"Checkbox","type":"checkbox","checkbox":{}},"Rollup":{"id":"xE%5E~","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"=S?h","function":"count"}},"Relation
+      two-way":{"id":"zf%5EK","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Schema B (Relation two-way)","synced_property_id":"~PUm"}}},"Number":{"id":"%7DHuf","name":"Number","type":"number","number":{"format":"dollar"}},"URL":{"id":"%7DvWL","name":"URL","type":"url","url":{}},"Last
+      edited time":{"id":"~%3F%7BP","name":"Last edited time","type":"last_edited_time","last_edited_time":{}},"Multi-select":{"id":"~uR%5C","name":"Multi-select","type":"multi_select","multi_select":{"options":[{"id":"a69542ac-1684-44b6-b06d-ecb531da7292","name":"Option1","color":"default","description":null},{"id":"87363c1c-e58f-49a9-8a6c-c8e850e98add","name":"Option2","color":"red","description":null}]}},"Title":{"id":"title","name":"Title","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b388819c9eded573a6e1f903","public_url":null,"archived":false,"in_trash":false,"request_id":"6a7057d6-dcae-41ed-9fdc-64421139217d"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464b66ef75d5d-FRA
+      - 97024fbac8cf2c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -243,7 +246,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - ca62c0bc-fcbd-4af6-9527-d0bbadcf83ef
+      - 6a7057d6-dcae-41ed-9fdc-64421139217d
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -277,25 +280,25 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/21b974f3-b388-8102-9de0-da133c198bd2
+    uri: https://api.notion.com/v1/databases/251974f3-b388-819c-9ede-d573a6e1f903
   response:
-    content: '{"object":"database","id":"21b974f3-b388-8102-9de0-da133c198bd2","cover":null,"icon":null,"created_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-06-23T13:39:00.000Z","title":[{"type":"text","text":{"content":"Schema
+    content: '{"object":"database","id":"251974f3-b388-819c-9ede-d573a6e1f903","cover":null,"icon":null,"created_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:29:00.000Z","title":[{"type":"text","text":{"content":"Schema
       B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
       B","href":null}],"description":[{"type":"text","text":{"content":"Actual interesting
       schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Multi-select":{"id":"%3E%3FKq","name":"Multi-select","type":"multi_select","multi_select":{"options":[{"id":"dfa3b139-ac10-4c7e-a2a7-af1791000aa3","name":"Option1","color":"default","description":null},{"id":"ae2b0773-fb3f-4443-a143-d8be454343ad","name":"Option2","color":"red","description":null}]}},"Number":{"id":"%40%3DDe","name":"Number","type":"number","number":{"format":"dollar"}},"Created
-      by":{"id":"FsFF","name":"Created by","type":"created_by","created_by":{}},"Phone
-      number":{"id":"MF~%5C","name":"Phone number","type":"phone_number","phone_number":{}},"Select":{"id":"ZwBI","name":"Select","type":"select","select":{"options":[{"id":"b0ffb5b0-0cc4-44e6-972d-f236b763c3f4","name":"Option1","color":"default","description":null},{"id":"a015c4cb-5ae0-434e-ad81-49317f42b23c","name":"Option2","color":"red","description":null}]}},"Relation":{"id":"%5E%3E%3Ch","name":"Relation","type":"relation","relation":{"database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","type":"single_property","single_property":{}}},"Files":{"id":"%5Ej%3B%7D","name":"Files","type":"files","files":{}},"People":{"id":"a_%7Bt","name":"People","type":"people","people":{}},"Rollup":{"id":"fQHD","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"^><h","function":"count"}},"URL":{"id":"iDkb","name":"URL","type":"url","url":{}},"Formula":{"id":"iVlb","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:%40%3DDe:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
-      * 2"}},"Last edited time":{"id":"ixbt","name":"Last edited time","type":"last_edited_time","last_edited_time":{}},"Created
-      time":{"id":"joyc","name":"Created time","type":"created_time","created_time":{}},"Email":{"id":"rBqh","name":"Email","type":"email","email":{}},"Last
-      edited by":{"id":"uVMR","name":"Last edited by","type":"last_edited_by","last_edited_by":{}},"Checkbox":{"id":"w_%7Dm","name":"Checkbox","type":"checkbox","checkbox":{}},"Date":{"id":"y%3ChH","name":"Date","type":"date","date":{}},"Relation
-      two-way":{"id":"z%5CWl","name":"Relation two-way","type":"relation","relation":{"database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Schema B (Relation two-way)","synced_property_id":"fZlO"}}},"Text":{"id":"%7ClYp","name":"Text","type":"rich_text","rich_text":{}},"Title":{"id":"title","name":"Title","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/21b974f3b38881029de0da133c198bd2","public_url":null,"archived":false,"in_trash":false,"request_id":"c4ea5a33-9fcd-4e2f-87ef-34133b5ca3ca"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Files":{"id":"%3CJu%7C","name":"Files","type":"files","files":{}},"Select":{"id":"%3Cx%5CY","name":"Select","type":"select","select":{"options":[{"id":"e56b7cba-2bdf-4a0f-a4d5-07b0c9538166","name":"Option1","color":"default","description":null},{"id":"bab7d0c3-f1dd-45e7-9804-e987fba70353","name":"Option2","color":"red","description":null}]}},"Email":{"id":"%3Cx%7Ch","name":"Email","type":"email","email":{}},"Relation":{"id":"%3DS%3Fh","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486","type":"single_property","single_property":{}}},"Created
+      by":{"id":"A%5BRV","name":"Created by","type":"created_by","created_by":{}},"Formula":{"id":"IE%5B%3F","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:%7DHuf:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
+      * 2"}},"Last edited by":{"id":"S%7BAW","name":"Last edited by","type":"last_edited_by","last_edited_by":{}},"Created
+      time":{"id":"TvJN","name":"Created time","type":"created_time","created_time":{}},"Phone
+      number":{"id":"_bRw","name":"Phone number","type":"phone_number","phone_number":{}},"Text":{"id":"%60A%3Bc","name":"Text","type":"rich_text","rich_text":{}},"People":{"id":"aGA%7B","name":"People","type":"people","people":{}},"Date":{"id":"l%3Co%5E","name":"Date","type":"date","date":{}},"Checkbox":{"id":"uoaq","name":"Checkbox","type":"checkbox","checkbox":{}},"Rollup":{"id":"xE%5E~","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"=S?h","function":"count"}},"Relation
+      two-way":{"id":"zf%5EK","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Schema B (Relation two-way)","synced_property_id":"~PUm"}}},"Number":{"id":"%7DHuf","name":"Number","type":"number","number":{"format":"dollar"}},"URL":{"id":"%7DvWL","name":"URL","type":"url","url":{}},"Last
+      edited time":{"id":"~%3F%7BP","name":"Last edited time","type":"last_edited_time","last_edited_time":{}},"Multi-select":{"id":"~uR%5C","name":"Multi-select","type":"multi_select","multi_select":{"options":[{"id":"a69542ac-1684-44b6-b06d-ecb531da7292","name":"Option1","color":"default","description":null},{"id":"87363c1c-e58f-49a9-8a6c-c8e850e98add","name":"Option2","color":"red","description":null}]}},"Title":{"id":"title","name":"Title","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b388819c9eded573a6e1f903","public_url":null,"archived":false,"in_trash":false,"request_id":"83f2efba-1d28-4681-9e3d-c81ee043aa7d"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464bc0b695d5d-FRA
+      - 97024fc318d22c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -325,7 +328,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - c4ea5a33-9fcd-4e2f-87ef-34133b5ca3ca
+      - 83f2efba-1d28-4681-9e3d-c81ee043aa7d
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -333,7 +336,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"fZlO": {"name": "Relation"}}}'
+    body: '{"properties": {"~PUm": {"name": "Relation"}}}'
     headers:
       accept:
       - '*/*'
@@ -356,19 +359,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/21b974f3-b388-8114-9e7a-f0d6f68fd526
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81b1-b4e1-d3b0c759a486
   response:
-    content: '{"object":"database","id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","cover":null,"icon":null,"created_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-06-23T13:39:00.000Z","title":[{"type":"text","text":{"content":"Schema
+    content: '{"object":"database","id":"251974f3-b388-81b1-b4e1-d3b0c759a486","cover":null,"icon":null,"created_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:29:00.000Z","title":[{"type":"text","text":{"content":"Schema
       A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
       A","href":null}],"description":[{"type":"text","text":{"content":"Only used
       to create relations in Schema B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema B","href":null}],"is_inline":false,"properties":{"Relation":{"id":"fZlO","name":"Relation","type":"relation","relation":{"database_id":"21b974f3-b388-8102-9de0-da133c198bd2","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"z%5CWl"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/21b974f3b38881149e7af0d6f68fd526","public_url":null,"archived":false,"in_trash":false,"request_id":"a828aa40-52e4-4f6a-a112-218debadba05"}'
+      used to create relations in Schema B","href":null}],"is_inline":false,"properties":{"Relation":{"id":"~PUm","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-819c-9ede-d573a6e1f903","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"zf%5EK"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881b1b4e1d3b0c759a486","public_url":null,"archived":false,"in_trash":false,"request_id":"7f64c877-bbf5-452c-bc59-f0b9a10cae15"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464c2afe95d5d-FRA
+      - 97024fcaceef2c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -398,7 +401,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a828aa40-52e4-4f6a-a112-218debadba05
+      - 7f64c877-bbf5-452c-bc59-f0b9a10cae15
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -429,24 +432,24 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/21b974f3-b388-8102-9de0-da133c198bd2
+    uri: https://api.notion.com/v1/databases/251974f3-b388-819c-9ede-d573a6e1f903
   response:
-    content: '{"object":"database","id":"21b974f3-b388-8102-9de0-da133c198bd2","cover":null,"icon":null,"created_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-06-23T13:39:00.000Z","title":[{"type":"text","text":{"content":"Schema
+    content: '{"object":"database","id":"251974f3-b388-819c-9ede-d573a6e1f903","cover":null,"icon":null,"created_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:29:00.000Z","title":[{"type":"text","text":{"content":"Schema
       B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Schema
       B","href":null}],"description":[{"type":"text","text":{"content":"Actual interesting
       schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Multi-select":{"id":"%3E%3FKq","name":"Multi-select","type":"multi_select","multi_select":{"options":[{"id":"dfa3b139-ac10-4c7e-a2a7-af1791000aa3","name":"Option1","color":"default","description":null},{"id":"ae2b0773-fb3f-4443-a143-d8be454343ad","name":"Option2","color":"red","description":null}]}},"Number":{"id":"%40%3DDe","name":"Number","type":"number","number":{"format":"dollar"}},"Created
-      by":{"id":"FsFF","name":"Created by","type":"created_by","created_by":{}},"Phone
-      number":{"id":"MF~%5C","name":"Phone number","type":"phone_number","phone_number":{}},"Select":{"id":"ZwBI","name":"Select","type":"select","select":{"options":[{"id":"b0ffb5b0-0cc4-44e6-972d-f236b763c3f4","name":"Option1","color":"default","description":null},{"id":"a015c4cb-5ae0-434e-ad81-49317f42b23c","name":"Option2","color":"red","description":null}]}},"Relation":{"id":"%5E%3E%3Ch","name":"Relation","type":"relation","relation":{"database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","type":"single_property","single_property":{}}},"Files":{"id":"%5Ej%3B%7D","name":"Files","type":"files","files":{}},"People":{"id":"a_%7Bt","name":"People","type":"people","people":{}},"Rollup":{"id":"fQHD","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"^><h","function":"count"}},"URL":{"id":"iDkb","name":"URL","type":"url","url":{}},"Formula":{"id":"iVlb","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:%40%3DDe:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
-      * 2"}},"Last edited time":{"id":"ixbt","name":"Last edited time","type":"last_edited_time","last_edited_time":{}},"Created
-      time":{"id":"joyc","name":"Created time","type":"created_time","created_time":{}},"Email":{"id":"rBqh","name":"Email","type":"email","email":{}},"Last
-      edited by":{"id":"uVMR","name":"Last edited by","type":"last_edited_by","last_edited_by":{}},"Checkbox":{"id":"w_%7Dm","name":"Checkbox","type":"checkbox","checkbox":{}},"Date":{"id":"y%3ChH","name":"Date","type":"date","date":{}},"Relation
-      two-way":{"id":"z%5CWl","name":"Relation two-way","type":"relation","relation":{"database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"fZlO"}}},"Text":{"id":"%7ClYp","name":"Text","type":"rich_text","rich_text":{}},"Title":{"id":"title","name":"Title","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/21b974f3b38881029de0da133c198bd2","public_url":null,"archived":false,"in_trash":false,"request_id":"7b20c13b-d88e-4ad3-8232-094af81dd5f9"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Files":{"id":"%3CJu%7C","name":"Files","type":"files","files":{}},"Select":{"id":"%3Cx%5CY","name":"Select","type":"select","select":{"options":[{"id":"e56b7cba-2bdf-4a0f-a4d5-07b0c9538166","name":"Option1","color":"default","description":null},{"id":"bab7d0c3-f1dd-45e7-9804-e987fba70353","name":"Option2","color":"red","description":null}]}},"Email":{"id":"%3Cx%7Ch","name":"Email","type":"email","email":{}},"Relation":{"id":"%3DS%3Fh","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486","type":"single_property","single_property":{}}},"Created
+      by":{"id":"A%5BRV","name":"Created by","type":"created_by","created_by":{}},"Formula":{"id":"IE%5B%3F","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:%7DHuf:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}
+      * 2"}},"Last edited by":{"id":"S%7BAW","name":"Last edited by","type":"last_edited_by","last_edited_by":{}},"Created
+      time":{"id":"TvJN","name":"Created time","type":"created_time","created_time":{}},"Phone
+      number":{"id":"_bRw","name":"Phone number","type":"phone_number","phone_number":{}},"Text":{"id":"%60A%3Bc","name":"Text","type":"rich_text","rich_text":{}},"People":{"id":"aGA%7B","name":"People","type":"people","people":{}},"Date":{"id":"l%3Co%5E","name":"Date","type":"date","date":{}},"Checkbox":{"id":"uoaq","name":"Checkbox","type":"checkbox","checkbox":{}},"Rollup":{"id":"xE%5E~","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"=S?h","function":"count"}},"Relation
+      two-way":{"id":"zf%5EK","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"~PUm"}}},"Number":{"id":"%7DHuf","name":"Number","type":"number","number":{"format":"dollar"}},"URL":{"id":"%7DvWL","name":"URL","type":"url","url":{}},"Last
+      edited time":{"id":"~%3F%7BP","name":"Last edited time","type":"last_edited_time","last_edited_time":{}},"Multi-select":{"id":"~uR%5C","name":"Multi-select","type":"multi_select","multi_select":{"options":[{"id":"a69542ac-1684-44b6-b06d-ecb531da7292","name":"Option1","color":"default","description":null},{"id":"87363c1c-e58f-49a9-8a6c-c8e850e98add","name":"Option2","color":"red","description":null}]}},"Title":{"id":"title","name":"Title","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b388819c9eded573a6e1f903","public_url":null,"archived":false,"in_trash":false,"request_id":"e253a095-8fbe-450a-9c60-de958360e144"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464c8abe25d5d-FRA
+      - 97024fcd69c82c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -476,7 +479,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 7b20c13b-d88e-4ad3-8232-094af81dd5f9
+      - e253a095-8fbe-450a-9c60-de958360e144
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -508,12 +511,12 @@ interactions:
     content: '{"object":"list","results":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
       Wilhelm","avatar_url":"https://lh3.googleusercontent.com/a-/AAuE7mBBGq22qnRbLoOSo5zScC4miXci-xi4vELc30G9Aw=s100","type":"person","person":{"email":"florian.wilhelm@gmail.com"}},{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
       Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{"owner":{"type":"workspace","workspace":true},"workspace_name":"GitHub
-      Unittests","workspace_limits":{"max_file_upload_size_in_bytes":5242880}}}],"next_cursor":null,"has_more":false,"type":"user","user":{},"request_id":"d58245d9-a360-4717-8717-eb6a52f24973"}'
+      Unittests","workspace_limits":{"max_file_upload_size_in_bytes":5242880}}}],"next_cursor":null,"has_more":false,"type":"user","user":{},"request_id":"8721aa32-46f6-4a52-b8b1-031f85827f9e"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464d008915d5d-FRA
+      - 97024fd56f072c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -543,7 +546,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - d58245d9-a360-4717-8717-eb6a52f24973
+      - 8721aa32-46f6-4a52-b8b1-031f85827f9e
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -574,12 +577,12 @@ interactions:
   response:
     content: '{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
       Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{"owner":{"type":"workspace","workspace":true},"workspace_name":"GitHub
-      Unittests","workspace_limits":{"max_file_upload_size_in_bytes":5242880}},"request_id":"b3f27908-f13a-48e0-91e8-21845dae3044"}'
+      Unittests","workspace_limits":{"max_file_upload_size_in_bytes":5242880}},"request_id":"3458fa81-99e9-49b4-8f54-acc741f8c231"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464d31ab45d5d-FRA
+      - 97024fd6e8432c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -609,7 +612,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - b3f27908-f13a-48e0-91e8-21845dae3044
+      - 3458fa81-99e9-49b4-8f54-acc741f8c231
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -617,7 +620,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "database_id", "database_id": "21b974f3-b388-8114-9e7a-f0d6f68fd526"},
+    body: '{"parent": {"type": "database_id", "database_id": "251974f3-b388-81b1-b4e1-d3b0c759a486"},
       "properties": {"Name": {"type": "title", "title": [{"type": "text", "plain_text":
       "Item 1", "annotations": {"bold": false, "italic": false, "strikethrough": false,
       "underline": false, "code": false, "color": "default"}, "text": {"content":
@@ -646,14 +649,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"21b974f3-b388-81b1-831d-fa98dbe13377","created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526"},"archived":false,"in_trash":false,"properties":{"Relation":{"id":"fZlO","type":"relation","relation":[],"has_more":false},"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Item
+    content: '{"object":"page","id":"251974f3-b388-81ca-a263-c0889f862a1b","created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486"},"archived":false,"in_trash":false,"properties":{"Relation":{"id":"~PUm","type":"relation","relation":[],"has_more":false},"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Item
       1","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Item
-      1","href":null}]}},"url":"https://www.notion.so/Item-1-21b974f3b38881b1831dfa98dbe13377","public_url":null,"request_id":"724531b0-629c-4455-8ef0-a132b4ea8d01"}'
+      1","href":null}]}},"url":"https://www.notion.so/Item-1-251974f3b38881caa263c0889f862a1b","public_url":null,"request_id":"8d8ae4ac-397d-4fd4-b1d3-bad2e9e008ff"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464d4cbc35d5d-FRA
+      - 97024fd8c9652c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -683,7 +686,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 724531b0-629c-4455-8ef0-a132b4ea8d01
+      - 8d8ae4ac-397d-4fd4-b1d3-bad2e9e008ff
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -691,7 +694,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "database_id", "database_id": "21b974f3-b388-8114-9e7a-f0d6f68fd526"},
+    body: '{"parent": {"type": "database_id", "database_id": "251974f3-b388-81b1-b4e1-d3b0c759a486"},
       "properties": {"Name": {"type": "title", "title": [{"type": "text", "plain_text":
       "Item 2", "annotations": {"bold": false, "italic": false, "strikethrough": false,
       "underline": false, "code": false, "color": "default"}, "text": {"content":
@@ -720,14 +723,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"21b974f3-b388-815a-baa5-f63f86e68865","created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"21b974f3-b388-8114-9e7a-f0d6f68fd526"},"archived":false,"in_trash":false,"properties":{"Relation":{"id":"fZlO","type":"relation","relation":[],"has_more":false},"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Item
+    content: '{"object":"page","id":"251974f3-b388-81c2-847e-fe42ebc29482","created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"251974f3-b388-81b1-b4e1-d3b0c759a486"},"archived":false,"in_trash":false,"properties":{"Relation":{"id":"~PUm","type":"relation","relation":[],"has_more":false},"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Item
       2","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Item
-      2","href":null}]}},"url":"https://www.notion.so/Item-2-21b974f3b388815abaa5f63f86e68865","public_url":null,"request_id":"762120b8-aa0f-4185-a3fc-84c883ad919a"}'
+      2","href":null}]}},"url":"https://www.notion.so/Item-2-251974f3b38881c2847efe42ebc29482","public_url":null,"request_id":"1518a8d5-02a5-48b1-8e96-e16204413fdd"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464eb9b395d5d-FRA
+      - 97024fdb7ae72c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -757,7 +760,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 762120b8-aa0f-4185-a3fc-84c883ad919a
+      - 1518a8d5-02a5-48b1-8e96-e16204413fdd
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -765,7 +768,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "database_id", "database_id": "21b974f3-b388-8102-9de0-da133c198bd2"},
+    body: '{"parent": {"type": "database_id", "database_id": "251974f3-b388-819c-9ede-d573a6e1f903"},
       "properties": {}}'
     headers:
       accept:
@@ -791,20 +794,20 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"21b974f3-b388-8112-843a-d219190c3a24","created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"21b974f3-b388-8102-9de0-da133c198bd2"},"archived":false,"in_trash":false,"properties":{"Multi-select":{"id":"%3E%3FKq","type":"multi_select","multi_select":[]},"Number":{"id":"%40%3DDe","type":"number","number":null},"Created
-      by":{"id":"FsFF","type":"created_by","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
-      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Phone
-      number":{"id":"MF~%5C","type":"phone_number","phone_number":null},"Select":{"id":"ZwBI","type":"select","select":null},"Relation":{"id":"%5E%3E%3Ch","type":"relation","relation":[],"has_more":false},"Files":{"id":"%5Ej%3B%7D","type":"files","files":[]},"People":{"id":"a_%7Bt","type":"people","people":[]},"Rollup":{"id":"fQHD","type":"rollup","rollup":{"type":"number","number":null,"function":"count"}},"URL":{"id":"iDkb","type":"url","url":null},"Formula":{"id":"iVlb","type":"formula","formula":{"type":"number","number":0}},"Last
-      edited time":{"id":"ixbt","type":"last_edited_time","last_edited_time":"2025-06-23T13:39:00.000Z"},"Created
-      time":{"id":"joyc","type":"created_time","created_time":"2025-06-23T13:39:00.000Z"},"Email":{"id":"rBqh","type":"email","email":null},"Last
-      edited by":{"id":"uVMR","type":"last_edited_by","last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
-      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Checkbox":{"id":"w_%7Dm","type":"checkbox","checkbox":false},"Date":{"id":"y%3ChH","type":"date","date":null},"Relation
-      two-way":{"id":"z%5CWl","type":"relation","relation":[],"has_more":false},"Text":{"id":"%7ClYp","type":"rich_text","rich_text":[]},"Title":{"id":"title","type":"title","title":[]}},"url":"https://www.notion.so/21b974f3b3888112843ad219190c3a24","public_url":null,"request_id":"459993b6-2666-4b71-b84a-782ec37bd3d4"}'
+    content: '{"object":"page","id":"251974f3-b388-816d-96c1-ec3b410180a7","created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"251974f3-b388-819c-9ede-d573a6e1f903"},"archived":false,"in_trash":false,"properties":{"Files":{"id":"%3CJu%7C","type":"files","files":[]},"Select":{"id":"%3Cx%5CY","type":"select","select":null},"Email":{"id":"%3Cx%7Ch","type":"email","email":null},"Relation":{"id":"%3DS%3Fh","type":"relation","relation":[],"has_more":false},"Created
+      by":{"id":"A%5BRV","type":"created_by","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
+      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Formula":{"id":"IE%5B%3F","type":"formula","formula":{"type":"number","number":0}},"Last
+      edited by":{"id":"S%7BAW","type":"last_edited_by","last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
+      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Created
+      time":{"id":"TvJN","type":"created_time","created_time":"2025-08-16T16:29:00.000Z"},"Phone
+      number":{"id":"_bRw","type":"phone_number","phone_number":null},"Text":{"id":"%60A%3Bc","type":"rich_text","rich_text":[]},"People":{"id":"aGA%7B","type":"people","people":[]},"Date":{"id":"l%3Co%5E","type":"date","date":null},"Checkbox":{"id":"uoaq","type":"checkbox","checkbox":false},"Rollup":{"id":"xE%5E~","type":"rollup","rollup":{"type":"number","number":null,"function":"count"}},"Relation
+      two-way":{"id":"zf%5EK","type":"relation","relation":[],"has_more":false},"Number":{"id":"%7DHuf","type":"number","number":null},"URL":{"id":"%7DvWL","type":"url","url":null},"Last
+      edited time":{"id":"~%3F%7BP","type":"last_edited_time","last_edited_time":"2025-08-16T16:29:00.000Z"},"Multi-select":{"id":"~uR%5C","type":"multi_select","multi_select":[]},"Title":{"id":"title","type":"title","title":[]}},"url":"https://www.notion.so/251974f3b388816d96c1ec3b410180a7","public_url":null,"request_id":"c8d8766a-6dad-434a-b0e0-d69c437f6140"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464f14f285d5d-FRA
+      - 97024fdeacea2c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -834,7 +837,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 459993b6-2666-4b71-b84a-782ec37bd3d4
+      - c8d8766a-6dad-434a-b0e0-d69c437f6140
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -842,26 +845,26 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "database_id", "database_id": "21b974f3-b388-8102-9de0-da133c198bd2"},
+    body: '{"parent": {"type": "database_id", "database_id": "251974f3-b388-819c-9ede-d573a6e1f903"},
       "properties": {"Checkbox": {"type": "checkbox", "checkbox": true}, "Date": {"type":
       "date", "date": {"start": "2021-01-01"}}, "Email": {"type": "email", "email":
       "email@provider.com"}, "Files": {"type": "files", "files": [{"type": "external",
       "name": "My File", "external": {"url": "https://..."}}]}, "Multi-select": {"type":
-      "multi_select", "multi_select": [{"name": "Option1"}]}, "Number": {"type": "number",
-      "number": 42}, "People": {"people": [{"id": "b10cb6df-12ef-44d3-88ad-250168f66322",
+      "multi_select", "multi_select": [{"name": "Option1", "color": "default"}]},
+      "Number": {"type": "number", "number": 42}, "People": {"people": [{"id": "b10cb6df-12ef-44d3-88ad-250168f66322",
       "object": "user"}], "type": "people"}, "Phone number": {"type": "phone_number",
       "phone_number": "+1 234 567 890"}, "Relation": {"type": "relation", "relation":
-      [{"id": "21b974f3-b388-81b1-831d-fa98dbe13377"}, {"id": "21b974f3-b388-815a-baa5-f63f86e68865"}],
+      [{"id": "251974f3-b388-81ca-a263-c0889f862a1b"}, {"id": "251974f3-b388-81c2-847e-fe42ebc29482"}],
       "has_more": false}, "Relation two-way": {"type": "relation", "relation": [{"id":
-      "21b974f3-b388-81b1-831d-fa98dbe13377"}, {"id": "21b974f3-b388-815a-baa5-f63f86e68865"}],
-      "has_more": false}, "Select": {"type": "select", "select": {"name": "Option1"}},
-      "Text": {"type": "rich_text", "rich_text": [{"type": "text", "plain_text": "Text",
-      "annotations": {"bold": false, "italic": false, "strikethrough": false, "underline":
-      false, "code": false, "color": "default"}, "text": {"content": "Text"}}]}, "Title":
-      {"type": "title", "title": [{"type": "text", "plain_text": "Title", "annotations":
-      {"bold": false, "italic": false, "strikethrough": false, "underline": false,
-      "code": false, "color": "default"}, "text": {"content": "Title"}}]}, "URL":
-      {"type": "url", "url": "https://ultimate-notion.com/"}}}'
+      "251974f3-b388-81ca-a263-c0889f862a1b"}, {"id": "251974f3-b388-81c2-847e-fe42ebc29482"}],
+      "has_more": false}, "Select": {"type": "select", "select": {"name": "Option1",
+      "color": "default"}}, "Text": {"type": "rich_text", "rich_text": [{"type": "text",
+      "plain_text": "Text", "annotations": {"bold": false, "italic": false, "strikethrough":
+      false, "underline": false, "code": false, "color": "default"}, "text": {"content":
+      "Text"}}]}, "Title": {"type": "title", "title": [{"type": "text", "plain_text":
+      "Title", "annotations": {"bold": false, "italic": false, "strikethrough": false,
+      "underline": false, "code": false, "color": "default"}, "text": {"content":
+      "Title"}}]}, "URL": {"type": "url", "url": "https://ultimate-notion.com/"}}}'
     headers:
       accept:
       - '*/*'
@@ -872,7 +875,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1640'
+      - '1680'
       content-type:
       - application/json
       cookie:
@@ -886,22 +889,22 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"21b974f3-b388-816a-ae60-e2a92f31db6e","created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"21b974f3-b388-8102-9de0-da133c198bd2"},"archived":false,"in_trash":false,"properties":{"Multi-select":{"id":"%3E%3FKq","type":"multi_select","multi_select":[{"id":"dfa3b139-ac10-4c7e-a2a7-af1791000aa3","name":"Option1","color":"default"}]},"Number":{"id":"%40%3DDe","type":"number","number":42},"Created
-      by":{"id":"FsFF","type":"created_by","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
-      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Phone
-      number":{"id":"MF~%5C","type":"phone_number","phone_number":"+1 234 567 890"},"Select":{"id":"ZwBI","type":"select","select":{"id":"b0ffb5b0-0cc4-44e6-972d-f236b763c3f4","name":"Option1","color":"default"}},"Relation":{"id":"%5E%3E%3Ch","type":"relation","relation":[{"id":"21b974f3-b388-81b1-831d-fa98dbe13377"},{"id":"21b974f3-b388-815a-baa5-f63f86e68865"}],"has_more":false},"Files":{"id":"%5Ej%3B%7D","type":"files","files":[{"name":"My
-      File","type":"external","external":{"url":"https://..."}}]},"People":{"id":"a_%7Bt","type":"people","people":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
-      Wilhelm","avatar_url":"https://lh3.googleusercontent.com/a-/AAuE7mBBGq22qnRbLoOSo5zScC4miXci-xi4vELc30G9Aw=s100","type":"person","person":{"email":"florian.wilhelm@gmail.com"}}]},"Rollup":{"id":"fQHD","type":"rollup","rollup":{"type":"number","number":2,"function":"count"}},"URL":{"id":"iDkb","type":"url","url":"https://ultimate-notion.com/"},"Formula":{"id":"iVlb","type":"formula","formula":{"type":"number","number":84}},"Last
-      edited time":{"id":"ixbt","type":"last_edited_time","last_edited_time":"2025-06-23T13:39:00.000Z"},"Created
-      time":{"id":"joyc","type":"created_time","created_time":"2025-06-23T13:39:00.000Z"},"Email":{"id":"rBqh","type":"email","email":"email@provider.com"},"Last
-      edited by":{"id":"uVMR","type":"last_edited_by","last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
-      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Checkbox":{"id":"w_%7Dm","type":"checkbox","checkbox":true},"Date":{"id":"y%3ChH","type":"date","date":{"start":"2021-01-01","end":null,"time_zone":null}},"Relation
-      two-way":{"id":"z%5CWl","type":"relation","relation":[{"id":"21b974f3-b388-81b1-831d-fa98dbe13377"},{"id":"21b974f3-b388-815a-baa5-f63f86e68865"}],"has_more":false},"Text":{"id":"%7ClYp","type":"rich_text","rich_text":[{"type":"text","text":{"content":"Text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Text","href":null}]},"Title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Title","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Title","href":null}]}},"url":"https://www.notion.so/Title-21b974f3b388816aae60e2a92f31db6e","public_url":null,"request_id":"9535a6bd-49fc-4afe-b3c9-5f0fb75d0568"}'
+    content: '{"object":"page","id":"251974f3-b388-8196-88f6-ca0fc53f07ba","created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"251974f3-b388-819c-9ede-d573a6e1f903"},"archived":false,"in_trash":false,"properties":{"Files":{"id":"%3CJu%7C","type":"files","files":[{"name":"My
+      File","type":"external","external":{"url":"https://..."}}]},"Select":{"id":"%3Cx%5CY","type":"select","select":{"id":"e56b7cba-2bdf-4a0f-a4d5-07b0c9538166","name":"Option1","color":"default"}},"Email":{"id":"%3Cx%7Ch","type":"email","email":"email@provider.com"},"Relation":{"id":"%3DS%3Fh","type":"relation","relation":[{"id":"251974f3-b388-81ca-a263-c0889f862a1b"},{"id":"251974f3-b388-81c2-847e-fe42ebc29482"}],"has_more":false},"Created
+      by":{"id":"A%5BRV","type":"created_by","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
+      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Formula":{"id":"IE%5B%3F","type":"formula","formula":{"type":"number","number":84}},"Last
+      edited by":{"id":"S%7BAW","type":"last_edited_by","last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
+      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Created
+      time":{"id":"TvJN","type":"created_time","created_time":"2025-08-16T16:29:00.000Z"},"Phone
+      number":{"id":"_bRw","type":"phone_number","phone_number":"+1 234 567 890"},"Text":{"id":"%60A%3Bc","type":"rich_text","rich_text":[{"type":"text","text":{"content":"Text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Text","href":null}]},"People":{"id":"aGA%7B","type":"people","people":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
+      Wilhelm","avatar_url":"https://lh3.googleusercontent.com/a-/AAuE7mBBGq22qnRbLoOSo5zScC4miXci-xi4vELc30G9Aw=s100","type":"person","person":{"email":"florian.wilhelm@gmail.com"}}]},"Date":{"id":"l%3Co%5E","type":"date","date":{"start":"2021-01-01","end":null,"time_zone":null}},"Checkbox":{"id":"uoaq","type":"checkbox","checkbox":true},"Rollup":{"id":"xE%5E~","type":"rollup","rollup":{"type":"number","number":2,"function":"count"}},"Relation
+      two-way":{"id":"zf%5EK","type":"relation","relation":[{"id":"251974f3-b388-81ca-a263-c0889f862a1b"},{"id":"251974f3-b388-81c2-847e-fe42ebc29482"}],"has_more":false},"Number":{"id":"%7DHuf","type":"number","number":42},"URL":{"id":"%7DvWL","type":"url","url":"https://ultimate-notion.com/"},"Last
+      edited time":{"id":"~%3F%7BP","type":"last_edited_time","last_edited_time":"2025-08-16T16:29:00.000Z"},"Multi-select":{"id":"~uR%5C","type":"multi_select","multi_select":[{"id":"a69542ac-1684-44b6-b06d-ecb531da7292","name":"Option1","color":"default"}]},"Title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Title","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Title","href":null}]}},"url":"https://www.notion.so/Title-251974f3b388819688f6ca0fc53f07ba","public_url":null,"request_id":"44f0d5b5-2206-4ebd-af67-b8de723269a1"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954464f539b35d5d-FRA
+      - 97024fe7ba412c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -931,7 +934,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 9535a6bd-49fc-4afe-b3c9-5f0fb75d0568
+      - 44f0d5b5-2206-4ebd-af67-b8de723269a1
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -939,26 +942,26 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "database_id", "database_id": "21b974f3-b388-8102-9de0-da133c198bd2"},
+    body: '{"parent": {"type": "database_id", "database_id": "251974f3-b388-819c-9ede-d573a6e1f903"},
       "properties": {"Checkbox": {"type": "checkbox", "checkbox": true}, "Date": {"type":
       "date", "date": {"start": "2021-01-01"}}, "Email": {"type": "email", "email":
       "email@provider.com"}, "Files": {"type": "files", "files": [{"type": "external",
       "name": "My File", "external": {"url": "https://..."}}]}, "Multi-select": {"type":
-      "multi_select", "multi_select": [{"name": "Option1"}]}, "Number": {"type": "number",
-      "number": 42}, "People": {"people": [{"id": "b10cb6df-12ef-44d3-88ad-250168f66322",
+      "multi_select", "multi_select": [{"name": "Option1", "color": "default"}]},
+      "Number": {"type": "number", "number": 42}, "People": {"people": [{"id": "b10cb6df-12ef-44d3-88ad-250168f66322",
       "object": "user"}], "type": "people"}, "Phone number": {"type": "phone_number",
       "phone_number": "+1 234 567 890"}, "Relation": {"type": "relation", "relation":
-      [{"id": "21b974f3-b388-81b1-831d-fa98dbe13377"}, {"id": "21b974f3-b388-815a-baa5-f63f86e68865"}],
+      [{"id": "251974f3-b388-81ca-a263-c0889f862a1b"}, {"id": "251974f3-b388-81c2-847e-fe42ebc29482"}],
       "has_more": false}, "Relation two-way": {"type": "relation", "relation": [{"id":
-      "21b974f3-b388-81b1-831d-fa98dbe13377"}, {"id": "21b974f3-b388-815a-baa5-f63f86e68865"}],
-      "has_more": false}, "Select": {"type": "select", "select": {"name": "Option1"}},
-      "Text": {"type": "rich_text", "rich_text": [{"type": "text", "plain_text": "Text",
-      "annotations": {"bold": false, "italic": false, "strikethrough": false, "underline":
-      false, "code": false, "color": "default"}, "text": {"content": "Text"}}]}, "Title":
-      {"type": "title", "title": [{"type": "text", "plain_text": "Title", "annotations":
-      {"bold": false, "italic": false, "strikethrough": false, "underline": false,
-      "code": false, "color": "default"}, "text": {"content": "Title"}}]}, "URL":
-      {"type": "url", "url": "https://ultimate-notion.com/"}}}'
+      "251974f3-b388-81ca-a263-c0889f862a1b"}, {"id": "251974f3-b388-81c2-847e-fe42ebc29482"}],
+      "has_more": false}, "Select": {"type": "select", "select": {"name": "Option1",
+      "color": "default"}}, "Text": {"type": "rich_text", "rich_text": [{"type": "text",
+      "plain_text": "Text", "annotations": {"bold": false, "italic": false, "strikethrough":
+      false, "underline": false, "code": false, "color": "default"}, "text": {"content":
+      "Text"}}]}, "Title": {"type": "title", "title": [{"type": "text", "plain_text":
+      "Title", "annotations": {"bold": false, "italic": false, "strikethrough": false,
+      "underline": false, "code": false, "color": "default"}, "text": {"content":
+      "Title"}}]}, "URL": {"type": "url", "url": "https://ultimate-notion.com/"}}}'
     headers:
       accept:
       - '*/*'
@@ -969,7 +972,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1640'
+      - '1680'
       content-type:
       - application/json
       cookie:
@@ -983,22 +986,22 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"21b974f3-b388-8186-b43f-d7fcdce9ad48","created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"21b974f3-b388-8102-9de0-da133c198bd2"},"archived":false,"in_trash":false,"properties":{"Multi-select":{"id":"%3E%3FKq","type":"multi_select","multi_select":[{"id":"dfa3b139-ac10-4c7e-a2a7-af1791000aa3","name":"Option1","color":"default"}]},"Number":{"id":"%40%3DDe","type":"number","number":42},"Created
-      by":{"id":"FsFF","type":"created_by","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
-      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Phone
-      number":{"id":"MF~%5C","type":"phone_number","phone_number":"+1 234 567 890"},"Select":{"id":"ZwBI","type":"select","select":{"id":"b0ffb5b0-0cc4-44e6-972d-f236b763c3f4","name":"Option1","color":"default"}},"Relation":{"id":"%5E%3E%3Ch","type":"relation","relation":[{"id":"21b974f3-b388-81b1-831d-fa98dbe13377"},{"id":"21b974f3-b388-815a-baa5-f63f86e68865"}],"has_more":false},"Files":{"id":"%5Ej%3B%7D","type":"files","files":[{"name":"My
-      File","type":"external","external":{"url":"https://..."}}]},"People":{"id":"a_%7Bt","type":"people","people":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
-      Wilhelm","avatar_url":"https://lh3.googleusercontent.com/a-/AAuE7mBBGq22qnRbLoOSo5zScC4miXci-xi4vELc30G9Aw=s100","type":"person","person":{"email":"florian.wilhelm@gmail.com"}}]},"Rollup":{"id":"fQHD","type":"rollup","rollup":{"type":"number","number":2,"function":"count"}},"URL":{"id":"iDkb","type":"url","url":"https://ultimate-notion.com/"},"Formula":{"id":"iVlb","type":"formula","formula":{"type":"number","number":84}},"Last
-      edited time":{"id":"ixbt","type":"last_edited_time","last_edited_time":"2025-06-23T13:39:00.000Z"},"Created
-      time":{"id":"joyc","type":"created_time","created_time":"2025-06-23T13:39:00.000Z"},"Email":{"id":"rBqh","type":"email","email":"email@provider.com"},"Last
-      edited by":{"id":"uVMR","type":"last_edited_by","last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
-      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Checkbox":{"id":"w_%7Dm","type":"checkbox","checkbox":true},"Date":{"id":"y%3ChH","type":"date","date":{"start":"2021-01-01","end":null,"time_zone":null}},"Relation
-      two-way":{"id":"z%5CWl","type":"relation","relation":[{"id":"21b974f3-b388-81b1-831d-fa98dbe13377"},{"id":"21b974f3-b388-815a-baa5-f63f86e68865"}],"has_more":false},"Text":{"id":"%7ClYp","type":"rich_text","rich_text":[{"type":"text","text":{"content":"Text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Text","href":null}]},"Title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Title","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Title","href":null}]}},"url":"https://www.notion.so/Title-21b974f3b3888186b43fd7fcdce9ad48","public_url":null,"request_id":"3c56a1a6-09dd-4c9b-b8e1-0cfe32922544"}'
+    content: '{"object":"page","id":"251974f3-b388-818d-91bd-ea1520880675","created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"251974f3-b388-819c-9ede-d573a6e1f903"},"archived":false,"in_trash":false,"properties":{"Files":{"id":"%3CJu%7C","type":"files","files":[{"name":"My
+      File","type":"external","external":{"url":"https://..."}}]},"Select":{"id":"%3Cx%5CY","type":"select","select":{"id":"e56b7cba-2bdf-4a0f-a4d5-07b0c9538166","name":"Option1","color":"default"}},"Email":{"id":"%3Cx%7Ch","type":"email","email":"email@provider.com"},"Relation":{"id":"%3DS%3Fh","type":"relation","relation":[{"id":"251974f3-b388-81ca-a263-c0889f862a1b"},{"id":"251974f3-b388-81c2-847e-fe42ebc29482"}],"has_more":false},"Created
+      by":{"id":"A%5BRV","type":"created_by","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
+      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Formula":{"id":"IE%5B%3F","type":"formula","formula":{"type":"number","number":84}},"Last
+      edited by":{"id":"S%7BAW","type":"last_edited_by","last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
+      Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{}}},"Created
+      time":{"id":"TvJN","type":"created_time","created_time":"2025-08-16T16:29:00.000Z"},"Phone
+      number":{"id":"_bRw","type":"phone_number","phone_number":"+1 234 567 890"},"Text":{"id":"%60A%3Bc","type":"rich_text","rich_text":[{"type":"text","text":{"content":"Text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Text","href":null}]},"People":{"id":"aGA%7B","type":"people","people":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
+      Wilhelm","avatar_url":"https://lh3.googleusercontent.com/a-/AAuE7mBBGq22qnRbLoOSo5zScC4miXci-xi4vELc30G9Aw=s100","type":"person","person":{"email":"florian.wilhelm@gmail.com"}}]},"Date":{"id":"l%3Co%5E","type":"date","date":{"start":"2021-01-01","end":null,"time_zone":null}},"Checkbox":{"id":"uoaq","type":"checkbox","checkbox":true},"Rollup":{"id":"xE%5E~","type":"rollup","rollup":{"type":"number","number":2,"function":"count"}},"Relation
+      two-way":{"id":"zf%5EK","type":"relation","relation":[{"id":"251974f3-b388-81ca-a263-c0889f862a1b"},{"id":"251974f3-b388-81c2-847e-fe42ebc29482"}],"has_more":false},"Number":{"id":"%7DHuf","type":"number","number":42},"URL":{"id":"%7DvWL","type":"url","url":"https://ultimate-notion.com/"},"Last
+      edited time":{"id":"~%3F%7BP","type":"last_edited_time","last_edited_time":"2025-08-16T16:29:00.000Z"},"Multi-select":{"id":"~uR%5C","type":"multi_select","multi_select":[{"id":"a69542ac-1684-44b6-b06d-ecb531da7292","name":"Option1","color":"default"}]},"Title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Title","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Title","href":null}]}},"url":"https://www.notion.so/Title-251974f3b388818d91bdea1520880675","public_url":null,"request_id":"a2bf35b3-bb1d-4320-aa45-d6481add91bd"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954465064ee85d5d-FRA
+      - 97024feacc452c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1028,7 +1031,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 3c56a1a6-09dd-4c9b-b8e1-0cfe32922544
+      - a2bf35b3-bb1d-4320-aa45-d6481add91bd
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1055,15 +1058,15 @@ interactions:
       user-agent:
       - secret...
     method: DELETE
-    uri: https://api.notion.com/v1/blocks/21b974f3-b388-8114-9e7a-f0d6f68fd526
+    uri: https://api.notion.com/v1/blocks/251974f3-b388-81b1-b4e1-d3b0c759a486
   response:
-    content: '{"object":"block","id":"21b974f3-b388-8114-9e7a-f0d6f68fd526","parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":true,"in_trash":true,"type":"child_database","child_database":{"title":"Schema
-      A"},"request_id":"7e17c206-acb8-4a87-ac1b-76d938990036"}'
+    content: '{"object":"block","id":"251974f3-b388-81b1-b4e1-d3b0c759a486","parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":true,"in_trash":true,"type":"child_database","child_database":{"title":"Schema
+      A"},"request_id":"cc512deb-77a0-4de1-9429-55f34e3bf39b"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 95446509894b5d5d-FRA
+      - 97024ff87e882c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1093,7 +1096,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 7e17c206-acb8-4a87-ac1b-76d938990036
+      - cc512deb-77a0-4de1-9429-55f34e3bf39b
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1122,12 +1125,12 @@ interactions:
     method: GET
     uri: https://api.notion.com/v1/pages/5f505199-b292-4713-920b-61d813bf72a3
   response:
-    content: '{"object":"page","id":"5f505199-b292-4713-920b-61d813bf72a3","created_time":"2022-08-22T15:47:00.000Z","last_edited_time":"2025-06-23T13:39:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-5f505199b2924713920b61d813bf72a3","public_url":null,"request_id":"a67478f0-5e0d-47b1-9b26-b6be464d59e2"}'
+    content: '{"object":"page","id":"5f505199-b292-4713-920b-61d813bf72a3","created_time":"2022-08-22T15:47:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-5f505199b2924713920b61d813bf72a3","public_url":null,"request_id":"9c0dc5dd-ff35-4036-a3e9-5e005b6307eb"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9544650fadf45d5d-FRA
+      - 97024ffe9a7f2c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1157,7 +1160,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a67478f0-5e0d-47b1-9b26-b6be464d59e2
+      - 9c0dc5dd-ff35-4036-a3e9-5e005b6307eb
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1184,15 +1187,15 @@ interactions:
       user-agent:
       - secret...
     method: DELETE
-    uri: https://api.notion.com/v1/blocks/21b974f3-b388-8102-9de0-da133c198bd2
+    uri: https://api.notion.com/v1/blocks/251974f3-b388-819c-9ede-d573a6e1f903
   response:
-    content: '{"object":"block","id":"21b974f3-b388-8102-9de0-da133c198bd2","parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"created_time":"2025-06-23T13:39:00.000Z","last_edited_time":"2025-06-23T13:40:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":true,"in_trash":true,"type":"child_database","child_database":{"title":"Schema
-      B"},"request_id":"1f615f57-f902-4151-8a74-8d79f2f6436b"}'
+    content: '{"object":"block","id":"251974f3-b388-819c-9ede-d573a6e1f903","parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"created_time":"2025-08-16T16:29:00.000Z","last_edited_time":"2025-08-16T16:29:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":true,"in_trash":true,"type":"child_database","child_database":{"title":"Schema
+      B"},"request_id":"642dc4b2-3946-4946-a15c-fac86768cb9e"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 954465121fa95d5d-FRA
+      - 9702500758982c6e-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1222,7 +1225,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 1f615f57-f902-4151-8a74-8d79f2f6436b
+      - 642dc4b2-3946-4946-a15c-fac86768cb9e
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:

--- a/tests/cassettes/test_schema/test_bind_db.yaml
+++ b/tests/cassettes/test_schema/test_bind_db.yaml
@@ -1,0 +1,86 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "5f505199-b292-4713-920b-61d813bf72a3"},
+      "title": [{"type": "text", "plain_text": "Bind DB Test", "annotations": {"bold":
+      false, "italic": false, "strikethrough": false, "underline": false, "code":
+      false, "color": "default"}, "text": {"content": "Bind DB Test"}}], "properties":
+      {"Name": {"type": "title", "title": {}}, "Category": {"type": "select", "select":
+      {"options": [{"name": "Cat1", "color": "default"}, {"name": "Cat2", "color":
+      "red"}]}}, "Tags": {"type": "multi_select", "multi_select": {"options": [{"name":
+      "Cat1", "color": "default"}, {"name": "Cat2", "color": "red"}]}}}, "is_inline":
+      false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '648'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"251974f3-b388-818e-8afe-f3a75497beb3","cover":null,"icon":null,"created_time":"2025-08-16T13:24:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T13:24:00.000Z","title":[{"type":"text","text":{"content":"Bind
+      DB Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Bind
+      DB Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"cWdR","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"33435b62-f961-4de5-b2f6-124aa95b6122","name":"Cat1","color":"default","description":null},{"id":"fbc05bdb-dc46-42e6-8fe7-c7ed9f705a96","name":"Cat2","color":"red","description":null}]}},"Category":{"id":"s%3D~G","name":"Category","type":"select","select":{"options":[{"id":"85dd376c-e8e3-4ca9-8b79-bd4294ec4ee8","name":"Cat1","color":"default","description":null},{"id":"da3b2603-439a-4c94-8cc2-f92ef54d79d0","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b388818e8afef3a75497beb3","public_url":null,"archived":false,"in_trash":false,"request_id":"706eb284-d157-4e63-b824-4def0e271b61"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 970140f47d8fd2d2-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=0s54aquoArRD2BtJq2E0KRCUChqbWwt0drU1i6tiDYw-1755350685-1.0.1.1-.ejIgYSmlwcgIiSG01ER.lnR9rBoi5Zinepgtuf6FkpRB3W38VKLwfo4aTXJaMeXStzFEhFmkCZO4XLqiV_ztxK.DBuLxPJzr3pJl0SiRKQ;
+        path=/; expires=Sat, 16-Aug-25 13:54:45 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=bPF0IvwzPrgmAKSY5HeocbETewqUPNM.OFxedOLaCKo-1755350685570-0.0.1.1-604800000;
+        path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 706eb284-d157-4e63-b824-4def0e271b61
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_schema/test_update_prop_type_attrs.yaml
+++ b/tests/cassettes/test_schema/test_update_prop_type_attrs.yaml
@@ -30,14 +30,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:22:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
-      Prop-Test: Schema A","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"7a70c998-7b84-4971-ae98-a12f236ddd4f"}'
+      Prop-Test: Schema A","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"7afca9a7-4647-4fa2-963d-df233edd05a4"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962584f8bc020a18-ARN
+      - 970245ed5fa01d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -47,10 +47,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=kXLQ.261Y4ER9WeCJeD9nrLbH3PcjBMm5Rv0UbO0crA-1753046604-1.0.1.1-KHTcaASn12FTArcuyk.zYqgh9jXxDHqZ96RHLRYhY87ChgRwQTi7qivMUPQoRB43jhKIEMEuXWvHCi3o2uZYc53POQnHx58e5Ujm7pqKDIk;
-        path=/; expires=Sun, 20-Jul-25 21:53:24 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=GcH.r.CU39fwoi9sojXuMffT4LjYX2wiHsWKJnI3qnw-1755361375-1.0.1.1-NJzsmAHKKBFZqJlb8HBB2d49Uq8vLtZQ92SBQ.0DxHMNwwTq08QLtMRIXa0j9v3v58HyVwMgZhhpnvamIHpGE7xjLUQLMAmqYBKsAtnwX4k;
+        path=/; expires=Sat, 16-Aug-25 16:52:55 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=xl64EIUE..dE11rrot2NE6gSPq9HzjaX2BS8h53nHHs-1753046604645-0.0.1.1-604800000;
+      - _cfuvid=M9kHHfDcDv7TELy5XZFUcI2xt4Yxhz__F157dAaAz5g-1755361375283-0.0.1.1-604800000;
         path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -73,7 +73,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 7a70c998-7b84-4971-ae98-a12f236ddd4f
+      - 7afca9a7-4647-4fa2-963d-df233edd05a4
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -107,18 +107,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:22:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"2996ed02-f214-4a4e-9ff5-01a0728da453"}'
+      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"26c38f59-11be-4c22-9207-10bd21bb53ce"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962584ff4aaf0a18-ARN
+      - 970245f3b9151d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -148,7 +148,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 2996ed02-f214-4a4e-9ff5-01a0728da453
+      - 26c38f59-11be-4c22-9207-10bd21bb53ce
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -186,14 +186,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"236974f3-b388-810d-8237-fa2435146aa7","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e5-9f2f-df39c9543447","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:22:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
-      Prop-Test: Schema B","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388810d8237fa2435146aa7","public_url":null,"archived":false,"in_trash":false,"request_id":"09ee1673-cd0f-49d9-aacf-134fc365dd70"}'
+      Prop-Test: Schema B","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e59f2fdf39c9543447","public_url":null,"archived":false,"in_trash":false,"request_id":"63d6fe86-c4f0-4a9a-8fb0-fb2706f4e42d"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96258507dbc00a18-ARN
+      - 97024600eb9d1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -223,7 +223,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 09ee1673-cd0f-49d9-aacf-134fc365dd70
+      - 63d6fe86-c4f0-4a9a-8fb0-fb2706f4e42d
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -257,18 +257,18 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-810d-8237-fa2435146aa7
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e5-9f2f-df39c9543447
   response:
-    content: '{"object":"database","id":"236974f3-b388-810d-8237-fa2435146aa7","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e5-9f2f-df39c9543447","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:22:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema B","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema B","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388810d8237fa2435146aa7","public_url":null,"archived":false,"in_trash":false,"request_id":"2c83277e-bf97-4eff-8d72-a22f78623f97"}'
+      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e59f2fdf39c9543447","public_url":null,"archived":false,"in_trash":false,"request_id":"d60278a8-3839-4f76-9d30-f2fda132fe3c"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625850b9ff80a18-ARN
+      - 970246069bfa1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -298,7 +298,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 2c83277e-bf97-4eff-8d72-a22f78623f97
+      - d60278a8-3839-4f76-9d30-f2fda132fe3c
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -311,9 +311,9 @@ interactions:
       {"bold": false, "italic": false, "strikethrough": false, "underline": false,
       "code": false, "color": "default"}, "text": {"content": "Update Prop-Test: Schema
       C"}}], "properties": {"Name": {"type": "title", "title": {}}, "Relation": {"type":
-      "relation", "relation": {"type": "single_property", "database_id": "236974f3-b388-8180-ae1f-cf64ed73e229",
+      "relation", "relation": {"type": "single_property", "database_id": "251974f3-b388-81a3-aa3e-e78e9b7ca882",
       "single_property": {}}}, "Relation two-way": {"type": "relation", "relation":
-      {"type": "dual_property", "database_id": "236974f3-b388-8180-ae1f-cf64ed73e229",
+      {"type": "dual_property", "database_id": "251974f3-b388-81a3-aa3e-e78e9b7ca882",
       "dual_property": {}}}, "Rollup": {"type": "rollup", "rollup": {"function": "count",
       "relation_property_name": "Relation", "rollup_property_name": "Name"}}}, "is_inline":
       false}'
@@ -341,16 +341,16 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:22:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
-      Prop-Test: Schema C","href":null}],"description":[],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"b562e672-8c9e-48e6-882a-d45b453d6e26"}'
+      Prop-Test: Schema C","href":null}],"description":[],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"87a3533d-3b75-4bc3-bc52-83d2963ba334"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585184d980a18-ARN
+      - 9702460978331d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -380,7 +380,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - b562e672-8c9e-48e6-882a-d45b453d6e26
+      - 87a3533d-3b75-4bc3-bc52-83d2963ba334
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -414,20 +414,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"1bbe9141-33f4-4ac9-8365-317d2de0c606"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"fc19010a-9085-46cb-bce5-ec9e3f9c27cf"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585281c620a18-ARN
+      - 97024612def81d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -457,7 +457,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 1bbe9141-33f4-4ac9-8365-317d2de0c606
+      - fc19010a-9085-46cb-bce5-ec9e3f9c27cf
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -465,7 +465,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"D%3EPt": {"name": "Relation"}}}'
+    body: '{"properties": {"%7BxCM": {"name": "Relation"}}}'
     headers:
       accept:
       - '*/*'
@@ -488,19 +488,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"2ab13894-e28d-4b60-8bd5-8cb9f620652e"}'
+      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"cb6c2e0f-293c-4f4b-aa7b-b5df7b5b3f98"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96258537bbef0a18-ARN
+      - 97024617decc1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -530,7 +530,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 2ab13894-e28d-4b60-8bd5-8cb9f620652e
+      - cb6c2e0f-293c-4f4b-aa7b-b5df7b5b3f98
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -561,19 +561,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"932534e0-2a86-44a4-a2fa-2d78a6b018aa"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"fb1db0b7-8aa4-4e0b-9fd6-c1d3b444a215"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96258543bf820a18-ARN
+      - 9702463b6b9c1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -603,7 +603,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 932534e0-2a86-44a4-a2fa-2d78a6b018aa
+      - fb1db0b7-8aa4-4e0b-9fd6-c1d3b444a215
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -611,8 +611,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Relation": {"type": "relation", "id": "uS%7D%40", "name":
-      "Relation", "relation": {"type": "dual_property", "database_id": "236974f3-b388-8180-ae1f-cf64ed73e229",
+    body: '{"properties": {"Relation": {"type": "relation", "id": "OuH%3F", "name":
+      "Relation", "relation": {"type": "dual_property", "database_id": "251974f3-b388-81a3-aa3e-e78e9b7ca882",
       "dual_property": {}}}}}'
     headers:
       accept:
@@ -624,7 +624,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '203'
+      - '201'
       content-type:
       - application/json
       cookie:
@@ -636,20 +636,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Update Prop-Test: Schema C (Relation)","synced_property_id":"%3FW%3Ek"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"c8799b62-777d-472c-984b-5013d06bd42d"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Update Prop-Test: Schema C (Relation)","synced_property_id":"%40%5Db%7D"}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"e5ddb1ed-d071-45b9-8565-0a2395b837da"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625854e7bc40a18-ARN
+      - 97024644f8ed1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -679,7 +679,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - c8799b62-777d-472c-984b-5013d06bd42d
+      - e5ddb1ed-d071-45b9-8565-0a2395b837da
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -706,21 +706,21 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
       used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Related
-      to Update Prop-Test: Schema C (Relation)":{"id":"%3FW%3Ek","name":"Related to
-      Update Prop-Test: Schema C (Relation)","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"uS%7D%40"}}},"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"8cf620d3-1663-4275-b69f-c03f0cf77026"}'
+      to Update Prop-Test: Schema C (Relation)":{"id":"%40%5Db%7D","name":"Related
+      to Update Prop-Test: Schema C (Relation)","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"OuH%3F"}}},"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"e6f22813-c239-4eeb-9613-13c30e655090"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585558b8a0a18-ARN
+      - 9702464b5ce41d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -750,7 +750,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 8cf620d3-1663-4275-b69f-c03f0cf77026
+      - e6f22813-c239-4eeb-9613-13c30e655090
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -782,20 +782,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
       used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Back
-      Relation":{"id":"%3FW%3Ek","name":"Back Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"uS%7D%40"}}},"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"24842620-cab0-4d91-af54-9a8e0612910b"}'
+      Relation":{"id":"%40%5Db%7D","name":"Back Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"OuH%3F"}}},"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"451e5177-656d-4f0a-ad76-2bef39d3abcc"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585575d6a0a18-ARN
+      - 9702464cef241d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -825,84 +825,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 24842620-cab0-4d91-af54-9a8e0612910b
-      x-permitted-cross-domain-policies:
-      - none
-      x-xss-protection:
-      - '0'
-    http_version: HTTP/1.1
-    status_code: 200
-- request:
-    body: '{"properties": {"Back Relation": {"type": "relation", "id": "%3FW%3Ek",
-      "name": "Back Relation", "relation": {"type": "dual_property", "database_id":
-      "236974f3-b388-8165-80bb-f60e912a3c09", "dual_property": {"synced_property_name":
-      "Relation", "synced_property_id": "uS%7D%40"}}}}}'
-    headers:
-      accept:
-      - '*/*'
-      accept-encoding:
-      - gzip, deflate
-      authorization:
-      - secret...
-      connection:
-      - keep-alive
-      content-length:
-      - '281'
-      content-type:
-      - application/json
-      cookie:
-      - secret...
-      host:
-      - api.notion.com
-      notion-version:
-      - '2022-06-28'
-      user-agent:
-      - secret...
-    method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
-  response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
-      Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
-      Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
-      used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Back
-      Relation":{"id":"%3FW%3Ek","name":"Back Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"uS%7D%40"}}},"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"a4a92892-3715-4d0d-a6cc-758966f035ce"}'
-    headers:
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-Ray:
-      - 9625855c6a6e0a18-ARN
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      alt-svc:
-      - h3=":443"; ma=86400
-      content-security-policy:
-      - default-src 'none'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      x-content-type-options:
-      - nosniff
-      x-dns-prefetch-control:
-      - 'off'
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - SAMEORIGIN
-      x-notion-request-id:
-      - a4a92892-3715-4d0d-a6cc-758966f035ce
+      - 451e5177-656d-4f0a-ad76-2bef39d3abcc
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -929,20 +852,20 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"%3FW%3Ek"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"591dbfbd-4dd4-451e-921e-4e48716ab239"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"%40%5Db%7D"}}},"Relation two-way":{"id":"vd%3C%7D","name":"Relation
+      two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"bfb4ba32-51f5-49fd-8dca-b1c3deb1dcfc"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585639ad40a18-ARN
+      - 97024659dc211d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -972,7 +895,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 591dbfbd-4dd4-451e-921e-4e48716ab239
+      - bfb4ba32-51f5-49fd-8dca-b1c3deb1dcfc
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -980,8 +903,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Relation": {"type": "relation", "id": "uS%7D%40", "name":
-      "Relation", "relation": {"type": "dual_property", "database_id": "236974f3-b388-8180-ae1f-cf64ed73e229",
+    body: '{"properties": {"Relation": {"type": "relation", "id": "OuH%3F", "name":
+      "Relation", "relation": {"type": "dual_property", "database_id": "251974f3-b388-81a3-aa3e-e78e9b7ca882",
       "dual_property": {}}}}}'
     headers:
       accept:
@@ -993,7 +916,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '203'
+      - '201'
       content-type:
       - application/json
       cookie:
@@ -1005,20 +928,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Back
-      Relation","synced_property_id":"%3FW%3Ek"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"a4a934e0-235b-438a-96c8-80bffc7d2614"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Back
+      Relation","synced_property_id":"%40%5Db%7D"}}},"Relation two-way":{"id":"vd%3C%7D","name":"Relation
+      two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"c4b3526b-4346-48cb-9d66-7befec614457"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585658c9f0a18-ARN
+      - 9702465b7e821d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1048,7 +971,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a4a934e0-235b-438a-96c8-80bffc7d2614
+      - c4b3526b-4346-48cb-9d66-7befec614457
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1075,20 +998,20 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
       used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Back
-      Relation":{"id":"%3FW%3Ek","name":"Back Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"uS%7D%40"}}},"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"0e9b4d4c-aae6-4b44-af4c-3da3bb66e813"}'
+      Relation":{"id":"%40%5Db%7D","name":"Back Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"OuH%3F"}}},"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"f13760fa-5831-4dc4-a6f4-a8390b41cb85"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625856aea0e0a18-ARN
+      - 97024663db381d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1118,7 +1041,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 0e9b4d4c-aae6-4b44-af4c-3da3bb66e813
+      - f13760fa-5831-4dc4-a6f4-a8390b41cb85
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1149,20 +1072,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
       used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Other
-      Back Relation":{"id":"%3FW%3Ek","name":"Other Back Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"uS%7D%40"}}},"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"dca4cb91-0d1f-4b4e-ad28-b6d4324f8519"}'
+      Back Relation":{"id":"%40%5Db%7D","name":"Other Back Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"OuH%3F"}}},"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"7030e575-9c37-4309-9317-0dbba93edbde"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585706fcd0a18-ARN
+      - 970246663e751d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1192,84 +1115,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - dca4cb91-0d1f-4b4e-ad28-b6d4324f8519
-      x-permitted-cross-domain-policies:
-      - none
-      x-xss-protection:
-      - '0'
-    http_version: HTTP/1.1
-    status_code: 200
-- request:
-    body: '{"properties": {"Other Back Relation": {"type": "relation", "id": "%3FW%3Ek",
-      "name": "Other Back Relation", "relation": {"type": "dual_property", "database_id":
-      "236974f3-b388-8165-80bb-f60e912a3c09", "dual_property": {"synced_property_name":
-      "Relation", "synced_property_id": "uS%7D%40"}}}}}'
-    headers:
-      accept:
-      - '*/*'
-      accept-encoding:
-      - gzip, deflate
-      authorization:
-      - secret...
-      connection:
-      - keep-alive
-      content-length:
-      - '293'
-      content-type:
-      - application/json
-      cookie:
-      - secret...
-      host:
-      - api.notion.com
-      notion-version:
-      - '2022-06-28'
-      user-agent:
-      - secret...
-    method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
-  response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
-      Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
-      Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
-      used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Other
-      Back Relation":{"id":"%3FW%3Ek","name":"Other Back Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"uS%7D%40"}}},"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"485f7acf-59a6-4006-adb8-9ed62acb5125"}'
-    headers:
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-Ray:
-      - 962585778f9a0a18-ARN
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      alt-svc:
-      - h3=":443"; ma=86400
-      content-security-policy:
-      - default-src 'none'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      x-content-type-options:
-      - nosniff
-      x-dns-prefetch-control:
-      - 'off'
-      x-download-options:
-      - noopen
-      x-frame-options:
-      - SAMEORIGIN
-      x-notion-request-id:
-      - 485f7acf-59a6-4006-adb8-9ed62acb5125
+      - 7030e575-9c37-4309-9317-0dbba93edbde
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1296,20 +1142,20 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Other
-      Back Relation","synced_property_id":"%3FW%3Ek"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"216fbb99-5713-49f3-a500-61c330af2391"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Other
+      Back Relation","synced_property_id":"%40%5Db%7D"}}},"Relation two-way":{"id":"vd%3C%7D","name":"Relation
+      two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"bf7b860c-9fdf-4e9a-af5a-15923fd7fdb1"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625858158d90a18-ARN
+      - 970246691ae91d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1339,7 +1185,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 216fbb99-5713-49f3-a500-61c330af2391
+      - bf7b860c-9fdf-4e9a-af5a-15923fd7fdb1
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1347,8 +1193,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Relation": {"type": "relation", "id": "uS%7D%40", "name":
-      "Relation", "relation": {"type": "single_property", "database_id": "236974f3-b388-8180-ae1f-cf64ed73e229",
+    body: '{"properties": {"Relation": {"type": "relation", "id": "OuH%3F", "name":
+      "Relation", "relation": {"type": "single_property", "database_id": "251974f3-b388-81a3-aa3e-e78e9b7ca882",
       "single_property": {}}}}}'
     headers:
       accept:
@@ -1360,7 +1206,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '207'
+      - '205'
       content-type:
       - application/json
       cookie:
@@ -1372,19 +1218,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"4efc91ca-db1f-4a9b-a9f4-c00b027fc9d3"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"8ca5ec9a-a237-4fa1-95e6-fedbea8cc64a"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585833ab90a18-ARN
+      - 9702466b5e6d1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1414,7 +1260,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 4efc91ca-db1f-4a9b-a9f4-c00b027fc9d3
+      - 8ca5ec9a-a237-4fa1-95e6-fedbea8cc64a
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1445,19 +1291,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"8c764957-a025-4efa-9d5e-ac6def542bb6"}'
+      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"63229e6f-b54a-4ea1-bd25-2bb4a0e43dd5"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585955bfc0a18-ARN
+      - 970246735bd81d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1487,7 +1333,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 8c764957-a025-4efa-9d5e-ac6def542bb6
+      - 63229e6f-b54a-4ea1-bd25-2bb4a0e43dd5
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1514,19 +1360,19 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8180-ae1f-cf64ed73e229
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81a3-aa3e-e78e9b7ca882
   response:
-    content: '{"object":"database","id":"236974f3-b388-8180-ae1f-cf64ed73e229","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema A","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema A","href":null}],"description":[{"type":"text","text":{"content":"Only
       used to create relations in Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Only
-      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Relation":{"id":"D%3EPt","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-8165-80bb-f60e912a3c09","type":"dual_property","dual_property":{"synced_property_name":"Relation
-      two-way","synced_property_id":"jKfa"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b3888180ae1fcf64ed73e229","public_url":null,"archived":false,"in_trash":false,"request_id":"f5778ad7-980a-4ce6-8681-d14b089ed3bd"}'
+      used to create relations in Schema C","href":null}],"is_inline":false,"properties":{"Relation":{"id":"%7BxCM","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e6-8a48-ea104f2abb09","type":"dual_property","dual_property":{"synced_property_name":"Relation
+      two-way","synced_property_id":"vd%3C%7D"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881a3aa3ee78e9b7ca882","public_url":null,"archived":false,"in_trash":false,"request_id":"efdccfc4-ac34-4c8e-9003-20abfa437d7d"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625859d3b920a18-ARN
+      - 97024678cc911d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1556,7 +1402,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - f5778ad7-980a-4ce6-8681-d14b089ed3bd
+      - efdccfc4-ac34-4c8e-9003-20abfa437d7d
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1564,8 +1410,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Relation": {"type": "relation", "id": "uS%7D%40", "name":
-      "Relation", "relation": {"type": "single_property", "database_id": "236974f3-b388-810d-8237-fa2435146aa7",
+    body: '{"properties": {"Relation": {"type": "relation", "id": "OuH%3F", "name":
+      "Relation", "relation": {"type": "single_property", "database_id": "251974f3-b388-81e5-9f2f-df39c9543447",
       "single_property": {}}}}}'
     headers:
       accept:
@@ -1577,7 +1423,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '207'
+      - '205'
       content-type:
       - application/json
       cookie:
@@ -1589,19 +1435,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-810d-8237-fa2435146aa7","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"a24983d7-f069-4396-8640-ce545baec96f"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e5-9f2f-df39c9543447","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"8d015f82-362e-4bb3-9d3d-550b49aa1718"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625859f2d7f0a18-ARN
+      - 9702467a8fb81d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1631,7 +1477,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a24983d7-f069-4396-8640-ce545baec96f
+      - 8d015f82-362e-4bb3-9d3d-550b49aa1718
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1658,19 +1504,19 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-8180-ae1f-cf64ed73e229","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"D%3EPt"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-810d-8237-fa2435146aa7","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"f0167dda-cd67-45e9-91e0-ed8a889d6911"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e5-9f2f-df39c9543447","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81a3-aa3e-e78e9b7ca882","type":"dual_property","dual_property":{"synced_property_name":"Relation","synced_property_id":"%7BxCM"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"a862d455-c3f7-425e-9517-4b8e4addc779"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585b2f88c0a18-ARN
+      - 970246826c361d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1700,7 +1546,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - f0167dda-cd67-45e9-91e0-ed8a889d6911
+      - a862d455-c3f7-425e-9517-4b8e4addc779
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1708,9 +1554,9 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Relation two-way": {"type": "relation", "id": "jKfa",
+    body: '{"properties": {"Relation two-way": {"type": "relation", "id": "vd%3C%7D",
       "name": "Relation two-way", "relation": {"type": "dual_property", "database_id":
-      "236974f3-b388-810d-8237-fa2435146aa7", "dual_property": {}}}}}'
+      "251974f3-b388-81e5-9f2f-df39c9543447", "dual_property": {}}}}}'
     headers:
       accept:
       - '*/*'
@@ -1721,7 +1567,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '215'
+      - '219'
       content-type:
       - application/json
       cookie:
@@ -1733,20 +1579,20 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-810d-8237-fa2435146aa7","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"%5Cjx_"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-810d-8237-fa2435146aa7","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"a4721951-1c88-403e-af88-4b69464bd10f"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e5-9f2f-df39c9543447","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81e5-9f2f-df39c9543447","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"ae%5CY"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"f1df7359-431e-4e38-905c-e05195e4bb32"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585b6dcb70a18-ARN
+      - 97024683eef51d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1776,7 +1622,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - a4721951-1c88-403e-af88-4b69464bd10f
+      - f1df7359-431e-4e38-905c-e05195e4bb32
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1803,20 +1649,20 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-8165-80bb-f60e912a3c09
+    uri: https://api.notion.com/v1/databases/251974f3-b388-81e6-8a48-ea104f2abb09
   response:
-    content: '{"object":"database","id":"236974f3-b388-8165-80bb-f60e912a3c09","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Update
+    content: '{"object":"database","id":"251974f3-b388-81e6-8a48-ea104f2abb09","cover":null,"icon":null,"created_time":"2025-08-16T16:22:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Update
       Prop-Test: Schema C","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Update
       Prop-Test: Schema C","href":null}],"description":[{"type":"text","text":{"content":"Actual
       interesting schema/db","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Actual
-      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"_D%3BW","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"uS}@","function":"count"}},"Relation
-      two-way":{"id":"jKfa","name":"Relation two-way","type":"relation","relation":{"database_id":"236974f3-b388-810d-8237-fa2435146aa7","type":"dual_property","dual_property":{"synced_property_name":"Related
-      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"%5Cjx_"}}},"Relation":{"id":"uS%7D%40","name":"Relation","type":"relation","relation":{"database_id":"236974f3-b388-810d-8237-fa2435146aa7","type":"single_property","single_property":{}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816580bbf60e912a3c09","public_url":null,"archived":false,"in_trash":false,"request_id":"7909ee67-353d-4576-ba99-97b96096f1de"}'
+      interesting schema/db","href":null}],"is_inline":false,"properties":{"Rollup":{"id":"%3FTe%5C","name":"Rollup","type":"rollup","rollup":{"rollup_property_name":"Name","relation_property_name":"Relation","rollup_property_id":"title","relation_property_id":"OuH?","function":"count"}},"Relation":{"id":"OuH%3F","name":"Relation","type":"relation","relation":{"database_id":"251974f3-b388-81e5-9f2f-df39c9543447","type":"single_property","single_property":{}}},"Relation
+      two-way":{"id":"vd%3C%7D","name":"Relation two-way","type":"relation","relation":{"database_id":"251974f3-b388-81e5-9f2f-df39c9543447","type":"dual_property","dual_property":{"synced_property_name":"Related
+      to Update Prop-Test: Schema C (Relation two-way)","synced_property_id":"ae%5CY"}}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b38881e68a48ea104f2abb09","public_url":null,"archived":false,"in_trash":false,"request_id":"60a04fb6-5b1c-4d75-9971-4561b9b0b5a0"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585c0ede20a18-ARN
+      - 9702468ac9cc1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1846,7 +1692,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 7909ee67-353d-4576-ba99-97b96096f1de
+      - 60a04fb6-5b1c-4d75-9971-4561b9b0b5a0
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1889,14 +1735,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"dollar"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"42ecb312-d5dc-4bff-949f-ff0e74bca7ea"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"dollar"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"1afa33df-f654-4891-ade6-3a581138902b"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585cc4a140a18-ARN
+      - 9702468c7c8f1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1926,7 +1772,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 42ecb312-d5dc-4bff-949f-ff0e74bca7ea
+      - 1afa33df-f654-4891-ade6-3a581138902b
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1934,8 +1780,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Number": {"type": "number", "id": "OqBk", "name": "Number",
-      "number": {"format": "percent"}}}}'
+    body: '{"properties": {"Number": {"type": "number", "id": "xy%7D%3A", "name":
+      "Number", "number": {"format": "percent"}}}}'
     headers:
       accept:
       - '*/*'
@@ -1946,7 +1792,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '111'
+      - '115'
       content-type:
       - application/json
       cookie:
@@ -1958,16 +1804,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"percent"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"9c6f9cee-4ba6-43c1-aa56-75b5dd076074"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"percent"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"0af8aa68-69eb-4bf0-b4e1-b2bc72909d1d"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585d2c8ac0a18-ARN
+      - 970246997a971d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1997,7 +1843,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 9c6f9cee-4ba6-43c1-aa56-75b5dd076074
+      - 0af8aa68-69eb-4bf0-b4e1-b2bc72909d1d
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2024,16 +1870,16 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:23:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"percent"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"ccd311b8-3dcf-40a7-9f60-6820248dad9d"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"percent"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"b08a36cb-2091-4abb-bef6-a42545dc83bb"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585d6dcfe0a18-ARN
+      - 970246af998d1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2063,7 +1909,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - ccd311b8-3dcf-40a7-9f60-6820248dad9d
+      - b08a36cb-2091-4abb-bef6-a42545dc83bb
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2071,8 +1917,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Number": {"type": "number", "id": "OqBk", "name": "Number",
-      "number": {"format": "euro"}}}}'
+    body: '{"properties": {"Number": {"type": "number", "id": "xy%7D%3A", "name":
+      "Number", "number": {"format": "euro"}}}}'
     headers:
       accept:
       - '*/*'
@@ -2083,7 +1929,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '108'
+      - '112'
       content-type:
       - application/json
       cookie:
@@ -2095,16 +1941,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"0f069c72-a773-4919-9160-3ed6d913f70d"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"41466e2d-3500-46d0-9b81-8420baf58bf1"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585db7a6d0a18-ARN
+      - 970246b979a51d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2134,7 +1980,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 0f069c72-a773-4919-9160-3ed6d913f70d
+      - 41466e2d-3500-46d0-9b81-8420baf58bf1
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2142,8 +1988,8 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Formula": {"type": "formula", "id": "MAUH", "name": "Formula",
-      "formula": {"expression": "prop(\"Category\")"}}}}'
+    body: '{"properties": {"Formula": {"type": "formula", "id": "%7D%3Bn%7D", "name":
+      "Formula", "formula": {"expression": "prop(\"Category\")"}}}}'
     headers:
       accept:
       - '*/*'
@@ -2154,7 +2000,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '130'
+      - '136'
       content-type:
       - application/json
       cookie:
@@ -2166,16 +2012,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"9b22e257-3d74-46f8-b637-ea331834669d"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"ac39021e-646c-4c36-870b-803279c258d8"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585e3ecde0a18-ARN
+      - 970246bc1e3d1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2205,7 +2051,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 9b22e257-3d74-46f8-b637-ea331834669d
+      - ac39021e-646c-4c36-870b-803279c258d8
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2232,16 +2078,16 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"65cc527f-eeb0-45c4-b56b-379535e9c7dd"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"24e32bab-5c74-4ea2-a417-b41ccc76dd82"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585e6afbb0a18-ARN
+      - 970246c3ba831d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2271,7 +2117,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 65cc527f-eeb0-45c4-b56b-379535e9c7dd
+      - 24e32bab-5c74-4ea2-a417-b41ccc76dd82
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2279,9 +2125,9 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Category": {"type": "select", "id": "X%5EbP", "name":
-      "Category", "select": {"options": [{"name": "Cat1", "id": "83e71d6b-8b2f-4a5e-b33b-3b89c474c874",
-      "color": "default"}, {"name": "Cat2", "id": "09b44105-34c6-4dfb-8214-97c2463ab2b9",
+    body: '{"properties": {"Category": {"type": "select", "id": "TO%3A%3C", "name":
+      "Category", "select": {"options": [{"name": "Cat1", "id": "24267fe3-5666-41e0-86a5-4e15b84c01e0",
+      "color": "default"}, {"name": "Cat2", "id": "13144825-ed1c-4136-88f7-1551251d6dc5",
       "color": "red"}, {"name": "Cat3", "color": "red"}]}}}}'
     headers:
       accept:
@@ -2293,7 +2139,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '307'
+      - '309'
       content-type:
       - application/json
       cookie:
@@ -2305,16 +2151,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null},{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"40ff5aa1-c694-416b-b235-318fae58c75f"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null},{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"d395362c-3e7a-4aa3-86ee-16006b1cb7cf"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585ec7e970a18-ARN
+      - 970246ca1c861d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2344,7 +2190,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 40ff5aa1-c694-416b-b235-318fae58c75f
+      - d395362c-3e7a-4aa3-86ee-16006b1cb7cf
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2371,16 +2217,16 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"83e71d6b-8b2f-4a5e-b33b-3b89c474c874","name":"Cat1","color":"default","description":null},{"id":"09b44105-34c6-4dfb-8214-97c2463ab2b9","name":"Cat2","color":"red","description":null},{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"49e48e69-a8fc-46ac-a0bd-a0e0202dda63"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"24267fe3-5666-41e0-86a5-4e15b84c01e0","name":"Cat1","color":"default","description":null},{"id":"13144825-ed1c-4136-88f7-1551251d6dc5","name":"Cat2","color":"red","description":null},{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"abaccfda-9474-4f3a-bd15-41bd8e78d090"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585f2dd2e0a18-ARN
+      - 970246cd59791d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2410,7 +2256,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 49e48e69-a8fc-46ac-a0bd-a0e0202dda63
+      - abaccfda-9474-4f3a-bd15-41bd8e78d090
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2418,7 +2264,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Category": {"type": "select", "id": "X%5EbP", "name":
+    body: '{"properties": {"Category": {"type": "select", "id": "TO%3A%3C", "name":
       "Category", "select": {"options": [{"name": "Cat3", "color": "red"}]}}}}'
     headers:
       accept:
@@ -2430,7 +2276,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '143'
+      - '145'
       content-type:
       - application/json
       cookie:
@@ -2442,16 +2288,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"f955a287-9bf7-4f3e-a3b6-5d3c32aecd3c"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"ca1a1c79-8b5f-44cc-af29-60061a2c0d56"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585f53f900a18-ARN
+      - 970246d82bd71d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2481,7 +2327,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - f955a287-9bf7-4f3e-a3b6-5d3c32aecd3c
+      - ca1a1c79-8b5f-44cc-af29-60061a2c0d56
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2508,16 +2354,16 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"ab5476fc-49b9-48d3-bfef-3dc6f7074279"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"6fe23696-21be-486c-a0dc-24798c64cd95"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585faad110a18-ARN
+      - 970246f63b271d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2547,7 +2393,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - ab5476fc-49b9-48d3-bfef-3dc6f7074279
+      - 6fe23696-21be-486c-a0dc-24798c64cd95
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2555,9 +2401,9 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Tags": {"type": "multi_select", "id": "%3EE%7D%3C", "name":
-      "Tags", "multi_select": {"options": [{"name": "Cat1", "id": "5acf81e6-ff0c-456a-a80d-544bc0f637cd",
-      "color": "default"}, {"name": "Cat2", "id": "fdf609dc-dd0d-4122-88f0-3b8b2e469a61",
+    body: '{"properties": {"Tags": {"type": "multi_select", "id": "U%7DF%60", "name":
+      "Tags", "multi_select": {"options": [{"name": "Cat1", "id": "d007128e-56e2-4f26-a7be-c516297f2731",
+      "color": "default"}, {"name": "Cat2", "id": "751a91d5-8b88-4d03-b140-36007847aee5",
       "color": "red"}, {"name": "Cat3", "color": "red"}]}}}}'
     headers:
       accept:
@@ -2569,7 +2415,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '315'
+      - '313'
       content-type:
       - application/json
       cookie:
@@ -2581,16 +2427,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null},{"id":"d6d9bc9e-cd15-4b25-9c71-a43cc4f3127c","name":"Cat3","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"71a63b74-103c-41b5-8c75-eff004684821"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null},{"id":"0f338935-7e09-4120-b477-31ee848a0bf1","name":"Cat3","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"23157fea-60a8-4e3d-863a-648e54e09478"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 962585fd38080a18-ARN
+      - 970246f7dde31d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2620,7 +2466,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 71a63b74-103c-41b5-8c75-eff004684821
+      - 23157fea-60a8-4e3d-863a-648e54e09478
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2647,16 +2493,16 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"5acf81e6-ff0c-456a-a80d-544bc0f637cd","name":"Cat1","color":"default","description":null},{"id":"fdf609dc-dd0d-4122-88f0-3b8b2e469a61","name":"Cat2","color":"red","description":null},{"id":"d6d9bc9e-cd15-4b25-9c71-a43cc4f3127c","name":"Cat3","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"7678bc40-465f-4e32-90fe-29c5bff0733a"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d007128e-56e2-4f26-a7be-c516297f2731","name":"Cat1","color":"default","description":null},{"id":"751a91d5-8b88-4d03-b140-36007847aee5","name":"Cat2","color":"red","description":null},{"id":"0f338935-7e09-4120-b477-31ee848a0bf1","name":"Cat3","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"5cce7590-605d-4692-ba87-f307455d4ba6"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 96258603af6d0a18-ARN
+      - 97024702dab41d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2686,7 +2532,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 7678bc40-465f-4e32-90fe-29c5bff0733a
+      - 5cce7590-605d-4692-ba87-f307455d4ba6
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2694,7 +2540,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"properties": {"Tags": {"type": "multi_select", "id": "%3EE%7D%3C", "name":
+    body: '{"properties": {"Tags": {"type": "multi_select", "id": "U%7DF%60", "name":
       "Tags", "multi_select": {"options": [{"name": "Cat3", "color": "red"}]}}}}'
     headers:
       accept:
@@ -2706,7 +2552,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '151'
+      - '149'
       content-type:
       - application/json
       cookie:
@@ -2718,16 +2564,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d6d9bc9e-cd15-4b25-9c71-a43cc4f3127c","name":"Cat3","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"912591e0-de33-4783-b2e0-5edd7f59d33f"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"0f338935-7e09-4120-b477-31ee848a0bf1","name":"Cat3","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"df02c49c-0493-4d96-9ca0-65f63f57df8c"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625860599510a18-ARN
+      - 970247047d7c1d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2757,7 +2603,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 912591e0-de33-4783-b2e0-5edd7f59d33f
+      - df02c49c-0493-4d96-9ca0-65f63f57df8c
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -2784,16 +2630,16 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/databases/236974f3-b388-816a-bf15-ecdde2305a36
+    uri: https://api.notion.com/v1/databases/251974f3-b388-8144-853d-c08e939cfc29
   response:
-    content: '{"object":"database","id":"236974f3-b388-816a-bf15-ecdde2305a36","cover":null,"icon":null,"created_time":"2025-07-20T21:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-07-20T21:24:00.000Z","title":[{"type":"text","text":{"content":"Select
+    content: '{"object":"database","id":"251974f3-b388-8144-853d-c08e939cfc29","cover":null,"icon":null,"created_time":"2025-08-16T16:23:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_time":"2025-08-16T16:23:00.000Z","title":[{"type":"text","text":{"content":"Select
       Options Update Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Select
-      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Tags":{"id":"%3EE%7D%3C","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"d6d9bc9e-cd15-4b25-9c71-a43cc4f3127c","name":"Cat3","color":"red","description":null}]}},"Formula":{"id":"MAUH","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:X%5EbP:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Number":{"id":"OqBk","name":"Number","type":"number","number":{"format":"euro"}},"Category":{"id":"X%5EbP","name":"Category","type":"select","select":{"options":[{"id":"7987f220-afd0-45fc-82c7-dce1dfec6e47","name":"Cat3","color":"red","description":null}]}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/236974f3b388816abf15ecdde2305a36","public_url":null,"archived":false,"in_trash":false,"request_id":"5076d3c9-aa67-494d-8a5e-d03f5bf28de6"}'
+      Options Update Test","href":null}],"description":[],"is_inline":false,"properties":{"Category":{"id":"TO%3A%3C","name":"Category","type":"select","select":{"options":[{"id":"e11821b4-f5d7-4f8b-a09d-51157b27c584","name":"Cat3","color":"red","description":null}]}},"Tags":{"id":"U%7DF%60","name":"Tags","type":"multi_select","multi_select":{"options":[{"id":"0f338935-7e09-4120-b477-31ee848a0bf1","name":"Cat3","color":"red","description":null}]}},"Number":{"id":"xy%7D%3A","name":"Number","type":"number","number":{"format":"euro"}},"Formula":{"id":"%7D%3Bn%7D","name":"Formula","type":"formula","formula":{"expression":"{{notion:block_property:TO%3A%3C:00000000-0000-0000-0000-000000000000:5a65efbd-bfb2-4ebe-bb5d-ac95c98fb252}}"}},"Name":{"id":"title","name":"Name","type":"title","title":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/251974f3b3888144853dc08e939cfc29","public_url":null,"archived":false,"in_trash":false,"request_id":"c02cc691-bc63-44bb-9836-c4e12d3653a1"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 9625860ba8220a18-ARN
+      - 9702470c9bc51d0c-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -2823,7 +2669,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 5076d3c9-aa67-494d-8a5e-d03f5bf28de6
+      - c02cc691-bc63-44bb-9836-c4e12d3653a1
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -24,7 +24,7 @@ def test_schema(article_db: uno.Database) -> None:
     assert issubclass(ref_schema, uno.Schema)
     db_schema = {
         'Name': uno.PropType.Title(),
-        'Cost': uno.PropType.Number(uno.NumberFormat.DOLLAR),
+        'Cost': uno.PropType.Number(format=uno.NumberFormat.DOLLAR),
         'Description': uno.PropType.Text(),
     }
     assert ref_schema.to_dict() == db_schema

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -73,8 +73,8 @@ def test_db_without_title(notion: uno.Session, root_page: uno.Page) -> None:
         desc = uno.PropType.Text('Description')
 
     db = notion.create_db(parent=root_page, schema=Article)
-    assert db.title == ''
-    assert db.description == ''
+    assert db.title is None
+    assert db.description is None
     db.delete()
 
 
@@ -89,12 +89,12 @@ def test_db_with_title(notion: uno.Session, root_page: uno.Page) -> None:
 
     db = notion.create_db(parent=root_page, schema=Article, title='Overwritten Title')
     assert db.title == 'Overwritten Title'
-    assert db.description == ''
+    assert db.description is None
     db.delete()
 
     db = notion.create_db(parent=root_page, title='No Schema Used')
     assert db.title == 'No Schema Used'
-    assert db.description == ''
+    assert db.description is None
     db.delete()
 
 
@@ -110,7 +110,7 @@ def test_db_with_docstring(notion: uno.Session, root_page: uno.Page) -> None:
         desc = uno.PropType.Text('Description')
 
     db = notion.create_db(parent=root_page, schema=Article)
-    assert db.title == ''
+    assert db.title is None
     assert db.description == 'My articles'
     db.delete()
 
@@ -140,13 +140,13 @@ def test_title_setter(notion: uno.Session, article_db: uno.Database) -> None:
     assert article_db.title == new_title
     article_db.title = uno.text(old_title)
     assert article_db.title == old_title
-    article_db.title = ''
-    assert article_db.title == ''
+    article_db.title = None
+    assert article_db.title is None
 
 
 @pytest.mark.vcr()
 def test_description_setter(notion: uno.Session, article_db: uno.Database) -> None:
-    assert article_db.description == ''
+    assert article_db.description is None
 
     new_description = 'My most favorite articles'
     article_db.description = new_description  # type: ignore
@@ -156,8 +156,8 @@ def test_description_setter(notion: uno.Session, article_db: uno.Database) -> No
     del notion.cache[article_db.id]
     article_db = notion.get_db(article_db.id)
     assert article_db.description == new_description
-    article_db.description = ''  # type: ignore
-    assert article_db.description == ''
+    article_db.description = None
+    assert article_db.description is None
 
 
 @pytest.mark.vcr()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -295,7 +295,7 @@ def test_more_than_max_refs_per_relation_property(notion: uno.Session, root_page
     customer.reload()  # reload to get the updated relation
     time.sleep(3)  # wait for the changes to be applied on the server side
 
-    assert_eventually(lambda: len(customer.props.purchases) == n_prop_items)  # type: ignore[attr-defined]
+    assert_eventually(lambda: len(customer.props.purchases) == n_prop_items)
 
 
 @pytest.mark.vcr()
@@ -318,8 +318,8 @@ def test_more_than_max_mentions_per_text_property(notion: uno.Session, root_page
     item = Item.create(name=text, desc=text)
     item.reload()  # reload to clear cache and retrieve the page again
 
-    assert len(item.props.name.mentions) == n_mentions  # type: ignore[attr-defined]
-    assert len(item.props.desc.mentions) == n_mentions  # type: ignore[attr-defined]
+    assert len(item.props.name.mentions) == n_mentions
+    assert len(item.props.desc.mentions) == n_mentions
 
 
 @pytest.mark.vcr()
@@ -355,19 +355,19 @@ def test_option_page_props(notion: uno.Session, root_page: uno.Page) -> None:
     s_options = {opt.name: opt for opt in select_options}
     ms_options = {opt.name: opt for opt in multi_select_options}
 
-    assert page1.props.status == s_options['Open']  # type: ignore[attr-defined]
-    page1.props.status = s_options['Blocked']  # type: ignore[attr-defined]
-    assert page1.props.status.name == 'Blocked'  # type: ignore[attr-defined]
-    page1.props.status = 'Closed'  # type: ignore[attr-defined]
+    assert page1.props.status == s_options['Open']
+    page1.props.status = s_options['Blocked']
+    assert page1.props.status.name == 'Blocked'
+    page1.props.status = 'Closed'
     assert page1.props.status.name == 'Closed'  # type: ignore[attr-defined]
 
-    assert page2.props.multi_status == [ms_options['Option 1'], ms_options['Option 2']]  # type: ignore[attr-defined]
-    page2.props.multi_status = [ms_options['Option 1']]  # type: ignore[attr-defined]
-    assert page2.props.multi_status == [ms_options['Option 1']]  # type: ignore[attr-defined]
-    page2.props.multi_status = 'Option 2'  # type: ignore[attr-defined]
-    assert page2.props.multi_status == [ms_options['Option 2']]  # type: ignore[attr-defined]
-    page2.props.multi_status = ['Option 1', 'Option 2']  # type: ignore[attr-defined]
-    assert page2.props.multi_status == [ms_options['Option 1'], ms_options['Option 2']]  # type: ignore[attr-defined]
+    assert page2.props.multi_status == [ms_options['Option 1'], ms_options['Option 2']]
+    page2.props.multi_status = [ms_options['Option 1']]
+    assert page2.props.multi_status == [ms_options['Option 1']]
+    page2.props.multi_status = 'Option 2'
+    assert page2.props.multi_status == [ms_options['Option 2']]
+    page2.props.multi_status = ['Option 1', 'Option 2']
+    assert page2.props.multi_status == [ms_options['Option 1'], ms_options['Option 2']]
 
 
 @pytest.mark.vcr()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -261,7 +261,7 @@ def test_add_del_update_prop(notion: uno.Session, root_page: uno.Page) -> None:
     assert 'Formula' not in [prop.name for prop in db.schema]
     assert not hasattr(db.schema, 'formula')
 
-    db.schema.tags.delete()  # type: ignore[attr-defined]
+    db.schema.tags.delete()
     assert 'Tags' not in [prop.name for prop in db.schema]
     assert not hasattr(db.schema, 'tags')
     db.reload()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes issue #86, which was reported by @yonihik. 

### Types of change

All schema properties are now stored in a `_props` attribute (list) of the actual schema object, no longer as an actual object attribute like before. When you lookup a property, i.e. `schema.prop_name`, `__getattr__` gets called and looks thru all properties in `_props` to find the one with `attr_name == prop_name`, which is then returned. This fixes potential naming conflicts and even allows us to react in case an attr_name is no longer unique. 


## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
