### PR TITLE
Fix color codeblock

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -378,10 +378,12 @@ class Code(TextBlock[obj_blocks.Code], CaptionMixin[obj_blocks.Code], wraps=obj_
         self,
         text: str,
         *,
-        language: CodeLang = CodeLang.PLAIN_TEXT,
+        language: str | CodeLang = CodeLang.PLAIN_TEXT,
         caption: str | None = None,
     ) -> None:
         super().__init__(text)
+        if not isinstance(language, CodeLang):
+            language = CodeLang(language)
         self.obj_ref.value.language = language
         self.obj_ref.value.caption = Text(caption).obj_ref if caption is not None else []
 

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -346,7 +346,8 @@ class Annotations(GenericObject):
     strikethrough: bool = False
     underline: bool = False
     code: bool = False
-    color: Color | BGColor = Color.DEFAULT
+    # None for instance for code blocks to have flexible coloring. Will be replaced by DEFAULT
+    color: Color | BGColor | None = None
 
 
 class RichTextBaseObject(TypedObject[GenericObject], polymorphic_base=True):

--- a/src/ultimate_notion/rich_text.py
+++ b/src/ultimate_notion/rich_text.py
@@ -157,7 +157,7 @@ class RichText(RichTextBase[objs.TextObject], wraps=objs.TextObject):
         strikethrough: bool = False,
         code: bool = False,
         underline: bool = False,
-        color: Color = Color.DEFAULT,
+        color: Color | None = None,
         href: str | None = None,
     ) -> None:
         if len(text) > MAX_TEXT_OBJECT_SIZE:

--- a/tests/cassettes/test_blocks/test_color_code_block.yaml
+++ b/tests/cassettes/test_blocks/test_color_code_block.yaml
@@ -1,0 +1,280 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "5f505199-b292-4713-920b-61d813bf72a3"},
+      "properties": {"title": {"type": "title", "title": [{"type": "text", "plain_text":
+      "Page for color code block", "annotations": {"bold": false, "italic": false,
+      "strikethrough": false, "underline": false, "code": false}, "text": {"content":
+      "Page for color code block"}}]}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '329'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    content: '{"object":"page","id":"257974f3-b388-817f-b228-ddc878166360","created_time":"2025-08-22T09:15:00.000Z","last_edited_time":"2025-08-22T09:15:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Page
+      for color code block","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Page
+      for color code block","href":null}]}},"url":"https://www.notion.so/Page-for-color-code-block-257974f3b388817fb228ddc878166360","public_url":null,"request_id":"036d7e8e-8aed-4f51-b2a9-7b53aef2c708"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 97314460eed5b190-PRG
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=LxX6nWX1JI7WejjUD_JcRLgmO88IIXNIWkl9f7guENc-1755854142-1.0.1.1-IeWILK78TxXCdBm9rgvMDfjwrnLG6HQ.CTeKmNbzAU7DdbYgyPGcd49XMpN7e.0ATSkn1tiwbpc_rhLPK.nowZKly2U1SNOQpGYmrt_.5hA;
+        path=/; expires=Fri, 22-Aug-25 09:45:42 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 036d7e8e-8aed-4f51-b2a9-7b53aef2c708
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/5f505199-b292-4713-920b-61d813bf72a3
+  response:
+    content: '{"object":"page","id":"5f505199-b292-4713-920b-61d813bf72a3","created_time":"2022-08-22T15:47:00.000Z","last_edited_time":"2025-08-22T09:15:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-5f505199b2924713920b61d813bf72a3","public_url":null,"request_id":"7f69c2ff-3816-4bbd-afa4-e8483e84588b"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9731446449a7b190-PRG
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 7f69c2ff-3816-4bbd-afa4-e8483e84588b
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/blocks/257974f3-b388-817f-b228-ddc878166360/children?page_size=100
+  response:
+    content: '{"object":"list","results":[],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"a48dff5a-80c8-4307-843a-3d77e21a7274"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 97314465ff21b190-PRG
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - a48dff5a-80c8-4307-843a-3d77e21a7274
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"children":[{"object":"block","has_children":false,"in_trash":false,"archived":false,"type":"code","code":{"rich_text":[{"type":"text","plain_text":"print(\"Hello,
+      world!\")","annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false},"text":{"content":"print(\"Hello,
+      world!\")"}}],"caption":[],"language":"python"}}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '357'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/257974f3-b388-817f-b228-ddc878166360/children
+  response:
+    content: '{"object":"list","results":[{"object":"block","id":"257974f3-b388-812e-88d6-e8904a9d2439","parent":{"type":"page_id","page_id":"257974f3-b388-817f-b228-ddc878166360"},"created_time":"2025-08-22T09:15:00.000Z","last_edited_time":"2025-08-22T09:15:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":false,"in_trash":false,"type":"code","code":{"caption":[],"rich_text":[{"type":"text","text":{"content":"print(\"Hello,
+      world!\")","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"print(\"Hello,
+      world!\")","href":null}],"language":"python"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"ce9cf828-4793-49ed-bec4-8581651c984b"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 973144682ee0b190-PRG
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - ce9cf828-4793-49ed-bec4-8581651c984b
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -615,3 +615,17 @@ def test_nested_bullet_items(root_page: uno.Page, notion: uno.Session) -> None:
     page.append(uno.BulletedItem('First bullet'))
     page.append(second_bullet := uno.BulletedItem('Second bullet'))
     second_bullet.append(uno.BulletedItem('Nested bullet'))
+
+
+@pytest.mark.vcr()
+def test_color_code_block(root_page: uno.Page, notion: uno.Session) -> None:
+    page = notion.create_page(parent=root_page, title='Page for color code block')
+    code_block = uno.Code('print("Hello, world!")', language='python')
+    assert code_block.obj_ref.code.rich_text[0].annotations.color is None  # type: ignore[union-attr]
+    page.append(code_block)
+
+    assert page.children == (code_block,)
+    assert code_block.language == 'python'
+    # Note that None was replaced with Color.DEFAULT by the API. Sending it directly
+    # would have prevented the python code coloring from being applied in the Notion UI.
+    assert code_block.obj_ref.code.rich_text[0].annotations.color is uno.Color.DEFAULT  # type: ignore[union-attr]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes #93 by setting the default color to `None` instead of `Color.DEFAULT`. The API will return `Color.DEFAULT` though but sending it directly results in text not colored by the provided language specification.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
