### PR TITLE
Fix type data of low-level objects are initialized and thus share state

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -358,6 +358,14 @@ class Block(CommentMixin[B_co], ABC, wraps=obj_blocks.Block):
             msg = 'Cannot insert a block that has no parent.'
             raise InvalidAPIUsageError(msg)
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Block):
+            return NotImplemented
+        return bool(self.obj_ref == other.obj_ref)  # for type narrowing
+
+    def __hash__(self) -> int:
+        return hash(self.obj_ref)
+
 
 class CaptionMixin(Block[B_co], wraps=obj_blocks.Block):
     """Mixin for objects that can have captions."""
@@ -474,7 +482,6 @@ class ColoredTextBlock(TextBlock[TB], wraps=obj_blocks.ColoredTextBlock):
     ) -> None:
         super().__init__(text)
         value = self._get_value()
-        value.rich_text = Text(text).obj_ref
         value.color = color
 
     def _get_value(self) -> obj_blocks.ColoredTextBlockTypeData:

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -118,7 +118,7 @@ class UnsupportedBlockTypeData(GenericObject):
 class UnsupportedBlock(Block[UnsupportedBlockTypeData], type='unsupported'):
     """A placeholder for unsupported blocks in the API."""
 
-    unsupported: UnsupportedBlockTypeData = UnsupportedBlockTypeData()
+    unsupported: UnsupportedBlockTypeData = Field(default_factory=UnsupportedBlockTypeData)
 
 
 class TextBlockTypeData(GenericObject):
@@ -158,7 +158,7 @@ class ParagraphTypeData(ColoredTextBlockTypeData):
 class Paragraph(ColoredTextBlock[ParagraphTypeData], type='paragraph'):
     """A paragraph block in Notion."""
 
-    paragraph: ParagraphTypeData = ParagraphTypeData()
+    paragraph: ParagraphTypeData = Field(default_factory=ParagraphTypeData)
 
 
 class HeadingTypeData(ColoredTextBlockTypeData):
@@ -174,19 +174,19 @@ class Heading(ColoredTextBlock[HeadingTypeData]):
 class Heading1(Heading, type='heading_1'):
     """A heading_1 block in Notion."""
 
-    heading_1: HeadingTypeData = HeadingTypeData()
+    heading_1: HeadingTypeData = Field(default_factory=HeadingTypeData)
 
 
 class Heading2(Heading, type='heading_2'):
     """A heading_2 block in Notion."""
 
-    heading_2: HeadingTypeData = HeadingTypeData()
+    heading_2: HeadingTypeData = Field(default_factory=HeadingTypeData)
 
 
 class Heading3(Heading, type='heading_3'):
     """A heading_3 block in Notion."""
 
-    heading_3: HeadingTypeData = HeadingTypeData()
+    heading_3: HeadingTypeData = Field(default_factory=HeadingTypeData)
 
 
 class QuoteTypeData(ColoredTextBlockTypeData):
@@ -198,7 +198,7 @@ class QuoteTypeData(ColoredTextBlockTypeData):
 class Quote(ColoredTextBlock[QuoteTypeData], type='quote'):
     """A quote block in Notion."""
 
-    quote: QuoteTypeData = QuoteTypeData()
+    quote: QuoteTypeData = Field(default_factory=QuoteTypeData)
 
 
 class CodeTypeData(TextBlockTypeData, CaptionMixin):
@@ -210,7 +210,7 @@ class CodeTypeData(TextBlockTypeData, CaptionMixin):
 class Code(TextBlock[CodeTypeData], type='code'):
     """A code block in Notion."""
 
-    code: CodeTypeData = CodeTypeData()
+    code: CodeTypeData = Field(default_factory=CodeTypeData)
 
 
 class CalloutTypeData(ColoredTextBlockTypeData):
@@ -224,7 +224,7 @@ class CalloutTypeData(ColoredTextBlockTypeData):
 class Callout(ColoredTextBlock[CalloutTypeData], type='callout'):
     """A callout block in Notion."""
 
-    callout: CalloutTypeData = CalloutTypeData()
+    callout: CalloutTypeData = Field(default_factory=CalloutTypeData)
 
 
 class BulletedListItemTypeData(ColoredTextBlockTypeData):
@@ -236,7 +236,7 @@ class BulletedListItemTypeData(ColoredTextBlockTypeData):
 class BulletedListItem(ColoredTextBlock[BulletedListItemTypeData], type='bulleted_list_item'):
     """A bulleted list item in Notion."""
 
-    bulleted_list_item: BulletedListItemTypeData = BulletedListItemTypeData()
+    bulleted_list_item: BulletedListItemTypeData = Field(default_factory=BulletedListItemTypeData)
 
 
 class NumberedListItemTypeData(ColoredTextBlockTypeData):
@@ -248,7 +248,7 @@ class NumberedListItemTypeData(ColoredTextBlockTypeData):
 class NumberedListItem(ColoredTextBlock[NumberedListItemTypeData], type='numbered_list_item'):
     """A numbered list item in Notion."""
 
-    numbered_list_item: NumberedListItemTypeData = NumberedListItemTypeData()
+    numbered_list_item: NumberedListItemTypeData = Field(default_factory=NumberedListItemTypeData)
 
 
 class ToDoTypeData(ColoredTextBlockTypeData):
@@ -261,7 +261,7 @@ class ToDoTypeData(ColoredTextBlockTypeData):
 class ToDo(ColoredTextBlock[ToDoTypeData], type='to_do'):
     """A todo list item in Notion."""
 
-    to_do: ToDoTypeData = ToDoTypeData()
+    to_do: ToDoTypeData = Field(default_factory=ToDoTypeData)
 
 
 class ToggleTypeData(ColoredTextBlockTypeData):
@@ -273,7 +273,7 @@ class ToggleTypeData(ColoredTextBlockTypeData):
 class Toggle(ColoredTextBlock[ToggleTypeData], type='toggle'):
     """A toggle list item in Notion."""
 
-    toggle: ToggleTypeData = ToggleTypeData()
+    toggle: ToggleTypeData = Field(default_factory=ToggleTypeData)
 
 
 class DividerTypeData(GenericObject):
@@ -283,7 +283,7 @@ class DividerTypeData(GenericObject):
 class Divider(Block[DividerTypeData], type='divider'):
     """A divider block in Notion."""
 
-    divider: DividerTypeData = DividerTypeData()
+    divider: DividerTypeData = Field(default_factory=DividerTypeData)
 
 
 class TableOfContentsTypeData(GenericObject):
@@ -295,7 +295,7 @@ class TableOfContentsTypeData(GenericObject):
 class TableOfContents(Block[TableOfContentsTypeData], type='table_of_contents'):
     """A table_of_contents block in Notion."""
 
-    table_of_contents: TableOfContentsTypeData = TableOfContentsTypeData()
+    table_of_contents: TableOfContentsTypeData = Field(default_factory=TableOfContentsTypeData)
 
 
 class BreadcrumbTypeData(GenericObject):
@@ -305,7 +305,7 @@ class BreadcrumbTypeData(GenericObject):
 class Breadcrumb(Block[BreadcrumbTypeData], type='breadcrumb'):
     """A breadcrumb block in Notion."""
 
-    breadcrumb: BreadcrumbTypeData = BreadcrumbTypeData()
+    breadcrumb: BreadcrumbTypeData = Field(default_factory=BreadcrumbTypeData)
 
 
 class EmbedTypeData(CaptionMixin):
@@ -361,7 +361,7 @@ class EquationTypeData(GenericObject):
 class Equation(Block[EquationTypeData], type='equation'):
     """An equation block in Notion."""
 
-    equation: EquationTypeData = EquationTypeData()
+    equation: EquationTypeData = Field(default_factory=EquationTypeData)
 
 
 class FileBase(Block[FileObject], ABC):
@@ -428,7 +428,7 @@ class ColumnTypeData(GenericObject):
 class Column(Block[ColumnTypeData], type='column'):
     """A column block in Notion."""
 
-    column: ColumnTypeData = ColumnTypeData()
+    column: ColumnTypeData = Field(default_factory=ColumnTypeData)
 
     @classmethod
     def build(cls, width_ratio: float | None = None) -> Column:
@@ -446,7 +446,7 @@ class ColumnListTypeData(GenericObject):
 class ColumnList(Block[ColumnListTypeData], type='column_list'):
     """A column list block in Notion."""
 
-    column_list: ColumnListTypeData = ColumnListTypeData()
+    column_list: ColumnListTypeData = Field(default_factory=ColumnListTypeData)
 
 
 class TableRowTypeData(GenericObject):
@@ -458,7 +458,7 @@ class TableRowTypeData(GenericObject):
 class TableRow(Block[TableRowTypeData], type='table_row'):
     """A table_row block in Notion."""
 
-    table_row: TableRowTypeData = TableRowTypeData()
+    table_row: TableRowTypeData = Field(default_factory=TableRowTypeData)
 
     @classmethod
     def build(cls, n_cells: int) -> TableRow:
@@ -479,7 +479,7 @@ class TableTypeData(GenericObject):
 class Table(Block[TableTypeData], type='table'):
     """A table block in Notion."""
 
-    table: TableTypeData = TableTypeData()
+    table: TableTypeData = Field(default_factory=TableTypeData)
 
 
 class LinkToPage(Block[ParentRef], type='link_to_page'):
@@ -498,7 +498,7 @@ class SyncedBlockTypeData(GenericObject):
 class SyncedBlock(Block[SyncedBlockTypeData], type='synced_block'):
     """A synced_block block in Notion - either original or synced."""
 
-    synced_block: SyncedBlockTypeData = SyncedBlockTypeData()
+    synced_block: SyncedBlockTypeData = Field(default_factory=SyncedBlockTypeData)
 
     def serialize_for_api(self) -> dict[str, Any]:
         """Serialize the object for sending it to the Notion API."""
@@ -518,4 +518,4 @@ class TemplateTypeData(TextBlockTypeData):
 class Template(TextBlock[TemplateTypeData], type='template'):
     """A template block in Notion."""
 
-    template: TemplateTypeData = TemplateTypeData()
+    template: TemplateTypeData = Field(default_factory=TemplateTypeData)

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -317,7 +317,7 @@ class PersonTypeData(GenericObject):
 class Person(User[PersonTypeData], type='person'):
     """Represents a Person in Notion."""
 
-    person: PersonTypeData = PersonTypeData()
+    person: PersonTypeData = Field(default_factory=PersonTypeData)
 
 
 class WorkSpaceLimits(GenericObject):
@@ -331,7 +331,7 @@ class BotTypeData(GenericObject):
 
     owner: WorkspaceRef | None = None
     workspace_name: str | None = None
-    workspace_limits: WorkSpaceLimits = WorkSpaceLimits()
+    workspace_limits: WorkSpaceLimits = Field(default_factory=WorkSpaceLimits)
 
 
 class Bot(User[BotTypeData], type='bot'):
@@ -340,7 +340,7 @@ class Bot(User[BotTypeData], type='bot'):
     # Even if stated otherwise in the docs, `bot` type data is optional and for instance
     # not present when a new page is created by a bot within a database with a `CreatedBy` Property.
     # For ease of use, we include a default instance of the bot type data.
-    bot: BotTypeData = BotTypeData()
+    bot: BotTypeData = Field(default_factory=BotTypeData)
 
 
 class UnknownUserTypeData(GenericObject):
@@ -354,7 +354,7 @@ class UnknownUser(User[UnknownUserTypeData], type='unknown'):
     """
 
     name: Literal['Unknown User'] = 'Unknown User'
-    unknown: UnknownUserTypeData = UnknownUserTypeData()
+    unknown: UnknownUserTypeData = Field(default_factory=UnknownUserTypeData)
 
 
 class Annotations(GenericObject):

--- a/src/ultimate_notion/obj_api/props.py
+++ b/src/ultimate_notion/obj_api/props.py
@@ -17,7 +17,7 @@ from abc import ABC
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, cast
 
-from pydantic import SerializeAsAny, field_validator, model_serializer
+from pydantic import Field, SerializeAsAny, field_validator, model_serializer
 from typing_extensions import Self
 
 from ultimate_notion.obj_api.core import GenericObject, NotionObject, Unset, UnsetType
@@ -74,13 +74,13 @@ class PropertyValue(TypedObject[Any], polymorphic_base=True):
 class Title(PropertyValue, type='title'):
     """Notion title type."""
 
-    title: list[SerializeAsAny[RichTextBaseObject]] = None  # type: ignore
+    title: list[SerializeAsAny[RichTextBaseObject]] = Field(default_factory=list)
 
 
 class RichText(PropertyValue, type='rich_text'):
     """Notion rich text type."""
 
-    rich_text: list[SerializeAsAny[RichTextBaseObject]] = None  # type: ignore
+    rich_text: list[SerializeAsAny[RichTextBaseObject]] = Field(default_factory=list)
 
 
 class Number(PropertyValue, type='number'):
@@ -286,7 +286,7 @@ class UniqueID(PropertyValue, type='unique_id'):
         number: int = 0
         prefix: str | None = None
 
-    unique_id: TypeData = TypeData()
+    unique_id: TypeData = Field(default_factory=TypeData)
 
 
 class Verification(PropertyValue, type='verification'):
@@ -304,7 +304,7 @@ class Verification(PropertyValue, type='verification'):
         def validate_enum_field(cls, field: str) -> VState:
             return VState(field)
 
-    verification: TypeData = TypeData()
+    verification: TypeData = Field(default_factory=TypeData)
 
 
 class Button(PropertyValue, type='button'):
@@ -312,7 +312,7 @@ class Button(PropertyValue, type='button'):
 
     class TypeData(GenericObject): ...
 
-    button: TypeData = TypeData()
+    button: TypeData = Field(default_factory=TypeData)
 
 
 ##################

--- a/src/ultimate_notion/obj_api/schema.py
+++ b/src/ultimate_notion/obj_api/schema.py
@@ -29,7 +29,7 @@ class TitleTypeData(GenericObject):
 class Title(Property[TitleTypeData], type='title'):
     """Defines the title configuration for a database property."""
 
-    title: TitleTypeData = TitleTypeData()
+    title: TitleTypeData = Field(default_factory=TitleTypeData)
 
 
 class RichTextTypeData(GenericObject):
@@ -39,7 +39,7 @@ class RichTextTypeData(GenericObject):
 class RichText(Property[RichTextTypeData], type='rich_text'):
     """Defines the rich text configuration for a database property."""
 
-    rich_text: RichTextTypeData = RichTextTypeData()
+    rich_text: RichTextTypeData = Field(default_factory=RichTextTypeData)
 
 
 class NumberTypeData(GenericObject):
@@ -58,7 +58,7 @@ class NumberTypeData(GenericObject):
 class Number(Property[NumberTypeData], type='number'):
     """Defines the number configuration for a database property."""
 
-    number: NumberTypeData = NumberTypeData()
+    number: NumberTypeData = Field(default_factory=NumberTypeData)
 
     @classmethod
     def build(cls, format: NumberFormat) -> Number:  # noqa: A002
@@ -75,7 +75,7 @@ class SelectTypeData(GenericObject):
 class Select(Property[SelectTypeData], type='select'):
     """Defines the select configuration for a database property."""
 
-    select: SelectTypeData = SelectTypeData()
+    select: SelectTypeData = Field(default_factory=SelectTypeData)
 
     @classmethod
     def build(cls, options: list[SelectOption]) -> Select:
@@ -92,7 +92,7 @@ class MultiSelectTypeData(GenericObject):
 class MultiSelect(Property[MultiSelectTypeData], type='multi_select'):
     """Defines the multi-select configuration for a database property."""
 
-    multi_select: MultiSelectTypeData = MultiSelectTypeData()
+    multi_select: MultiSelectTypeData = Field(default_factory=MultiSelectTypeData)
 
     @classmethod
     def build(cls, options: list[SelectOption]) -> MultiSelect:
@@ -110,7 +110,7 @@ class StatusTypeData(GenericObject):
 class Status(Property[StatusTypeData], type='status'):
     """Defines the status configuration for a database property."""
 
-    status: StatusTypeData = StatusTypeData()
+    status: StatusTypeData = Field(default_factory=StatusTypeData)
 
     @classmethod
     def build(cls, options: list[SelectOption], groups: list[SelectGroup]) -> Status:
@@ -131,7 +131,7 @@ class DateTypeData(GenericObject):
 class Date(Property[DateTypeData], type='date'):
     """Defines the date configuration for a database property."""
 
-    date: DateTypeData = DateTypeData()
+    date: DateTypeData = Field(default_factory=DateTypeData)
 
 
 class PeopleTypeData(GenericObject):
@@ -141,7 +141,7 @@ class PeopleTypeData(GenericObject):
 class People(Property[PeopleTypeData], type='people'):
     """Defines the people configuration for a database property."""
 
-    people: PeopleTypeData = PeopleTypeData()
+    people: PeopleTypeData = Field(default_factory=PeopleTypeData)
 
 
 class FilesTypeData(GenericObject):
@@ -151,7 +151,7 @@ class FilesTypeData(GenericObject):
 class Files(Property[FilesTypeData], type='files'):
     """Defines the files configuration for a database property."""
 
-    files: FilesTypeData = FilesTypeData()
+    files: FilesTypeData = Field(default_factory=FilesTypeData)
 
 
 class CheckboxTypeData(GenericObject):
@@ -161,7 +161,7 @@ class CheckboxTypeData(GenericObject):
 class Checkbox(Property[CheckboxTypeData], type='checkbox'):
     """Defines the checkbox configuration for a database property."""
 
-    checkbox: CheckboxTypeData = CheckboxTypeData()
+    checkbox: CheckboxTypeData = Field(default_factory=CheckboxTypeData)
 
 
 class EmailTypeData(GenericObject):
@@ -171,7 +171,7 @@ class EmailTypeData(GenericObject):
 class Email(Property[EmailTypeData], type='email'):
     """Defines the email configuration for a database property."""
 
-    email: EmailTypeData = EmailTypeData()
+    email: EmailTypeData = Field(default_factory=EmailTypeData)
 
 
 class URLTypeData(GenericObject):
@@ -181,7 +181,7 @@ class URLTypeData(GenericObject):
 class URL(Property[URLTypeData], type='url'):
     """Defines the URL configuration for a database property."""
 
-    url: URLTypeData = URLTypeData()
+    url: URLTypeData = Field(default_factory=URLTypeData)
 
 
 class PhoneNumberTypeData(GenericObject):
@@ -191,7 +191,7 @@ class PhoneNumberTypeData(GenericObject):
 class PhoneNumber(Property[PhoneNumberTypeData], type='phone_number'):
     """Defines the phone number configuration for a database property."""
 
-    phone_number: PhoneNumberTypeData = PhoneNumberTypeData()
+    phone_number: PhoneNumberTypeData = Field(default_factory=PhoneNumberTypeData)
 
 
 class FormulaTypeData(GenericObject):
@@ -218,7 +218,7 @@ class FormulaTypeData(GenericObject):
 class Formula(Property[FormulaTypeData], type='formula'):
     """Defines the formula configuration for a database property."""
 
-    formula: FormulaTypeData = FormulaTypeData()
+    formula: FormulaTypeData = Field(default_factory=FormulaTypeData)
 
     @classmethod
     def build(cls, formula: str) -> Formula:
@@ -238,7 +238,7 @@ class SinglePropertyRelationTypeData(GenericObject):
 class SinglePropertyRelation(PropertyRelation[SinglePropertyRelationTypeData], type='single_property'):
     """Defines a one-way relation configuration for a database property."""
 
-    single_property: SinglePropertyRelationTypeData = SinglePropertyRelationTypeData()
+    single_property: SinglePropertyRelationTypeData = Field(default_factory=SinglePropertyRelationTypeData)
 
     @classmethod
     def build_relation(cls, dbref: UUID) -> Relation:
@@ -274,7 +274,7 @@ class DualPropertyRelation(PropertyRelation[DualPropertyRelationTypeData], type=
     If a two-way relation property X relates to Y then the two-way relation property Y relates to X.
     """
 
-    dual_property: DualPropertyRelationTypeData = DualPropertyRelationTypeData()
+    dual_property: DualPropertyRelationTypeData = Field(default_factory=DualPropertyRelationTypeData)
 
     @classmethod
     def build_relation(cls, dbref: UUID) -> Relation:
@@ -331,7 +331,7 @@ class RollupTypeData(GenericObject):
 class Rollup(Property[RollupTypeData], type='rollup'):
     """Defines the rollup configuration for a database property."""
 
-    rollup: RollupTypeData = RollupTypeData()
+    rollup: RollupTypeData = Field(default_factory=RollupTypeData)
 
     @classmethod
     def build(cls, relation: str, property: str, function: AggFunc) -> Rollup:  # noqa: A002
@@ -347,7 +347,7 @@ class CreatedTimeTypeData(GenericObject):
 class CreatedTime(Property[CreatedTimeTypeData], type='created_time'):
     """Defines the created-time configuration for a database property."""
 
-    created_time: CreatedTimeTypeData = CreatedTimeTypeData()
+    created_time: CreatedTimeTypeData = Field(default_factory=CreatedTimeTypeData)
 
 
 class CreatedByTypeData(GenericObject):
@@ -357,7 +357,7 @@ class CreatedByTypeData(GenericObject):
 class CreatedBy(Property[CreatedByTypeData], type='created_by'):
     """Defines the created-by configuration for a database property."""
 
-    created_by: CreatedByTypeData = CreatedByTypeData()
+    created_by: CreatedByTypeData = Field(default_factory=CreatedByTypeData)
 
 
 class LastEditedByTypeData(GenericObject):
@@ -367,7 +367,7 @@ class LastEditedByTypeData(GenericObject):
 class LastEditedBy(Property[LastEditedByTypeData], type='last_edited_by'):
     """Defines the last-edited-by configuration for a database property."""
 
-    last_edited_by: LastEditedByTypeData = LastEditedByTypeData()
+    last_edited_by: LastEditedByTypeData = Field(default_factory=LastEditedByTypeData)
 
 
 class LastEditedTimeTypeData(GenericObject):
@@ -377,7 +377,7 @@ class LastEditedTimeTypeData(GenericObject):
 class LastEditedTime(Property[LastEditedTimeTypeData], type='last_edited_time'):
     """Defines the last-edited-time configuration for a database property."""
 
-    last_edited_time: LastEditedTimeTypeData = LastEditedTimeTypeData()
+    last_edited_time: LastEditedTimeTypeData = Field(default_factory=LastEditedTimeTypeData)
 
 
 class UniqueIDTypeData(GenericObject):
@@ -389,7 +389,7 @@ class UniqueIDTypeData(GenericObject):
 class UniqueID(Property[UniqueIDTypeData], type='unique_id'):
     """Unique ID database property."""
 
-    unique_id: UniqueIDTypeData = UniqueIDTypeData()
+    unique_id: UniqueIDTypeData = Field(default_factory=UniqueIDTypeData)
 
 
 class VerificationTypeData(GenericObject):
@@ -399,7 +399,7 @@ class VerificationTypeData(GenericObject):
 class Verification(Property[VerificationTypeData], type='verification'):
     """Verfication database property of Wiki databases."""
 
-    verification: VerificationTypeData = VerificationTypeData()
+    verification: VerificationTypeData = Field(default_factory=VerificationTypeData)
 
 
 class ButtonTypeData(GenericObject):
@@ -409,7 +409,7 @@ class ButtonTypeData(GenericObject):
 class Button(Property[ButtonTypeData], type='button'):
     """Button database property."""
 
-    button: ButtonTypeData = ButtonTypeData()
+    button: ButtonTypeData = Field(default_factory=ButtonTypeData)
 
 
 class RenameProp(GenericObject):

--- a/tests/cassettes/test_blocks/test_block_equality_and_hash.yaml
+++ b/tests/cassettes/test_blocks/test_block_equality_and_hash.yaml
@@ -1,0 +1,290 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "5f505199-b292-4713-920b-61d813bf72a3"},
+      "properties": {"title": {"type": "title", "title": [{"type": "text", "plain_text":
+      "Page for testing block equality and hash", "annotations": {"bold": false, "italic":
+      false, "strikethrough": false, "underline": false, "code": false}, "text": {"content":
+      "Page for testing block equality and hash"}}]}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '359'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    content: '{"object":"page","id":"25c974f3-b388-814a-8a94-dbf9dfea61fe","created_time":"2025-08-27T19:04:00.000Z","last_edited_time":"2025-08-27T19:04:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Page
+      for testing block equality and hash","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Page
+      for testing block equality and hash","href":null}]}},"url":"https://www.notion.so/Page-for-testing-block-equality-and-hash-25c974f3b388814a8a94dbf9dfea61fe","public_url":null,"request_id":"f6651bcb-6ae2-46d7-b49b-3c3d82f5fbb9"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 975dd55f9e999738-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=oC6Dgeob0WcUErf9SJYSquNmBmNL5GlJysH8qpG32l0-1756321454-1.0.1.1-G09MiyhWHJRtOcJlW91yzc_rC1k0lRU8vxHfHJFSLSi7pdnmNKleVZ36veIRpBuXtQRTbqJQt87doba0GNHudW_gh9pSmdP5UQ15VGANX1w;
+        path=/; expires=Wed, 27-Aug-25 19:34:14 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=3Uxlzu43F0MGRhVjZKZIOTQ5V3j7LyvTwmNizhZXdW4-1756321454618-0.0.1.1-604800000;
+        path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f6651bcb-6ae2-46d7-b49b-3c3d82f5fbb9
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/5f505199-b292-4713-920b-61d813bf72a3
+  response:
+    content: '{"object":"page","id":"5f505199-b292-4713-920b-61d813bf72a3","created_time":"2022-08-22T15:47:00.000Z","last_edited_time":"2025-08-27T19:04:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-5f505199b2924713920b61d813bf72a3","public_url":null,"request_id":"7736a883-4d9e-4138-806b-65c1ac888106"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 975dd5638abe9738-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 7736a883-4d9e-4138-806b-65c1ac888106
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/blocks/25c974f3-b388-814a-8a94-dbf9dfea61fe/children?page_size=100
+  response:
+    content: '{"object":"list","results":[],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"8de3db09-27a6-45dc-a48e-f528a88077ee"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 975dd5653c739738-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 8de3db09-27a6-45dc-a48e-f528a88077ee
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"children":[{"object":"block","has_children":false,"in_trash":false,"archived":false,"type":"paragraph","paragraph":{"rich_text":[{"type":"text","plain_text":"Some
+      text","annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false},"text":{"content":"Some
+      text"}}],"color":"default","children":[]}},{"object":"block","has_children":false,"in_trash":false,"archived":false,"type":"paragraph","paragraph":{"rich_text":[{"type":"text","plain_text":"Different
+      text","annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false},"text":{"content":"Different
+      text"}}],"color":"default","children":[]}},{"object":"block","has_children":false,"in_trash":false,"archived":false,"type":"paragraph","paragraph":{"rich_text":[{"type":"text","plain_text":"Some
+      text","annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false},"text":{"content":"Some
+      text"}}],"color":"default","children":[]}}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '990'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/25c974f3-b388-814a-8a94-dbf9dfea61fe/children
+  response:
+    content: '{"object":"list","results":[{"object":"block","id":"25c974f3-b388-8124-945f-f96c398154cb","parent":{"type":"page_id","page_id":"25c974f3-b388-814a-8a94-dbf9dfea61fe"},"created_time":"2025-08-27T19:04:00.000Z","last_edited_time":"2025-08-27T19:04:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":false,"in_trash":false,"type":"paragraph","paragraph":{"rich_text":[{"type":"text","text":{"content":"Some
+      text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Some
+      text","href":null}],"color":"default"}},{"object":"block","id":"25c974f3-b388-8107-bbd4-d1df4957bcc5","parent":{"type":"page_id","page_id":"25c974f3-b388-814a-8a94-dbf9dfea61fe"},"created_time":"2025-08-27T19:04:00.000Z","last_edited_time":"2025-08-27T19:04:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":false,"in_trash":false,"type":"paragraph","paragraph":{"rich_text":[{"type":"text","text":{"content":"Different
+      text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Different
+      text","href":null}],"color":"default"}},{"object":"block","id":"25c974f3-b388-8198-a626-d5554d99bfd9","parent":{"type":"page_id","page_id":"25c974f3-b388-814a-8a94-dbf9dfea61fe"},"created_time":"2025-08-27T19:04:00.000Z","last_edited_time":"2025-08-27T19:04:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"has_children":false,"archived":false,"in_trash":false,"type":"paragraph","paragraph":{"rich_text":[{"type":"text","text":{"content":"Some
+      text","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Some
+      text","href":null}],"color":"default"}}],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"47c17ca6-1243-4628-af91-5525b5c71f52"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 975dd566ee519738-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 47c17ca6-1243-4628-af91-5525b5c71f52
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -664,3 +664,29 @@ def test_offline_block_assembly(root_page: uno.Page, notion: uno.Session) -> Non
     callout = uno.Heading1('This is a Heading.', toggleable=True)
     with pytest.raises(InvalidAPIUsageError):
         callout.append(uno.Paragraph('This is a child paragraph.'))
+
+
+@pytest.mark.vcr()
+def test_block_equality_and_hash(root_page: uno.Page, notion: uno.Session) -> None:
+    para1 = uno.Paragraph(text='Some text')
+    para2 = uno.Paragraph(text='Different text')
+    para1a = uno.Paragraph(text='Some text')
+
+    assert para1 != para2
+    assert hash(para1) != hash(para2)
+    assert para1 == para1a
+    assert hash(para1) == hash(para1a)
+
+    with pytest.raises(ValueError):
+        assert para1.id != para2.id
+
+    page = notion.create_page(parent=root_page, title='Page for testing block equality and hash')
+    page.append([para1, para2, para1a])
+
+    assert para1.id != para2.id
+    assert para1.id != para1a.id
+
+    assert para1 != para2
+    assert para1 != para1a  # same content but now different id!
+    assert hash(para1) != hash(para2)
+    assert hash(para1) != hash(para1a)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes bug #100. 

### Types of change

* Pydantic initializes nested Basemodel only once, this is fixed with `Field(default_factory=...)`
* Proper hashing implemented for the `GenericObject`

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
