### PR TITLE
Fix failing retrieval of page if parent is not accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ First Beta release:
 - Fix: Wrong equality check between properties as well as property values.
 - New: Bind a schema automatically with `bind_schema()` if `db_id` or `db_title` is set in the `Schema`.
 - Chg: Consistently return `None` for title, description, caption if these are not set instead of an empty string.
-- Fix: More strict typing and checks which led to many small bug fixes in edge cases.
+- Fix: More strict typing and checks which led to many small bug fixes in edge cases, e.g. issue #96.
 - Fix: Too strict dependencies that too often lead to conflicts with other packages, e.g. issue #90.
 - New: `uno` command line interface to show the current resolved config and integration info.
 - New: Allow offline assembly of blocks to create a page with content in one call, issue #94.
+- Fix: Different blocks now have a different hash, equality works as expected, issue #100.
+- Fix: Retrieve a page object even without access access to the parent database, issue #103.
 
 ## Version 0.8, 2025-06-23
 

--- a/src/ultimate_notion/__init__.py
+++ b/src/ultimate_notion/__init__.py
@@ -45,7 +45,7 @@ from ultimate_notion.blocks import (
     ToggleItem,
     Video,
 )
-from ultimate_notion.core import get_active_session
+from ultimate_notion.core import Workspace, WorkspaceType, get_active_session
 from ultimate_notion.database import Database
 from ultimate_notion.emoji import Emoji
 from ultimate_notion.file import FileInfo
@@ -112,6 +112,8 @@ __all__ = [
     'User',
     'VState',
     'Video',
+    'Workspace',
+    'WorkspaceType',  # for type hinting only
     '__version__',
     'get_active_session',
     'join',

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, Any, TypeGuard, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from emoji import is_emoji
-from typing_extensions import Self
+from typing_extensions import Self, TypeIs
 
 from ultimate_notion.blocks import ChildrenMixin, CommentMixin, DataObject, wrap_icon
 from ultimate_notion.comment import Discussion
-from ultimate_notion.core import NotionEntity, get_active_session, get_repr
+from ultimate_notion.core import NotionEntity, WorkspaceType, get_active_session, get_repr
 from ultimate_notion.emoji import CustomEmoji, Emoji
 from ultimate_notion.file import FileInfo
 from ultimate_notion.obj_api import blocks as obj_blocks
@@ -353,11 +353,11 @@ class Page(
         return self
 
 
-def is_db_guard(obj: NotionEntity | None) -> TypeGuard[Database]:
+def is_db_guard(obj: NotionEntity | WorkspaceType | None) -> TypeIs[Database]:
     """Return whether the object is a database as type guard."""
-    return obj is not None and obj.is_db
+    return isinstance(obj, NotionEntity) and obj.is_db
 
 
-def is_page_guard(obj: NotionEntity | None) -> TypeGuard[Page]:
+def is_page_guard(obj: NotionEntity | WorkspaceType | None) -> TypeIs[Page]:
     """Return whether the object is a page as type guard."""
-    return obj is not None and obj.is_page
+    return isinstance(obj, NotionEntity) and obj.is_page

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing_extensions import assert_type
+
+import ultimate_notion as uno
+
+
+def test_workspace_sentinel() -> None:
+    assert uno.Workspace != 'workspace_root'
+    assert_type(uno.Workspace, uno.WorkspaceType)
+
+    def func() -> str | uno.WorkspaceType:
+        return 'dummy'
+
+    my_var = func()
+    if my_var is uno.Workspace:
+        assert_type(my_var, uno.WorkspaceType)  # type narrowing check

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -21,9 +21,10 @@ def test_parent(page_hierarchy: tuple[Page, Page, Page]) -> None:
     assert isinstance(l1_page, uno.Page)
     assert isinstance(l2_page, uno.Page)
 
-    assert root_page.parent is None
+    assert root_page.parent is uno.Workspace
     assert l2_page.parent == l1_page
     assert l1_page.parent == root_page
+    assert isinstance(l2_page.parent, uno.Page)
     assert l2_page.parent.parent == root_page
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes issue #103 by gracefully accepting if the `parent` of a page is not accessible.

### Types of change

* A new sentinel value `Workspace` is returned if root is a workspace. If the parent cannot be retrieved, we just return `None`. 

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
