### PR TITLE
Add the 'description' field to a property

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -97,6 +97,7 @@ These limitations include:
 - locking or unlocking a page or database.
 - working with database button properties.
 - retrieving a list of all custom emojis defined in the workspace.
+- changing the description of a database property.
 
 If you think those limitations should be fixed, [let the developers of Notion know](mailto:developers@makenotion.com) 😆
 

--- a/src/ultimate_notion/obj_api/schema.py
+++ b/src/ultimate_notion/obj_api/schema.py
@@ -1,4 +1,18 @@
-"""Objects representing a database schema."""
+"""Objects representing a database schema.
+
+Properties are used when
+
+1. a database with a specific schema is [created],
+2. a database with a schema is [retrieved].
+
+Unfortunately, the way a schema is defined in case of 1. and 2. is not consistent.
+In case 1., the property name is only defined as a key while in case 2. it is additionally
+defined as `name` attribute of the property object. We treat these two cases the same way
+when constructing the property objects. For this reason `name` is `Unset` by default.
+
+[created]: https://developers.notion.com/reference/property-schema-object
+[retrieved]: https://developers.notion.com/reference/property-object
+"""
 
 from __future__ import annotations
 
@@ -19,7 +33,8 @@ class Property(TypedObject[GO_co], polymorphic_base=True):
     """Base class for Notion property objects."""
 
     id: str | UnsetType = Unset
-    name: str | UnsetType = Unset
+    name: str | UnsetType = Unset  # Unset when creating a database property schema
+    description: str | None = None
 
 
 class TitleTypeData(GenericObject):

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -185,6 +185,11 @@ class Property(Wrapper[GO_co], ABC, wraps=PropertyGO):
         self._rename_prop(new_name)
 
     @property
+    def description(self) -> str | None:
+        """Return the description of this property."""
+        return self.obj_ref.description
+
+    @property
     def attr_name(self) -> str:
         """Return the Python attribute name of the property in the schema."""
         if self._attr_name is None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -205,6 +205,11 @@ def test_more_than_max_page_size_pages(notion: uno.Session, root_page: uno.Page)
 
 
 @pytest.mark.vcr()
+def test_property_description(contacts_db: uno.Database) -> None:
+    assert contacts_db.schema['Title'].description == 'Title within the company'
+
+
+@pytest.mark.vcr()
 def test_new_task_db(new_task_db: uno.Database) -> None:
     # ToDo: Implement a proper test
     pass


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

A database property now has an additional `description`  field, which was added. Unfortunately this seems to be read only and can only be set via the Notion UI.

### Types of change
<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
