### PR TITLE
Add a CLI option to upload files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix: Linked databases are handled as `ChildDatabase` objects and no longer resolved, issue #110.
 - Chg: Have a `User` hierarchy with `Bot`, `Person`, etc. to reflect the actual Notion API.
 - Doc: Completed missing parts in the documentation and example for file uploads.
-- New: Allow uploading and appending a file as block to a page.
+- New: Allow uploading and appending a file as block to a page via the CLI.
 
 ## Version 0.9, 2025-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Linked databases are handled as `ChildDatabase` objects and no longer resolved, issue #110.
 - Chg: Have a `User` hierarchy with `Bot`, `Person`, etc. to reflect the actual Notion API.
 - Doc: Completed missing parts in the documentation and example for file uploads.
+- New: Allow uploading and appending a file as block to a page.
 
 ## Version 0.9, 2025-09-01
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -9,6 +9,7 @@ The CLI currently supports the following operations:
 
 - **Configuration management** - View your current configuration file location and contents
 - **Integration information** - Display details about your Notion integration and environment
+- **File uploads** - Upload files to Notion pages with automatic block type detection
 - **System diagnostics** - Check version information and workspace details
 
 To see all available commands and options:
@@ -41,6 +42,41 @@ Display information about your Notion integration, including version details and
 uno info
 ```
 
+### `upload`
+
+Upload a file to a Notion page and automatically append it as the appropriate block type:
+
+```console
+uno upload <file_path> <page_name_or_uuid>
+```
+
+The command automatically detects the file type and creates the appropriate block:
+
+- **Images** (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, etc.) → Image block
+- **Videos** (`.mp4`, `.avi`, `.mov`, `.wmv`, etc.) → Video block
+- **PDFs** (`.pdf`) → PDF block
+- **All other files** → File block
+
+#### Examples
+
+Upload an image to a page by name:
+
+```console
+uno upload screenshot.png "My Project Notes"
+```
+
+Upload a PDF to a page by UUID:
+
+```console
+uno upload document.pdf 12345678-1234-1234-1234-123456789abc
+```
+
+Upload a video file:
+
+```console
+uno upload demo.mp4 "Product Demo Page"
+```
+
 ## Options
 
 The CLI supports a `--log-level` option to control output verbosity. Available levels are `critical`, `error`,
@@ -49,6 +85,15 @@ The CLI supports a `--log-level` option to control output verbosity. Available l
 ```console
 uno --log-level debug info
 ```
+
+!!! tip "Upload Command Logging"
+    The `upload` command shows detailed progress information when using `--log-level info` or `--log-level debug`.
+    This includes file upload progress, page lookup details, and file URLs. By default, only success messages
+    and errors are shown.
+
+    ```console
+    uno --log-level info upload document.pdf "My Page"
+    ```
 
 For detailed help on any command, use:
 

--- a/src/ultimate_notion/__init__.py
+++ b/src/ultimate_notion/__init__.py
@@ -106,7 +106,7 @@ __all__ = [
     'OptionGroup',
     'OptionGroupType',
     'OptionNS',
-    'Page',
+    'Page',  # for type hinting only
     'Paragraph',
     'PropType',
     'Property',  # for type hinting only

--- a/src/ultimate_notion/cli.py
+++ b/src/ultimate_notion/cli.py
@@ -12,6 +12,7 @@ from ultimate_notion import Session, __version__
 from ultimate_notion.blocks import PDF, File, Image, Video
 from ultimate_notion.config import get_cfg, get_cfg_file
 from ultimate_notion.errors import UnknownPageError
+from ultimate_notion.page import Page
 from ultimate_notion.utils import pydantic_to_toml
 
 _logger = logging.getLogger(__name__)
@@ -84,7 +85,7 @@ def _is_uuid(value: str) -> bool:
         return False
 
 
-def _get_block_class_for_file(file_path: Path):
+def _get_block_class_for_file(file_path: Path) -> type[File | Image | Video | PDF]:
     """Determine the appropriate block class based on file content and extension.
 
     Uses the filetype library to detect file type by examining magic bytes,
@@ -104,7 +105,7 @@ def _get_block_class_for_file(file_path: Path):
     return File
 
 
-def _find_page_by_name(session: Session, page_name: str):
+def _find_page_by_name(session: Session, page_name: str) -> Page:
     """Find a page by name, ensuring it's unique."""
     pages = session.search_page(page_name, exact=True)
 

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -312,6 +312,18 @@ class Session:
 
         return page
 
+    def get_or_create_page(self, parent: Page | Database, title: str | None = None) -> Page:
+        """Get an existing page or create a new one if it doesn't exist."""
+        pages = SList(page for page in self.search_page(title) if page.parent == parent)
+        if len(pages) == 0:
+            page = self.create_page(parent, title=title)
+            while not [page for page in self.search_page(title) if page.parent == parent]:
+                _logger.info(f'Waiting for page `{page.title}` to be fully created.')
+                time.sleep(1)
+            return page
+        else:
+            return pages.item()
+
     def get_user(self, user_ref: UUID | str, *, use_cache: bool = True, raise_on_unknown: bool = True) -> User:
         """Get a user by uuid.
 

--- a/tests/cassettes/test_cli/test_info_command_displays_system_and_notion_info.yaml
+++ b/tests/cassettes/test_cli/test_info_command_displays_system_and_notion_info.yaml
@@ -23,12 +23,12 @@ interactions:
   response:
     content: '{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f","name":"Github
       Unittests","avatar_url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/975357ac-773b-4ccb-95f5-e3a2a6cef61f/GitHub-Mark-120px-plus.png","type":"bot","bot":{"owner":{"type":"workspace","workspace":true},"workspace_name":"GitHub
-      Unittests","workspace_limits":{"max_file_upload_size_in_bytes":5368709120}},"request_id":"fa40393a-6f2b-4e9b-aaf0-52000fd209a5"}'
+      Unittests","workspace_limits":{"max_file_upload_size_in_bytes":5368709120}},"request_id":"6e1c8bb8-7439-4ba4-9900-cde1de5275c8"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - 97943d4f5be2d2cf-FRA
+      - 9794ddd7de253638-FRA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -38,10 +38,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=QWhZyoEeg5NQPGmbw9ZfufrXowjCM8jzeD8gBCbIPAs-1756891942-1.0.1.1-WJFbcERmwwvzCJ3jroCGDq45sS5qY8k2wkclYdRGB88BrHqaIME54ZTPd2XhJYXu5Xz6D0ONICgbzdMpd28koYiVRWQs.J1Oq6VFIEZqaX8;
-        path=/; expires=Wed, 03-Sep-25 10:02:22 GMT; domain=.notion.com; HttpOnly;
+      - __cf_bm=SeadqCz6vveuBx8Z4B6odN5BGUnHotdGUnx25DEThtg-1756898518-1.0.1.1-2ksnUuc.PNz6ssXDhPRLqErBYzldSVXppXSBPV49okHHh3W1KE2ko8tRwRvdkHTP1j9WqtbiRrlMVnfQ8Gi0HASeMk6UPg.trvtf63hPS9E;
+        path=/; expires=Wed, 03-Sep-25 11:51:58 GMT; domain=.notion.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=elMzIfVzXgkSAehnXNob.oYjftZbju6g.kgG44DD.yk-1756891942523-0.0.1.1-604800000;
+      - _cfuvid=45EJ5VPQn3zcn425L_Sqg3jBohvyHYMAV29tRWafN5E-1756898518910-0.0.1.1-604800000;
         path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -64,7 +64,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - fa40393a-6f2b-4e9b-aaf0-52000fd209a5
+      - 6e1c8bb8-7439-4ba4-9900-cde1de5275c8
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:

--- a/tests/cassettes/test_cli/test_upload_invalid_page_uuid.yaml
+++ b/tests/cassettes/test_cli/test_upload_invalid_page_uuid.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/12345678-1234-1234-1234-123456789abc
+  response:
+    content: '{"object":"error","status":400,"code":"validation_error","message":"path
+      failed validation: path.page_id should be a valid uuid, instead was `\"12345678-1234-1234-1234-123456789abc\"`.","request_id":"6aa19615-d2bf-441a-b754-dbe360fdc9c2"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9795254bdd38efff-FRA
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '238'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=RwIPurL8zvB38KOU2ain6sqkzhwxtxjwyzTRsHNDRDw-1756901444-1.0.1.1-GPvQ7wWdDbw2_jAlw4El3fy5uyqqTASMY_2CPHI4UUx3VHJf_onT8PudIG6vYvoc7JIcbwO9lCHCv.H57I4AXbpyq7A6_qbCLYbrUhWWzes;
+        path=/; expires=Wed, 03-Sep-25 12:40:44 GMT; domain=.notion.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=b3jWjDQwpBYMYmA8k2NvSo7nN5q7VCepldY7crjcxWw-1756901444776-0.0.1.1-604800000;
+        path=/; domain=.notion.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 6aa19615-d2bf-441a-b754-dbe360fdc9c2
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 400
+version: 1

--- a/tests/cassettes/test_cli/test_upload_nonexistent_page_name.yaml
+++ b/tests/cassettes/test_cli/test_upload_nonexistent_page_name.yaml
@@ -1,0 +1,216 @@
+interactions:
+- request:
+    body: '{"query": "This Page Does Not Exist At All", "filter": {"property": "object",
+      "value": "page"}, "page_size": 100}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '105'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/search
+  response:
+    content: '{"object":"list","results":[{"object":"page","id":"263974f3-b388-81fb-bf8b-cd87bbcf83ec","created_time":"2025-09-03T11:18:00.000Z","last_edited_time":"2025-09-03T11:18:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"CLI
+      Upload Test Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"CLI
+      Upload Test Page","href":null}]}},"url":"https://www.notion.so/CLI-Upload-Test-Page-263974f3b38881fbbf8bcd87bbcf83ec","public_url":null},{"object":"page","id":"263974f3-b388-8197-bfc3-ec7f4a2b8a48","created_time":"2025-09-03T11:17:00.000Z","last_edited_time":"2025-09-03T11:17:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"CLI
+      Upload Test Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"CLI
+      Upload Test Page","href":null}]}},"url":"https://www.notion.so/CLI-Upload-Test-Page-263974f3b3888197bfc3ec7f4a2b8a48","public_url":null},{"object":"page","id":"263974f3-b388-81da-84b3-cdf3f34048b1","created_time":"2025-09-03T11:17:00.000Z","last_edited_time":"2025-09-03T11:17:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"CLI
+      Upload Test Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"CLI
+      Upload Test Page","href":null}]}},"url":"https://www.notion.so/CLI-Upload-Test-Page-263974f3b38881da84b3cdf3f34048b1","public_url":null},{"object":"page","id":"263974f3-b388-817c-87cc-e3bc9a66ee83","created_time":"2025-09-03T11:17:00.000Z","last_edited_time":"2025-09-03T11:17:00.000Z","created_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"CLI
+      Upload Test Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"CLI
+      Upload Test Page","href":null}]}},"url":"https://www.notion.so/CLI-Upload-Test-Page-263974f3b388817c87cce3bc9a66ee83","public_url":null},{"object":"page","id":"20c974f3-b388-808b-99a9-cfd22f106a8e","created_time":"2025-06-08T15:50:00.000Z","last_edited_time":"2025-06-08T19:22:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"cover":null,"icon":{"type":"custom_emoji","custom_emoji":{"id":"20c974f3-b388-8063-b812-007aeaf0578a","name":"ultimate-notion","url":"https://s3-us-west-2.amazonaws.com/public.notion-static.com/021a290b-d194-4457-ab01-01f9b2bf803f/favicon.svg"}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Custom
+      Emoji Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Custom
+      Emoji Page","href":null}]}},"url":"https://www.notion.so/Custom-Emoji-Page-20c974f3b388808b99a9cfd22f106a8e","public_url":null},{"object":"page","id":"61a3f87b-140a-4a71-8773-a25746e6f7b1","created_time":"2023-08-12T13:53:00.000Z","last_edited_time":"2023-08-12T13:53:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"cover":null,"icon":null,"parent":{"type":"database_id","database_id":"4c6e7417-ef05-4b7e-b55e-62ecbb55a38d"},"archived":false,"in_trash":false,"properties":{"Verification":{"id":"Mw%5E%3C","type":"verification","verification":{"state":"unverified","verified_by":null,"date":null}},"Tags":{"id":"OESf","type":"multi_select","multi_select":[]},"Last
+      edited time":{"id":"%5EB_%40","type":"last_edited_time","last_edited_time":"2023-08-12T13:53:00.000Z"},"Rollup":{"id":"gqYo","type":"rollup","rollup":{"type":"array","array":[],"function":"show_original"}},"Page":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Wiki
+      Page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Wiki
+      Page","href":null}]},"Owner":{"id":"notion%3A%2F%2Fwiki%2Fowner_property","type":"people","people":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
+      Wilhelm","avatar_url":"https://lh3.googleusercontent.com/a-/AAuE7mBBGq22qnRbLoOSo5zScC4miXci-xi4vELc30G9Aw=s100","type":"person","person":{"email":"florian.wilhelm@gmail.com"}}]}},"url":"https://www.notion.so/Wiki-Page-61a3f87b140a4a718773a25746e6f7b1","public_url":null}],"next_cursor":null,"has_more":false,"type":"page_or_database","page_or_database":{},"request_id":"93000876-f705-4429-b3e2-332a3f63d680"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9794de08fbb33638-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 93000876-f705-4429-b3e2-332a3f63d680
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/5f505199-b292-4713-920b-61d813bf72a3
+  response:
+    content: '{"object":"page","id":"5f505199-b292-4713-920b-61d813bf72a3","created_time":"2022-08-22T15:47:00.000Z","last_edited_time":"2025-09-03T11:22:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"645e79dd-3e43-40de-9d51-39357c1c427f"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"archived":false,"in_trash":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-5f505199b2924713920b61d813bf72a3","public_url":null,"request_id":"5008b3e1-97bc-4447-ac8c-72ee97ac15f4"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9794de0bbdd03638-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 5008b3e1-97bc-4447-ac8c-72ee97ac15f4
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/4c6e7417-ef05-4b7e-b55e-62ecbb55a38d
+  response:
+    content: '{"object":"database","id":"4c6e7417-ef05-4b7e-b55e-62ecbb55a38d","cover":null,"icon":null,"created_time":"2023-08-12T13:26:00.000Z","created_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_by":{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322"},"last_edited_time":"2025-07-26T19:31:00.000Z","title":[{"type":"text","text":{"content":"Wiki
+      DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Wiki
+      DB","href":null}],"description":[],"is_inline":false,"properties":{"Verification":{"id":"Mw%5E%3C","name":"Verification","description":null,"type":"verification","verification":{}},"Tags":{"id":"OESf","name":"Tags","description":null,"type":"multi_select","multi_select":{"options":[{"id":"4036ff5b-932f-4883-8d0c-6ca1fa6f9cf6","name":"Onboarding","color":"blue","description":null},{"id":"869be616-aa64-491d-b56c-161ea3e81b56","name":"Design","color":"green","description":null}]}},"Last
+      edited time":{"id":"%5EB_%40","name":"Last edited time","description":null,"type":"last_edited_time","last_edited_time":{}},"Page":{"id":"title","name":"Page","description":null,"type":"title","title":{}},"Owner":{"id":"notion%3A%2F%2Fwiki%2Fowner_property","name":"Owner","description":null,"type":"people","people":{}}},"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"url":"https://www.notion.so/4c6e7417ef054b7eb55e62ecbb55a38d","public_url":null,"archived":false,"in_trash":false,"request_id":"74bf90f9-4fc4-47f2-90b7-5d6da758df29"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9794de0d9f943638-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 74bf90f9-4fc4-47f2-90b7-5d6da758df29
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,14 +116,15 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             if marker_name in item.keywords:
                 item.add_marker(skip_release_test)
 
-    # Handle file_upload marker
-    file_upload_marker = 'file_upload'
-    file_upload_flag = f'--{file_upload_marker.replace("_", "-")}'
-    if not config.getoption(file_upload_flag):
-        skip_file_upload = pytest.mark.skip(reason=f'use flag `{file_upload_flag}` to run file upload tests')
-        for item in items:
-            if file_upload_marker in item.keywords:
-                item.add_marker(skip_file_upload)
+    # Handle file_upload marker - only if check_latest_release didn't already filter
+    if not config.getoption('--check-latest-release'):
+        file_upload_marker = 'file_upload'
+        file_upload_flag = f'--{file_upload_marker.replace("_", "-")}'
+        if not config.getoption(file_upload_flag):
+            skip_file_upload = pytest.mark.skip(reason=f'use flag `{file_upload_flag}` to run file upload tests')
+            for item in items:
+                if file_upload_marker in item.keywords:
+                    item.add_marker(skip_file_upload)
 
 
 def exec_pyfile(file_path: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,7 @@ def test_upload_directory_instead_of_file(tmp_path: Path) -> None:
     assert f"Error: '{test_dir}' is not a file" in result.stderr
 
 
+@pytest.mark.vcr()
 def test_upload_invalid_page_uuid(notion: Session) -> None:
     """Test uploading to a page with invalid UUID."""
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,14 +2,17 @@
 
 import logging
 import sys
+import tempfile
+import textwrap
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 from typer.testing import CliRunner
 
+import ultimate_notion as uno
 from ultimate_notion import Session, __version__
-from ultimate_notion.cli import LogLevel, app, setup_logging
+from ultimate_notion.cli import LogLevel, _get_block_class_for_file, app, setup_logging  # noqa: PLC2701
 
 
 @patch('logging.basicConfig')
@@ -98,3 +101,186 @@ def test_log_level_option_affects_logging() -> None:
         result = runner.invoke(app, ['--log-level', 'error', 'config'])
         assert result.exit_code == 0
         mock_setup.assert_called_with(LogLevel.ERROR)
+
+
+@pytest.mark.file_upload
+def test_upload_image_by_page_name(notion: Session, root_page: uno.Page) -> None:
+    """Test uploading an image file by page name."""
+    runner = CliRunner()
+    test_page = notion.get_or_create_page(parent=root_page, title='CLI Upload Image Test')
+    image_path = 'docs/assets/images/favicon.png'
+
+    with patch('ultimate_notion.cli.Session') as mock_session_class:
+        mock_session_class.return_value.__enter__.return_value = notion
+        mock_session_class.return_value.__exit__.return_value = None
+
+        result = runner.invoke(app, ['upload', image_path, str(test_page.title)])
+
+    assert result.exit_code == 0
+    # Verify the block was actually added
+    test_page.reload()
+    assert len(test_page.children) > 0
+    assert isinstance(test_page.children[-1], uno.Image)
+
+
+@pytest.mark.file_upload
+def test_upload_pdf_by_uuid(notion: Session, root_page: uno.Page, tmp_path: Path) -> None:
+    """Test uploading a PDF file by page UUID."""
+    runner = CliRunner()
+    test_page = notion.get_or_create_page(parent=root_page, title='CLI Upload PDF Test')
+    pdf_content = textwrap.dedent("""\
+        %PDF-1.4
+        1 0 obj
+        <<
+        /Type /Catalog
+        /Pages 2 0 R
+        >>
+        endobj
+        2 0 obj
+        <<
+        /Type /Pages
+        /Kids [3 0 R]
+        /Count 1
+        >>
+        endobj
+        3 0 obj
+        <<
+        /Type /Page
+        /Parent 2 0 R
+        /MediaBox [0 0 612 792]
+        >>
+        endobj
+        xref
+        0 4
+        0000000000 65535 f
+        0000000010 00000 n
+        0000000053 00000 n
+        0000000125 00000 n
+        trailer
+        <<
+        /Size 4
+        /Root 1 0 R
+        >>
+        startxref
+        230
+        %%EOF""").encode('utf-8')
+
+    pdf_file = tmp_path / 'test.pdf'
+    pdf_file.write_bytes(pdf_content)
+
+    with patch('ultimate_notion.cli.Session') as mock_session_class:
+        mock_session_class.return_value.__enter__.return_value = notion
+        mock_session_class.return_value.__exit__.return_value = None
+
+        result = runner.invoke(app, ['upload', str(pdf_file), str(test_page.id)])
+
+    assert result.exit_code == 0
+
+    # Verify the block was actually added
+    test_page.reload()
+    assert len(test_page.children) > 0
+    assert isinstance(test_page.children[-1], uno.PDF)
+
+
+def test_upload_nonexistent_file() -> None:
+    """Test uploading a file that doesn't exist."""
+    runner = CliRunner()
+
+    result = runner.invoke(app, ['upload', 'nonexistent_file.txt', 'some-page'])
+
+    assert result.exit_code == 1
+    assert "Error: File 'nonexistent_file.txt' does not exist" in result.stderr
+
+
+def test_upload_directory_instead_of_file(tmp_path: Path) -> None:
+    """Test trying to upload a directory instead of a file."""
+    runner = CliRunner()
+    test_dir = tmp_path / 'test_directory'
+    test_dir.mkdir()
+
+    result = runner.invoke(app, ['upload', str(test_dir), 'some-page'])
+
+    assert result.exit_code == 1
+    assert f"Error: '{test_dir}' is not a file" in result.stderr
+
+
+def test_upload_invalid_page_uuid(notion: Session) -> None:
+    """Test uploading to a page with invalid UUID."""
+    runner = CliRunner()
+
+    # Create a temporary test file
+    with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as tmp_file:
+        tmp_file.write(b'test content')
+        tmp_file_path = tmp_file.name
+
+        invalid_uuid = '12345678-1234-1234-1234-123456789abc'
+
+        with patch('ultimate_notion.cli.Session') as mock_session_class:
+            mock_session_class.return_value.__enter__.return_value = notion
+            mock_session_class.return_value.__exit__.return_value = None
+
+            result = runner.invoke(app, ['upload', tmp_file_path, invalid_uuid])
+
+        assert result.exit_code == 1
+        assert f"Error: Page with UUID '{invalid_uuid}' not found" in result.stderr
+
+
+@pytest.mark.vcr()
+def test_upload_nonexistent_page_name(notion: Session) -> None:
+    """Test uploading to a page that doesn't exist by name."""
+    runner = CliRunner()
+
+    with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as tmp_file:
+        tmp_file.write(b'test content')
+        tmp_file_path = tmp_file.name
+
+        nonexistent_page = 'This Page Does Not Exist At All'
+
+        with patch('ultimate_notion.cli.Session') as mock_session_class:
+            mock_session_class.return_value.__enter__.return_value = notion
+            mock_session_class.return_value.__exit__.return_value = None
+
+            result = runner.invoke(app, ['upload', tmp_file_path, nonexistent_page])
+
+        assert result.exit_code == 1
+        assert f"Error: No page found with name '{nonexistent_page}'" in result.stderr
+
+
+@pytest.mark.file_upload
+def test_upload_generic_file(notion: Session, root_page: uno.Page, tmp_path: Path) -> None:
+    """Test uploading a generic file that falls back to File block."""
+    runner = CliRunner()
+
+    test_page = notion.get_or_create_page(parent=root_page, title='CLI Upload Generic File Test')
+    text_file = tmp_path / 'test.txt'
+    text_file.write_text('This is a test file content.')
+
+    with patch('ultimate_notion.cli.Session') as mock_session_class:
+        mock_session_class.return_value.__enter__.return_value = notion
+        mock_session_class.return_value.__exit__.return_value = None
+
+        result = runner.invoke(app, ['upload', str(text_file), 'CLI Upload Generic File Test'])
+
+    assert result.exit_code == 0
+
+    # Verify the block was actually added
+    test_page.reload()
+    assert len(test_page.children) > 0
+    assert isinstance(test_page.children[-1], uno.File)
+
+
+def test_upload_file_type_detection_with_filetype(tmp_path: Path) -> None:
+    """Test that file type detection works with filetype library for files without proper extensions."""
+    png_content = (
+        b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+        b'\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\tpHYs\x00\x00\x0b\x13'
+        b'\x00\x00\x0b\x13\x01\x00\x9a\x9c\x18\x00\x00\x00\nIDATx\x9cc```'
+        b'\x00\x00\x00\x04\x00\x01]\xcc\xdb\x8d\x00\x00\x00\x00IEND\xaeB`\x82'
+    )
+
+    fake_txt_file = tmp_path / 'image.txt'  # Wrong extension
+    fake_txt_file.write_bytes(png_content)
+
+    # Should detect as Image despite .txt extension
+    block_class = _get_block_class_for_file(fake_txt_file)
+    assert block_class == uno.Image


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

Add a CLi option `upload` to upload a file to Notion and append it to a given page.

### Types of change

- added CLI option
- added a `session.get_or_create_page` option to simplify the unit tests.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
