### PR TITLE
Fix retrieval of page with unaccessible database as parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - New: Add the new `Place` database/source property.
 - Fix: Allow to bind a schema with a two-way target property to an existing database, issue #134.
+- Fix: `session.get_page(PAGE)` no longer fails if parent of `Page` is not accessible by the integration, issue #135.
 
 ## Version 0.9.4, 2025-10-01
 

--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -31,7 +31,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeGuard, cast, overload
 
 import numpy as np
-from notion_client import APIResponseError
 from tabulate import tabulate
 from typing_extensions import Self, TypeVar
 from url_normalize import url_normalize
@@ -39,7 +38,7 @@ from url_normalize import url_normalize
 from ultimate_notion.comment import Comment, Discussion
 from ultimate_notion.core import NotionEntity, get_active_session, get_url
 from ultimate_notion.emoji import CustomEmoji, Emoji
-from ultimate_notion.errors import InvalidAPIUsageError
+from ultimate_notion.errors import InvalidAPIUsageError, UnknownDatabaseError
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
 from ultimate_notion.markdown import md_comment
 from ultimate_notion.obj_api import blocks as obj_blocks
@@ -191,7 +190,7 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
             elif isinstance(child_block, ChildDatabase):
                 try:
                     ref_block = cast(Block, child_block.db)
-                except APIResponseError:
+                except UnknownDatabaseError:
                     # linked database that cannot be retrieved via API. Check the docs:
                     # https://developers.notion.com/reference/retrieve-a-database
                     ref_block = cast(Block, child_block)

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -9,9 +9,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Generic, Literal, TypeAlias, cast
 from uuid import UUID
 
-from notion_client.errors import APIResponseError
 from typing_extensions import Self, TypeVar
 
+from ultimate_notion.errors import UnknownDatabaseError, UnknownPageError
 from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.core import raise_unset
@@ -165,16 +165,16 @@ class NotionEntity(NotionObject[NE_co], ABC, wraps=obj_core.NotionEntity):
             case objs.PageRef(page_id=page_id):
                 try:
                     return session.get_page(page_ref=page_id)
-                except APIResponseError as e:
-                    msg = f'Error retrieving page with id `{page_id}`: {e}'
-                    _logger.warning(msg)
+                except UnknownPageError as e:
+                    msg = f'No access to parent page with id `{page_id}`: {e}'
+                    _logger.info(msg)
                     return None
             case objs.DatabaseRef(database_id=database_id):
                 try:
                     return session.get_db(db_ref=database_id)
-                except APIResponseError as e:
-                    msg = f'Error retrieving database with id `{database_id}`: {e}'
-                    _logger.warning(msg)
+                except UnknownDatabaseError as e:
+                    msg = f'No access to parent database with id `{database_id}`: {e}'
+                    _logger.info(msg)
                     return None
             case objs.BlockRef(block_id=block_id):
                 return session.get_block(block_ref=block_id)

--- a/src/ultimate_notion/errors.py
+++ b/src/ultimate_notion/errors.py
@@ -28,6 +28,10 @@ class UnknownPageError(UltimateNotionError):
     """Raised when the page is unknown."""
 
 
+class UnknownDatabaseError(UltimateNotionError):
+    """Raised when the database is unknown."""
+
+
 class InvalidAPIUsageError(UltimateNotionError):
     """Raised when the API is used in an invalid way."""
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes #135, i.e. fixing the error when retrieving a page that has an unaccessible parent database or page.

### Types of change

- Introduced an exception `UnknownDatabaseError`
- This new exception is thrown if a database is unaccessible like in #103 for pages.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
