### PR TITLE
Allow binding a schema with a two-way target property to an existing database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.9.5
 
 - New: Add the new `Place` database/source property.
+- Fix: Allow to bind a schema with a two-way target property to an existing database, issue #134.
 
 ## Version 0.9.4, 2025-10-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,7 @@ dependencies = [
 ]
 [tool.hatch.envs.default.scripts]
 test = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=src/ultimate_notion --cov=tests --record-mode once {args}"
-debug =  "test --no-cov -s --pdb --pdbcls=IPython.core.debugger:Pdb {args}"
+debug =  "test --no-cov -s --pdb --pdbcls=IPython.core.debugger:Pdb --debug-uno -o log_cli=true {args}"
 vcr-off = "test --disable-recording {args}"
 vcr-only = "test --record-mode=none --block-network {args}"
 vcr-rewrite = "test --record-mode=rewrite {args}"


### PR DESCRIPTION
…database

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This allows binding a schema with relation that acts as two-way target as described in issue #134.

### Types of change

When checking for consistency we exclude two-way property targets.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
