### PR TITLE
Add type annotation `BGColor` for `text` and `Text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New: Add the new `Place` database/source property.
 - Fix: Allow to bind a schema with a two-way target property to an existing database, issue #134.
 - Fix: `session.get_page(PAGE)` no longer fails if parent of `Page` is not accessible by the integration, issue #135.
+- Fix: Added `BGColor` type annotation for color parameter in `text()` and `Text`, issue #140.
 
 ## Version 0.9.4, 2025-10-01
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -91,14 +91,16 @@ These limitations include:
 - setting the icon and cover of a database.
 - moving pages since a [page’s parent cannot be changed].
 - setting a [reminder] based on date and/or time.
-- modifying the URL of file-like blocks, e.g., `File`, `Image`, etc.
+- modifying the URL of file-like blocks, e.g., `File`, `Image`, etc. Replace the block with a new upload instead.
 - creating inline comments to start a new discussion thread.
 - resolving comments or listing unresolved comments.
 - locking or unlocking a page or database.
 - working with database button properties.
+- working with place properties.
 - retrieving a list of all custom emojis defined in the workspace.
 - changing the description of a database property.
 - resolve linked databases, i.e. views to a database.
+- setting the font and background color independently of each other for rich texts.
 
 If you think those limitations should be fixed, [let the developers of Notion know](mailto:developers@makenotion.com) 😆
 

--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -648,7 +648,7 @@ class Callout(ColoredTextBlock[obj_blocks.Callout], ParentBlock[obj_blocks.Callo
         if icon is None:
             # Use the Notion default icon instead of sending Unset, which would be replaced by Notion with their
             # default anyway. This will get us into trouble if Notion ever changes their default icon. But for now,
-            # this is the best we can do for comparison etc.
+            # this is the best we can do for comparison reasons (online vs. offline blocks), etc.
             icon = self.get_default_icon()
 
         self.obj_ref.value.icon = icon.obj_ref

--- a/src/ultimate_notion/obj_api/enums.py
+++ b/src/ultimate_notion/obj_api/enums.py
@@ -46,6 +46,21 @@ class Color(str, Enum):
     RED = 'red'
 
 
+class BGColor(str, Enum):
+    """Background colors for most textual blocks, e.g. paragraphs, callouts, etc."""
+
+    DEFAULT = 'default'
+    GRAY = 'gray_background'
+    BROWN = 'brown_background'
+    ORANGE = 'orange_background'
+    YELLOW = 'yellow_background'
+    GREEN = 'green_background'
+    BLUE = 'blue_background'
+    PURPLE = 'purple_background'
+    PINK = 'pink_background'
+    RED = 'red_background'
+
+
 class FormulaType(str, Enum):
     """Formula types for formulas.
 
@@ -90,21 +105,6 @@ class OptionGroupType(str, Enum):
     TO_DO = 'to_do'
     IN_PROGRESS = 'in_progress'
     COMPLETE = 'complete'
-
-
-class BGColor(str, Enum):
-    """Background colors for most textual blocks, e.g. paragraphs, callouts, etc."""
-
-    DEFAULT = 'default'
-    GRAY = 'gray_background'
-    BROWN = 'brown_background'
-    ORANGE = 'orange_background'
-    YELLOW = 'yellow_background'
-    GREEN = 'green_background'
-    BLUE = 'blue_background'
-    PURPLE = 'purple_background'
-    PINK = 'pink_background'
-    RED = 'red_background'
 
 
 class FileUploadStatus(str, Enum):

--- a/src/ultimate_notion/rich_text.py
+++ b/src/ultimate_notion/rich_text.py
@@ -17,7 +17,7 @@ from ultimate_notion.emoji import CustomEmoji
 from ultimate_notion.markdown import render_md, rich_texts_to_markdown
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.core import Unset
-from ultimate_notion.obj_api.enums import Color
+from ultimate_notion.obj_api.enums import BGColor, Color
 from ultimate_notion.obj_api.objects import MAX_TEXT_OBJECT_SIZE
 from ultimate_notion.user import User
 
@@ -152,7 +152,7 @@ class RichText(RichTextBase[objs.TextObject], wraps=objs.TextObject):
 
     !!! note
 
-        Only used internally. Use `Text` instead.
+        Only used internally. Use `Text` instead or the `text` function (recommended).
     """
 
     def __init__(
@@ -164,7 +164,7 @@ class RichText(RichTextBase[objs.TextObject], wraps=objs.TextObject):
         strikethrough: bool = False,
         code: bool = False,
         underline: bool = False,
-        color: Color | None = None,
+        color: Color | BGColor | None = None,
         href: str | None = None,
     ) -> None:
         if len(text) > MAX_TEXT_OBJECT_SIZE:
@@ -286,10 +286,15 @@ def text(
     strikethrough: bool = False,
     code: bool = False,
     underline: bool = False,
-    color: Color | None = None,
+    color: Color | BGColor | None = None,
     href: str | None = None,
 ) -> Text:
     """Create a rich text Text object from a normal string with formatting.
+
+    !!! note
+
+        With the `color` parameter the font color or the background color can be set.
+        Unfortunately Notion's API does not allow to set both at the same time like in the Notion UI.
 
     !!! warning
 

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -854,11 +854,11 @@ class SchemaType(ABCMeta):
             non_unique_attrs = ', '.join(str(attr) for attr in attr_name_props)
             msg = (
                 f'Attribute {name} is not unique for properties {non_unique_attrs}! '
-                'Use indexing, i.e. [...], to access the property.'
+                'Use indexing, i.e. [...], to access the property'  # `.` is added by AttributeError automatically
             )
             raise AttributeError(msg) from e
         except EmptyListError as e:
-            msg = f'Schema has no property with attribute name {name}.'
+            msg = f'Schema has no property with attribute name {name}'  # `.` is added by AttributeError automatically
             raise AttributeError(msg) from e
 
     def __setattr__(cls: type[Schema], name: str, value: Any) -> None:  # type: ignore[misc]
@@ -1142,8 +1142,8 @@ class Schema(metaclass=SchemaType):
             del other_schema_dct[name]
             if (
                 name in own_schema_dct
-                and isinstance(own_schema_dct[name], Relation)
-                and own_schema_dct[name].is_two_way
+                and isinstance(rel_prop := own_schema_dct[name], Relation)
+                and rel_prop.is_two_way
             ):
                 del own_schema_dct[name]
             else:

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -237,7 +237,7 @@ class Session:
             try:
                 db = Database.wrap_obj_ref(self.api.databases.retrieve(db_uuid))
             except APIResponseError as e:
-                msg = f'Database with id `{db_uuid}` not found!'
+                msg = f'Database with id `{db_uuid}` does not exist or is not accessible!'
                 _logger.warning(msg)
                 raise UnknownDatabaseError(msg) from e
             self.cache[db.id] = db
@@ -289,7 +289,7 @@ class Session:
             try:
                 page = Page.wrap_obj_ref(self.api.pages.retrieve(page_uuid))
             except APIResponseError as e:
-                msg = f'Page with id {page_uuid} not found!'
+                msg = f'Page with id {page_uuid} does not exist or is not accessible!'
                 _logger.warning(msg)
                 raise UnknownPageError(msg) from e
             self.cache[page.id] = page


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

Add the missing type annotation `BGColor` to `text` and `Text`. This fixes issue #140.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
