### PR TITLE
Fix retrieving a callout block without an icon

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -101,6 +101,7 @@ These limitations include:
 - changing the description of a database property.
 - resolve linked databases, i.e. views to a database.
 - setting the font and background color independently of each other for rich texts.
+- having a callout block without an icon as sending `null` is rejected by the Notion API.
 
 If you think those limitations should be fixed, [let the developers of Notion know](mailto:developers@makenotion.com) 😆
 

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -262,13 +262,24 @@ class CalloutTypeData(ColoredTextBlockTypeData):
 
     # `children` is undocumented and behaves inconsistent. It is used during creation but not filled when retrieved.
     children: list[SerializeAsAny[Block]] = Field(default_factory=list)
-    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | UnsetType = Unset
+    # `Unset` means the default icon as determined by Notion, and `None` means no icon when retrieved
+    #  but is not accepted when sending to Notion.
+    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | UnsetType | None = Unset
 
 
 class Callout(ColoredTextBlock[CalloutTypeData], type='callout'):
     """A callout block in Notion."""
 
     callout: CalloutTypeData = Field(default_factory=CalloutTypeData)  # type: ignore[arg-type]
+
+    # This would work if the Notion API would accept `null` for `icon` to have no icon but does not.
+    # def serialize_for_api(self) -> dict[str, Any]:
+    #     """Serialize the object for sending it to the Notion API."""
+    #     model_data = super().serialize_for_api()
+    #     # Everywhere else we have to remove "null" values but `callout` is an exception to have no icon
+    #     if self.callout.icon is None:
+    #         model_data['callout']['icon'] = None
+    #     return model_data
 
 
 class BulletedListItemTypeData(ColoredTextBlockTypeData):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -379,10 +379,11 @@ def test_custom_emoji_icon(notion: uno.Session, root_page: uno.Page, custom_emoj
         # Custom Emoji Page
 
         This page has a custom emoji :ultimate-notion: compared to 🚀.
+        💡 Callout block without an emoji
         """
     ).strip()
 
-    assert custom_emoji_page.to_markdown() == exp_md
+    assert custom_emoji_page.to_markdown().strip() == exp_md
 
     page = notion.create_page(
         parent=root_page,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes the problem when retrieving a callout block without an icon.
Unfortunately, it's not possible to create a callout block without an icon as the Notion API won't accept a `null` value as icon but returns it when set through the Notion UI. This fixes the bug part of #142.

### Types of change

- Accept in low-level Callout block a value of `None`.
- Explicitly use the default emoji 💡 instead of sending `None` for consistency reason.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
