### PR TITLE
Document cover image repositioning limitation

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -102,6 +102,7 @@ These limitations include:
 - resolve linked databases, i.e. views to a database.
 - setting the font and background color independently of each other for rich texts.
 - having a callout block without an icon as sending `null` is rejected by the Notion API.
+- repositioning a page's cover image.
 
 If you think those limitations should be fixed, [let the developers of Notion know](mailto:developers@makenotion.com) 😆
 


### PR DESCRIPTION
<img width="584" height="65" alt="image" src="https://github.com/user-attachments/assets/f617d42b-3975-4df0-910d-a81caf43e0fc" />
