### PR TITLE
Fix resolution of polymorphic TypeObjects in case of ConfigDict(extra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix: Determing the correct mime type of a file, which is now done using `mimetypes` instead of `filetypes`, issue #141.
 - New: Add the new `workspace_id` field to the `Bot`.
 - Fix: Unify texts locally the same way as remote, which is necessary for comparison, issue #136.
+- Fix: Resolution of polymorphic `TypedObject`, which led to wrong schema inference, issue #134.
 
 ## Version 0.9.5, 2025-10-24
 

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -393,7 +393,7 @@ class TypedObject(GenericObject, Generic[TO_co]):
             msg = f'Duplicate subtype for class - {name} :: {cls}'
             raise ValueError(msg)
 
-        _logger.debug('registered new subtype: %s => %s', name, cls)
+        _logger.debug('Registered new subtype: %s => %s', name, cls)
         cls._typemap[name] = cls
 
     @model_validator(mode='wrap')
@@ -408,9 +408,6 @@ class TypedObject(GenericObject, Generic[TO_co]):
         if isinstance(value, cls):
             return handler(value)
 
-        if not cls._polymorphic_base:  # breaks the recursion
-            return handler(value)
-
         if not isinstance(value, dict):
             msg = "Invalid 'data' object"
             raise ValueError(msg)
@@ -421,11 +418,14 @@ class TypedObject(GenericObject, Generic[TO_co]):
 
         type_name = value.get('type')
 
+        if (not cls._polymorphic_base) and cls.model_fields['type'].default == type_name:  # breaks the recursion
+            return handler(value)
+
         if type_name is None:
             _logger.warning(f'Missing type in data {value}. Most likely a User object without type')
             msg = f"Missing 'type' in data {value}"
-            if value['object'] == 'user':
-                type_name = 'unknown'  # for the unofficial type objects.UnknownUser
+            if value.get('object') == 'user':
+                type_name = 'unknown'  # for the unofficial type obj_api.objects.UnknownUser
             else:
                 raise ValueError(msg)
 
@@ -436,6 +436,16 @@ class TypedObject(GenericObject, Generic[TO_co]):
             raise ValueError(msg)
 
         return sub_cls(**value)
+
+    @classmethod
+    def build(cls, *args: Any, **kwargs: Any) -> Self:
+        """Build non-polymorphic instances of TypedObject by adding the proper `type` parameter."""
+        if cls._polymorphic_base:
+            msg = 'Cannot build instance of polymorphic base class directly.'
+            raise ValueError(msg)
+
+        kwargs['type'] = cls.model_fields['type'].default
+        return cls(*args, **kwargs)
 
     @property
     def value(self) -> TO_co:

--- a/src/ultimate_notion/obj_api/iterator.py
+++ b/src/ultimate_notion/obj_api/iterator.py
@@ -24,7 +24,7 @@ def convert_to_notion_obj(
 ) -> Block | Page | Database | PropertyItem | User | GenericObject | FileUpload:
     """Convert a dictionary to the corresponding subtype of Notion Object.
 
-    Used in the ObjectList below the convert the results from the Notion API.
+    Used in the ObjectList below to convert the results from the Notion API.
     """
     obj_field = 'object'
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes issue #134. 

### Types of changes

We change how the pydantic resolved polymorphic models. We made sure that the decision which TypeObject is generated really depends on the `type` value from the JSON. This is especially important for union types like in here:

```python
class Relation(Property[SinglePropertyRelation | DualPropertyRelation], type='relation'):
    """Defines the relation configuration for a database property."""

    relation: SinglePropertyRelation | DualPropertyRelation
```
In case of `model_config = ConfigDict(extra='ignore')`, pydantic would always resolve a `SinglePropertyRelation` as it is allowed to 'ignore' additional values. Now `TypedObject._resolve_type` makes sure that we really pick the right sub class based on the `type` attribute, no matter what.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
