### PR TITLE
Proper typing of block.children

### DIFF
--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Generic, Literal, TypeAlias, cast
 from uuid import UUID
 
-from typing_extensions import Self, TypeVar
+from typing_extensions import Self, TypeIs, TypeVar
 
 from ultimate_notion.errors import UnknownDatabaseError, UnknownPageError
 from ultimate_notion.obj_api import core as obj_core
@@ -24,6 +24,8 @@ GT_co = TypeVar('GT_co', bound=obj_core.GenericObject, default=obj_core.GenericO
 if TYPE_CHECKING:
     from pydantic_core import SchemaSerializer
 
+    from ultimate_notion.database import Database
+    from ultimate_notion.page import Page
     from ultimate_notion.session import Session
     from ultimate_notion.user import User
 
@@ -223,3 +225,13 @@ def get_repr(obj: Any, /, *, name: Any = None, desc: Any = None) -> str:
     type_str = str(name) if name is not None else obj.__class__.__name__
     desc_str = str(desc) if desc is not None else str(obj)
     return f"<{type_str}: '{desc_str}' at {hex(id(obj))}>"
+
+
+def is_db(obj: NotionEntity | None) -> TypeIs[Database]:
+    """Return whether the object is a database as type guard."""
+    return obj is not None and obj.is_db
+
+
+def is_page(obj: NotionEntity | None) -> TypeIs[Page]:
+    """Return whether the object is a page as type guard."""
+    return obj is not None and obj.is_page

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -481,7 +481,7 @@ def test_modify_column_blocks(root_page: uno.Page, notion: uno.Session) -> None:
     page.reload()
 
     cols = cast(uno.Columns, page.children[0])
-    col = cast(uno.Column, cols.children[0])
+    col = cols.columns[0]
     paragraph = cast(uno.Paragraph, col.children[0])
     assert paragraph == right
     assert left.reload().is_deleted
@@ -721,7 +721,7 @@ def test_max_children_length(root_page: uno.Page, notion: uno.Session) -> None:
     assert len(page.children) == len(blocks)
 
     ablocks = [uno.Paragraph(f'Another Paragraph {i}') for i in range(n_blocks)]
-    page.append(ablocks, after=page.children[2])
+    page.append(ablocks, after=page.blocks[2])
     assert page.children[3] == ablocks[0]
     assert len(page.children) == 2 * n_blocks
     assert page.children[3 + n_blocks] == blocks[3]
@@ -734,16 +734,16 @@ def test_max_nesting_level(root_page: uno.Page, notion: uno.Session) -> None:
     # add a 1st level of nesting
     blocks[0].append([uno.BulletedItem(f'Nested Point {i}') for i in range(n_blocks)])
     # add a 2nd level of nesting
-    blocks[0].children[0].append([uno.BulletedItem(f'Deeply Nested Point {i}') for i in range(n_blocks)])  # type: ignore[attr-defined]
+    blocks[0].blocks[0].append([uno.BulletedItem(f'Deeply Nested Point {i}') for i in range(n_blocks)])  # type: ignore[attr-defined]
 
     page = notion.create_page(
         parent=root_page, title='Page for testing max nesting level', blocks=[uno.Paragraph('Intro')]
     )
     page.append(blocks)
 
-    assert len(page.children) == n_blocks + 1
-    assert len(page.children[1].children) == n_blocks  # type: ignore[attr-defined]
-    assert len(page.children[1].children[0].children) == n_blocks  # type: ignore[attr-defined]
+    assert len(page.blocks) == n_blocks + 1
+    assert len(page.blocks[1].blocks) == n_blocks  # type: ignore[attr-defined]
+    assert len(page.blocks[1].blocks[0].blocks) == n_blocks  # type: ignore[attr-defined]
 
 
 @pytest.mark.vcr()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -67,7 +67,7 @@ def test_parent_subpages(notion: uno.Session, root_page: uno.Page) -> None:
 
 @pytest.mark.vcr()
 def test_parent_children(intro_page: uno.Page) -> None:
-    assert all(isinstance(block, Block) for block in intro_page.children)
+    assert all(isinstance(block, Block) for block in intro_page.blocks)
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

This fixes issue #159 but hinting the type of `.children` correctly to `tuple[Block | Page | Database, ...]`. For convenience, some additional methods were added like `blocks` that returns only the actual blocks and `rows` as well as `columns` for `Table` and `Columns` respectively.  

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
