### PR TITLE
Allow partial Schemas to bind to a Notion database

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@
 * [al1p-R](https://github.com/al1p-R)
 * [Tzumx](https://github.com/Tzumx)
 * [Ivan Lonel](https://github.com/ivanlonel)
+* [Yoni Hikri](https://github.com/yonihik)

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -120,7 +120,7 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
 
     def _set_schema(self, schema: type[Schema], *, during_init: bool) -> None:
         """Set a custom schema in order to change the Python variables names."""
-        self.schema.assert_consistency_with(schema, during_init=during_init)
+        self.schema.assert_consistency_with(schema, during_init=during_init, partial=schema._partial)
         schema._bind_db(self)
         self._schema = schema
 

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -919,13 +919,22 @@ class Schema(metaclass=SchemaType):
     _db_desc: rich_text.Text | None
     _database: Database | None = None
     _props: list[Property]
+    _partial: bool = False
 
-    def __init_subclass__(cls, db_title: str | None = None, db_id: str | None = None, **kwargs: Any):
+    def __init_subclass__(
+        cls,
+        db_title: str | None = None,
+        db_id: str | None = None,
+        *,
+        partial: bool = False,
+        **kwargs: Any,
+    ):
         if db_title is not None:
             db_title = rich_text.Text(db_title)
         cls._db_title = db_title
         cls._db_id = db_id
         cls._db_desc = rich_text.Text(cls.__doc__) if cls.__doc__ is not None else None
+        cls._partial = partial
         cls._validate()
         super().__init_subclass__(**kwargs)
 
@@ -1104,8 +1113,19 @@ class Schema(metaclass=SchemaType):
         return SList(prop for prop in cls.get_props() if isinstance(prop, Title)).item()
 
     @classmethod
-    def assert_consistency_with(cls, other_schema: type[Schema], *, during_init: bool = False) -> None:
-        """Assert that this schema is consistent with another schema."""
+    def assert_consistency_with(
+        cls,
+        other_schema: type[Schema],
+        *,
+        during_init: bool = False,
+        partial: bool = False,
+    ) -> None:
+        """Assert that this schema is consistent with another schema.
+
+        When `partial` is True, properties present in `cls` (the DB-reflected schema) but missing
+        from `other_schema` (the user-supplied schema) are tolerated. Extra properties in
+        `other_schema` and type mismatches still raise.
+        """
         own_schema_dct = cls.to_dict()
         other_schema_dct = other_schema.to_dict()
 
@@ -1150,14 +1170,18 @@ class Schema(metaclass=SchemaType):
 
         if other_schema_dct != own_schema_dct:
             props_added, props_removed, props_changed = dict_diff_str(own_schema_dct, other_schema_dct)
-            msg = 'Provided schema is not consistent with the current schema of the database:\n'
-            if props_added:
-                msg += f'- added: {", ".join(props_added)}\n'
-            if props_removed:
-                msg += f'- removed: {", ".join(props_removed)}\n'
-            if props_changed:
-                msg += f'- changed: {", ".join(props_changed)}\n'
-            raise SchemaError(msg)
+            if partial:
+                # Props in own (DB) but missing from other (user) are allowed in partial mode.
+                props_removed = []
+            if props_added or props_removed or props_changed:
+                msg = 'Provided schema is not consistent with the current schema of the database:\n'
+                if props_added:
+                    msg += f'- added: {", ".join(props_added)}\n'
+                if props_removed:
+                    msg += f'- removed: {", ".join(props_removed)}\n'
+                if props_changed:
+                    msg += f'- changed: {", ".join(props_changed)}\n'
+                raise SchemaError(msg)
 
     @classmethod
     def get_db(cls) -> Database:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -229,6 +229,42 @@ def test_property_name_is_set() -> None:
             tags = uno.PropType.Number()
 
 
+def test_partial_schema_consistency() -> None:
+    """`partial=True` lets a Schema be a subset of the DB schema; extras and type mismatches still error."""
+
+    class Full(uno.Schema, db_title='Full'):
+        name = uno.PropType.Title('Name')
+        cost = uno.PropType.Number('Cost', format=uno.NumberFormat.DOLLAR)
+        desc = uno.PropType.Text('Description')
+
+    class StrictSubset(uno.Schema, db_title='Strict Subset'):
+        name = uno.PropType.Title('Name')
+
+    assert StrictSubset._partial is False
+    with pytest.raises(SchemaError):
+        Full.assert_consistency_with(StrictSubset)
+
+    class PartialSubset(uno.Schema, db_title='Partial Subset', partial=True):
+        name = uno.PropType.Title('Name')
+
+    assert PartialSubset._partial is True
+    Full.assert_consistency_with(PartialSubset, partial=True)  # must not raise
+
+    class ExtraPartial(uno.Schema, db_title='Extra Partial', partial=True):
+        name = uno.PropType.Title('Name')
+        bogus = uno.PropType.Text('Bogus')
+
+    with pytest.raises(SchemaError):
+        Full.assert_consistency_with(ExtraPartial, partial=True)
+
+    class WrongTypePartial(uno.Schema, db_title='Wrong Type Partial', partial=True):
+        name = uno.PropType.Title('Name')
+        cost = uno.PropType.Text('Cost')
+
+    with pytest.raises(SchemaError):
+        Full.assert_consistency_with(WrongTypePartial, partial=True)
+
+
 def test_to_pydantic_model() -> None:
     class Schema(uno.Schema, db_title='Schema'):
         name = uno.PropType.Title('Name')


### PR DESCRIPTION
## Summary

- Adds an opt-in `partial=True` class kwarg on `Schema` so a Python schema may declare only a subset of the bound database's properties.
- `assert_consistency_with` now accepts a `partial` flag; when set, properties present in the DB but missing from the user's schema are tolerated. Extra properties in the schema and type mismatches still raise `SchemaError`.
- `Database._set_schema` reads `schema._partial` and forwards it through, so every binding path (`db.schema = X`, `Schema.bind_db`, `session.create_db`, `session.get_or_create_db`) honors partial mode.

## Why

Narrow scripts often legitimately don't care about every column of a database. Today, declaring a Schema with fewer fields than the live DB raises `SchemaError: ... - removed: <field>` at bind time, blocking that use case entirely. With `partial=True` users can write:

```python
class Tasks(uno.Schema, db_id=DB_ID, partial=True):
    name = uno.PropType.Title('Name')

session.get_or_create_db(parent=p, schema=Tasks)
Tasks.create(name='Buy milk')   # only sends 'Name'; Notion fills the rest
```

Reads of undeclared fields still work via the raw-name accessor (`page.props['Cost']`), so opting out of a property is non-destructive.

## Out of scope (deliberately)

- Writing to undeclared properties via `create_page`. `SchemaModel`'s `extra='forbid'` rejects kwargs for non-declared props — consistent with "I opted out of these fields."
- A per-binding override (`bind_db(db, partial=True)`). Class-level opt-in is the surface; a per-call override can land later without breaking this design.
- A test that does `article_db.schema = PartialSchema` end-to-end. That requires recording a fresh VCR cassette against a real workspace and is intended for a follow-up PR.

## Test plan

- [x] New `tests/test_schema.py::test_partial_schema_consistency` — pure-Python, no cassette. Covers binding success + every rejection branch (extra prop, type mismatch, default-strict subset still rejected, `_partial` flag propagates).
- [x] Existing `tests/test_database.py::test_schema` still passes — strict behavior unchanged.
- [x] `hatch run vcr-only tests/` — full suite is regression-clean (159 passed, 14 skipped; 7 pre-existing errors in unrelated `mention/user/bot` tests are present on `main` too).
- [x] `hatch run lint:all` — clean (ruff + mypy).
- [ ] Follow-up PR will add `test_partial_schema_create` + cassette covering `db.schema = PartialSchema` and `db.create_page(...)` end-to-end against a real DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)