### PR TITLE
Fix equality of Unset annotations vs API default annotations (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Chg: Return `FileUploadStatus` in `UploadedFile.file_import_result` for easier usage.
 - Fix: All objects are no longer `hash`able as they are mutable and thus the former behaviour was semantically incorrect.
 - Fix: Comparison of off-/online `MentionObject`s works, also when `UserRef` or an `ObjectRef` to a page is used, issue #170.
+- Fix: An `Unset` `annotations` (e.g. a mention built with `style=None`) now compares equal to the default `Annotations` returned by the Notion API, issue #174.
 
 ## Version 0.9.5, 2025-10-24
 

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -263,6 +263,13 @@ def _normalize_model(obj: T) -> T:
                     setattr(obj_copy, field_name, Unset)
                 elif field_name == 'color' and is_unset(field_value):
                     setattr(obj_copy, field_name, _normalize_color(field_value))
+                elif field_name == 'annotations' and is_unset(field_value):
+                    # An `Unset` annotation means default styling, which the Notion API returns as a
+                    # fully populated `Annotations` object. Normalize so that offline-built objects
+                    # (e.g. mentions built with `style=None`) compare equal to their online counterparts.
+                    from ultimate_notion.obj_api.objects import Annotations  # noqa: PLC0415  # Avoid circular import.
+
+                    setattr(obj_copy, field_name, _recurse(Annotations()))
                 elif isinstance(obj, TypedObject) and obj.type == 'mention' and field_name in {'plain_text', 'href'}:
                     # allows comparing offline-built mentions to online ones, e.g. UserRef
                     setattr(obj_copy, field_name, Unset)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from textwrap import dedent
 from typing import cast
+from uuid import uuid4
 
 import pytest
 
@@ -687,6 +688,34 @@ def test_rt_default_color() -> None:
     para_2.rich_text = rich_text
 
     assert para_1.obj_ref.serialize_for_api() == para_2.obj_ref.serialize_for_api()
+
+
+def test_unstyled_mention_equals_default_annotations() -> None:
+    """A mention built with `style=None` must compare equal to the default annotations the API returns.
+
+    Regression test for https://github.com/ultimate-notion/ultimate-notion/issues/174: a mention
+    built without a style has `annotations` set to `Unset`, while the Notion API returns a fully
+    populated `Annotations` object with `color=Color.DEFAULT`. Both represent default styling and
+    must therefore be considered equal.
+    """
+    user_id = uuid4()
+    user_ref = UserRef(id=user_id)
+
+    # Offline mention without any style, as built e.g. internally when no annotations are given.
+    unstyled_mention = objs.MentionUser.build_mention_from(user=user_ref, style=None)
+    unstyled_block = uno.Paragraph(text=Text.wrap_obj_ref(obj_refs=[unstyled_mention]))
+    assert unstyled_mention.annotations is Unset
+
+    # Mention with explicit default annotations, mimicking what the Notion API returns on read.
+    default_mention = objs.MentionUser.build_mention_from(user=user_ref, style=objs.Annotations())
+    default_block = uno.Paragraph(text=Text.wrap_obj_ref(obj_refs=[default_mention]))
+
+    assert unstyled_block == default_block
+
+    # A non-default style must still differ.
+    bold_mention = objs.MentionUser.build_mention_from(user=user_ref, style=objs.Annotations(bold=True))
+    bold_block = uno.Paragraph(text=Text.wrap_obj_ref(obj_refs=[bold_mention]))
+    assert unstyled_block != bold_block
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Description

Fixes #174. A rich-text object built without a style (e.g. a mention built with `style=None`) leaves its `annotations` field as `Unset`, while the Notion API returns a fully populated `Annotations` object with `color=Color.DEFAULT`. Since both represent default styling, `_normalize_model` now normalizes an `Unset` `annotations` to a default `Annotations` so that offline-built objects compare equal to their online counterparts. Added an offline regression test (`test_unstyled_mention_equals_default_annotations`) and a CHANGELOG entry.

### Types of change

Bug fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.