### PR TITLE
Remove type: ignore in deepcopy_with_sharing

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -199,7 +199,7 @@ def deepcopy_with_sharing(obj: T, shared_attributes: Sequence[str], memo: dict[i
     if hasattr(obj, '__deepcopy__'):
         # Undo hack
         obj.__deepcopy__ = deepcopy_method
-        del clone.__deepcopy__  # type: ignore[attr-defined]
+        del clone.__dict__['__deepcopy__']
 
     return clone
 


### PR DESCRIPTION
## Description

Removes a `# type: ignore[attr-defined]` in `deepcopy_with_sharing` by deleting the copied `__deepcopy__` instance attribute via `clone.__dict__['__deepcopy__']` instead of `del clone.__deepcopy__`. This matches the existing `del obj.__dict__[attr]` idiom a few lines above in the same function, is type-safe (so the ignore is no longer needed), and preserves the exact runtime behavior — the instance-level attribute is removed while the class-level `__deepcopy__` method stays intact. Verified with the project's pinned mypy 1.18.2 (clean across all 76 source files) and ruff.

### Types of change

Code cleanup / typing improvement (no behavior change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.