### PR TITLE
Drop attr-defined ignore via WithChildren type-data mixin

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -168,7 +168,7 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
     @property
     def _has_children_field(self) -> bool:
         """Return whether the object has a `children` field."""
-        return isinstance(self.obj_ref, obj_blocks.Block) and hasattr(self.obj_ref.value, 'children')
+        return isinstance(self.obj_ref, obj_blocks.Block) and isinstance(self.obj_ref.value, obj_blocks.WithChildren)
 
     def _gen_children_cache(self) -> list[Block]:
         """Generate the children cache."""
@@ -179,8 +179,8 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
         session = get_active_session()
         child_blocks_objs = list(session.api.blocks.children.list(parent=objs.get_uuid(self.obj_ref)))
         self.obj_ref.has_children = bool(child_blocks_objs)  # update the property manually to avoid API call
-        if self._has_children_field:
-            self.obj_ref.value.children = child_blocks_objs  # type: ignore[attr-defined] # update the children attribute
+        if isinstance(self.obj_ref, obj_blocks.Block) and isinstance(self.obj_ref.value, obj_blocks.WithChildren):
+            self.obj_ref.value.children = child_blocks_objs  # update the children attribute
 
         child_blocks: list[Block] = [Block.wrap_obj_ref(block) for block in child_blocks_objs]
 
@@ -422,9 +422,10 @@ class ParentBlock(Block[B_co], ChildrenMixin[B_co], wraps=obj_blocks.Block):
     @classmethod
     def wrap_obj_ref(cls: type[Self], obj_ref: B_co, /) -> Self:  # type: ignore[misc] # breaking covariance
         self = super().wrap_obj_ref(obj_ref)
-        if obj_ref.has_children and hasattr(self.obj_ref.value, 'children') and self.obj_ref.value.children:
-            self._children = [Block.wrap_obj_ref(child) for child in self.obj_ref.value.children]
-            self.obj_ref.value.children = []  # clear children to avoid confusion during comparison
+        value = self.obj_ref.value
+        if obj_ref.has_children and isinstance(value, obj_blocks.WithChildren) and value.children:
+            self._children = [Block.wrap_obj_ref(child) for child in value.children]
+            value.children = []  # clear children to avoid confusion during comparison
         return self
 
 
@@ -1577,10 +1578,11 @@ def _build_obj_ref(node: _Node) -> Block:
     if not isinstance(block, Block):
         msg = f'Non-block type {type(block)} not allowed on this level of the hierarchy.'
         raise TypeError(msg)
-    if isinstance(block, ParentBlock) and block.has_children and hasattr(block.obj_ref.value, 'children'):
+    value = block.obj_ref.value
+    if isinstance(block, ParentBlock) and block.has_children and isinstance(value, obj_blocks.WithChildren):
         for child in node.children:
             _build_obj_ref(child)
-        block.obj_ref.value.children = [child.block.obj_ref for child in children]
+        value.children = [child.block.obj_ref for child in children]
     return block
 
 

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -17,7 +17,7 @@ values from default/unset values.
 from __future__ import annotations
 
 from abc import ABC
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Generic, cast
 
 from pydantic import AfterValidator, Field, SerializeAsAny
 from typing_extensions import TypeVar
@@ -122,6 +122,20 @@ class Block(TypedObject[GO_co], DataObject, object='block', polymorphic_base=Tru
         return self.type == other.type and self.value == other.value
 
 
+# ToDo: Use new syntax when requires-python >= 3.12
+CB = TypeVar('CB', bound=Block, default=Block)  # invariant, as it is used in the mutable `children` list
+
+
+class WithChildren(GenericObject, ABC, Generic[CB]):
+    """Type data mixin for blocks that can hold child blocks.
+
+    Provides a common base so that type data carrying `children` can be detected and narrowed
+    with `isinstance`, e.g. when populating the children cache from the API.
+    """
+
+    children: list[SerializeAsAny[CB]] = Field(default_factory=list)
+
+
 class UnsupportedBlockTypeData(GenericObject):
     """Type data for `UnsupportedBlock`."""
 
@@ -184,10 +198,8 @@ class ColoredTextBlock(TextBlock[CTB_co]):
     """A standard abstract text block object in Notion with color."""
 
 
-class ParagraphTypeData(ColoredTextBlockTypeData):
+class ParagraphTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `Paragraph` block."""
-
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class Paragraph(ColoredTextBlock[ParagraphTypeData], type='paragraph'):
@@ -224,10 +236,8 @@ class Heading3(Heading, type='heading_3'):
     heading_3: HeadingTypeData = Field(default_factory=HeadingTypeData)
 
 
-class QuoteTypeData(ColoredTextBlockTypeData):
+class QuoteTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `Quote` block."""
-
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class Quote(ColoredTextBlock[QuoteTypeData], type='quote'):
@@ -254,11 +264,13 @@ class Code(TextBlock[CodeTypeData], type='code'):
     code: CodeTypeData = Field(default_factory=CodeTypeData)
 
 
-class CalloutTypeData(ColoredTextBlockTypeData):
-    """Type data for `Callout` block."""
+class CalloutTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
+    """Type data for `Callout` block.
 
-    # `children` is undocumented and behaves inconsistent. It is used during creation but not filled when retrieved.
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
+    Note: `children` is undocumented and behaves inconsistently. It is used during creation but not
+    filled when retrieved.
+    """
+
     # `Unset` means the default icon as determined by Notion, and `None` means no icon when retrieved
     #  but is not accepted when sending to Notion.
     icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | UnsetType | None = Unset
@@ -279,10 +291,8 @@ class Callout(ColoredTextBlock[CalloutTypeData], type='callout'):
     #     return model_data
 
 
-class BulletedListItemTypeData(ColoredTextBlockTypeData):
+class BulletedListItemTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `BulletedListItem` block."""
-
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class BulletedListItem(ColoredTextBlock[BulletedListItemTypeData], type='bulleted_list_item'):
@@ -291,10 +301,8 @@ class BulletedListItem(ColoredTextBlock[BulletedListItemTypeData], type='bullete
     bulleted_list_item: BulletedListItemTypeData = Field(default_factory=BulletedListItemTypeData)
 
 
-class NumberedListItemTypeData(ColoredTextBlockTypeData):
+class NumberedListItemTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `NumberedListItem` block."""
-
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class NumberedListItem(ColoredTextBlock[NumberedListItemTypeData], type='numbered_list_item'):
@@ -303,11 +311,10 @@ class NumberedListItem(ColoredTextBlock[NumberedListItemTypeData], type='numbere
     numbered_list_item: NumberedListItemTypeData = Field(default_factory=NumberedListItemTypeData)
 
 
-class ToDoTypeData(ColoredTextBlockTypeData):
+class ToDoTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `ToDo` block."""
 
     checked: bool = False
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class ToDo(ColoredTextBlock[ToDoTypeData], type='to_do'):
@@ -316,10 +323,8 @@ class ToDo(ColoredTextBlock[ToDoTypeData], type='to_do'):
     to_do: ToDoTypeData = Field(default_factory=ToDoTypeData)
 
 
-class ToggleTypeData(ColoredTextBlockTypeData):
+class ToggleTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `Toggle` block."""
-
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class Toggle(ColoredTextBlock[ToggleTypeData], type='toggle'):
@@ -474,12 +479,13 @@ class ChildDatabase(Block[ChildDatabaseTypeData], type='child_database'):
     child_database: ChildDatabaseTypeData
 
 
-class ColumnTypeData(GenericObject):
-    """Type data for `Column` block."""
+class ColumnTypeData(WithChildren[Block]):
+    """Type data for `Column` block.
 
-    # note that children will not be populated when getting this block
-    # https://developers.notion.com/changelog/column-list-and-column-support
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
+    Note that `children` will not be populated when getting this block.
+    See https://developers.notion.com/changelog/column-list-and-column-support
+    """
+
     width_ratio: float | None = None
 
 
@@ -493,11 +499,13 @@ class Column(Block[ColumnTypeData], type='column'):
         return Column.model_construct(column=ColumnTypeData.model_construct(children=[], width_ratio=width_ratio))
 
 
-class ColumnListTypeData(GenericObject):
-    """Type data for `ColumnList` block."""
+class ColumnListTypeData(WithChildren[Column]):
+    """Type data for `ColumnList` block.
 
-    # note that children will not be populated when getting this block
-    # https://developers.notion.com/changelog/column-list-and-column-support
+    Note that `children` will not be populated when getting this block.
+    See https://developers.notion.com/changelog/column-list-and-column-support
+    """
+
     children: list[Column] = Field(default_factory=list)
 
 
@@ -523,14 +531,16 @@ class TableRow(Block[TableRowTypeData], type='table_row'):
         return TableRow.model_construct(table_row=TableRowTypeData.model_construct(cells=[[] for _ in range(n_cells)]))
 
 
-class TableTypeData(GenericObject):
-    """Type data for `Table` block."""
+class TableTypeData(WithChildren[TableRow]):
+    """Type data for `Table` block.
+
+    Note that `children` will not be populated when getting this block.
+    See https://developers.notion.com/reference/block#table-blocks
+    """
 
     table_width: int = 0
     has_column_header: bool = False
     has_row_header: bool = False
-    # note that children will not be populated when getting this block
-    # https://developers.notion.com/reference/block#table-blocks
     children: list[TableRow] = Field(default_factory=list)
 
 
@@ -546,11 +556,10 @@ class LinkToPage(Block[ParentRef], type='link_to_page'):
     link_to_page: SerializeAsAny[ParentRef]
 
 
-class SyncedBlockTypeData(GenericObject):
+class SyncedBlockTypeData(WithChildren[Block]):
     """Type data for `SyncedBlock` block."""
 
     synced_from: BlockRef | None = None
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class SyncedBlock(Block[SyncedBlockTypeData], type='synced_block'):
@@ -567,10 +576,8 @@ class SyncedBlock(Block[SyncedBlockTypeData], type='synced_block'):
         return model_data
 
 
-class TemplateTypeData(TextBlockTypeData):
+class TemplateTypeData(TextBlockTypeData, WithChildren[Block]):
     """Type data for `Template` block."""
-
-    children: list[SerializeAsAny[Block]] = Field(default_factory=list)
 
 
 class Template(TextBlock[TemplateTypeData], type='template'):


### PR DESCRIPTION
## Description

Removes the `# type: ignore[attr-defined]` in the block children cache by fixing the root cause: a new generic `WithChildren` mixin now serves as a common base for all block type-data classes that carry child blocks, replacing per-class `children` field declarations. With this shared base, the children-cache population, `ParentBlock.wrap_obj_ref`, and `_build_obj_ref` narrow the nested `value` via `isinstance(..., WithChildren)` instead of `hasattr`, which type checkers can follow — also eliminating four pre-existing pyright errors on the same `hasattr` pattern. `ColumnList`/`Table` retain their narrower child types (`WithChildren[Column]`/`WithChildren[TableRow]`). No runtime behavior change.

### Types of change

Internal refactor / type-checking improvement (no functional change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)