### PR TITLE
Type object field as str | None to drop a bare type: ignore

### DIFF
--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -306,7 +306,7 @@ class NotionObject(UniqueObject):
     defines the general object type, e.g. `page`, `database`, `user`, `block`, ...
     """
 
-    object: str = Field(default=None)  # type: ignore # avoids mypy plugin errors as this is set in __init_subclass__
+    object: str | None = Field(default=None)
     """`object` is a string that identifies the general object type, e.g. `page`, `database`, `user`, `block`, ..."""
 
     request_id: UUID | None = None


### PR DESCRIPTION
## Description

Removes a bare `# type: ignore` on the `object` field of `NotionObject` (`obj_api/core.py`) by fixing the root cause: the annotation was inaccurate. The field is `None` on the abstract base and a real `str` on concrete subclasses (the default is set via `_set_field_default` in `__pydantic_init_subclass__`), so `str | None` honestly reflects its runtime values. The `Field(default=None)` is retained because the pydantic mypy plugin requires a default to avoid making `object` a required constructor argument everywhere. There is no behavioral change — `mypy` passes and concrete subclasses still resolve their string default and serialize unchanged.

### Types of change

Code quality / typing fix (removes a suppressed type error).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.