### PR TITLE
Type TypedObject.type as str | None to drop bare type: ignore

### DIFF
--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -419,7 +419,7 @@ class TypedObject(GenericObject, Generic[TO_co]):
         }
     """
 
-    type: str = Field(default=None)  # type: ignore  # avoids mypy errors as this is set in __pydantic_init_subclass__
+    type: str | None = Field(default=None)
     """`type` is a string that identifies the specific object type, e.g. `heading_1`, `paragraph`, `equation`, ..."""
     _polymorphic_base: ClassVar[bool] = False
     _typemap: ClassVar[dict[str, builtins.type[TypedObject]]]
@@ -512,9 +512,17 @@ class TypedObject(GenericObject, Generic[TO_co]):
         return cls(*args, **kwargs)
 
     @property
+    def _type_name(self) -> str:
+        """Return the registered `type` name, which is always a string on concrete subclasses."""
+        if self.type is None:
+            msg = f"'type' is not set on {type(self).__name__}; it is only set on concrete subclasses"
+            raise ValueError(msg)
+        return self.type
+
+    @property
     def value(self) -> TO_co:
         """Return the nested object."""
-        return cast(TO_co, getattr(self, self.type))
+        return cast(TO_co, getattr(self, self._type_name))
 
     @value.setter
     def value(self, val: TO_co) -> None:  # type: ignore[misc]  # breaking covariance
@@ -522,7 +530,7 @@ class TypedObject(GenericObject, Generic[TO_co]):
         # we are breaking covariance here but going down the Protocol way didn't work out
         # either due to many limititations, e.g. @runtime_checkable not working with inheritance, etc.
         # This is still the most programmatic way it seems without adding too much complexity.
-        setattr(self, self.type, val)
+        setattr(self, self._type_name, val)
 
 
 class ParentRef(TypedObject[T], ABC, polymorphic_base=True):

--- a/src/ultimate_notion/obj_api/endpoints.py
+++ b/src/ultimate_notion/obj_api/endpoints.py
@@ -171,8 +171,9 @@ class BlocksEndpoint(Endpoint):
         if isinstance(block, FileBase):
             # The Notiopn API does not support setting a new typed FileObject, e.g. `external` or `file`
             # It even must be removed from the params
-            dtype = params[block.type].pop('type')
-            del params[block.type][dtype]
+            block_type = block._type_name
+            dtype = params[block_type].pop('type')
+            del params[block_type][dtype]
 
         # Typing in notion_client sucks, so we cast
         data = cast(dict[str, Any], self.raw_api.update(block_id.hex, **params))

--- a/src/ultimate_notion/props.py
+++ b/src/ultimate_notion/props.py
@@ -310,7 +310,7 @@ class Formula(PropertyValue[obj_props.Formula], wraps=obj_props.Formula):
     @property
     def value_type(self) -> FormulaType | None:
         """Return the type of the formula result."""
-        return FormulaType(self.obj_ref.formula.type) if self.obj_ref.formula else None
+        return FormulaType(self.obj_ref.formula._type_name) if self.obj_ref.formula else None
 
 
 class Rollup(PropertyValue[obj_props.Rollup], wraps=obj_props.Rollup):

--- a/src/ultimate_notion/rich_text.py
+++ b/src/ultimate_notion/rich_text.py
@@ -135,7 +135,7 @@ class Mention(RichTextBase[objs.MentionObject], wraps=objs.MentionObject):
     @property
     def type(self) -> str:
         """Type of the mention, e.g. user, page, etc."""
-        return self.obj_ref.mention.type
+        return self.obj_ref.mention._type_name
 
 
 def mention(

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -206,7 +206,7 @@ class Property(Wrapper[GO_co], ABC, wraps=PropertyGO):
     @property
     def prop_value(self) -> type[PropertyValue]:
         """Return the corresponding property value of this property."""
-        return PropertyValue._type_value_map[self.obj_ref.type]
+        return PropertyValue._type_value_map[self.obj_ref._type_name]
 
     @property
     def readonly(self) -> bool:


### PR DESCRIPTION
## Description

The `type` field on `TypedObject` carried a bare `# type: ignore` masking an `[assignment]` error (`None` is not assignable to `str`); the annotation was inaccurate, since the field is `None` on the abstract polymorphic base and a real `str` on concrete subclasses, so it is now typed `str | None`, mirroring the earlier `object`-field fix (#204). A new `_type_name` property narrows `str | None` to `str` for the call sites that index by the type name — `value`/`value.setter`, `BlocksEndpoint.update`, `Property.prop_value`, `Mention.type`, and `Formula.value_type` — raising a clear `ValueError` if it is unexpectedly `None` (which never happens on a concrete instance) instead of the previous opaque `getattr(self, None)` `TypeError`. This is a typing-only change with no behavioral change for real usage; mypy reports the identical error set before and after.

### Types of change

Internal type-safety cleanup (removes a `# type: ignore`), no functional change.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)