### PR TITLE
Drop metaclass type: ignore by moving to_list onto OptionNSType

### DIFF
--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -67,23 +67,25 @@ class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
 
 
 class OptionNSType(type):
-    """Metaclass to implement `len` for type `OptionNS` itself, not an instance of it."""
+    """Metaclass providing class-level operations for `OptionNS` namespaces.
 
-    # ToDo: When mypy is smart enough to understand metaclasses, we can remove the `type: ignore` comments.
+    These operate on the namespace class itself, not on instances of it, so they live on the
+    metaclass. Typing the receiver this way (rather than annotating `cls` as `type[OptionNS]`)
+    lets mypy resolve the methods without a `type: ignore`.
+    """
 
-    def __len__(cls: type[OptionNS]) -> int:  # type: ignore[misc]
+    def to_list(cls) -> list[Option]:
+        """Convert the namespace to a list as needed by the (Multi)Select property types."""
+        return [
+            getattr(cls, var) for var in cls.__dict__ if not var.startswith('__') and not callable(getattr(cls, var))
+        ]
+
+    def __len__(cls) -> int:
         return len(cls.to_list())
 
 
 class OptionNS(metaclass=OptionNSType):
     """Option namespace to simplify working with (Multi-)Select options."""
-
-    @classmethod
-    def to_list(cls) -> list[Option]:
-        """Convert the enum to a list as needed by the (Multi)Select property types."""
-        return [
-            getattr(cls, var) for var in cls.__dict__ if not var.startswith('__') and not callable(getattr(cls, var))
-        ]
 
 
 class OptionGroup(Wrapper[objs.SelectGroup], wraps=objs.SelectGroup):


### PR DESCRIPTION
## Description

The `OptionNSType.__len__` metaclass method annotated its receiver as `cls: type[OptionNS]` so its body could call `cls.to_list()`, but mypy requires a method's receiver to be a supertype of the containing class (the metaclass itself), so this raised a `[misc]` "Self argument missing" error masked by a `# type: ignore` and an outdated ToDo. Since both `__len__` and `to_list` operate on the namespace class itself rather than on instances, this moves `to_list` from a `@classmethod` on `OptionNS` onto the `OptionNSType` metaclass, which lets mypy infer `cls` correctly and resolve the call without the ignore, the inaccurate annotation, or the ToDo. Public behaviour (`MyOptions.to_list()`, `len(MyOptions)`, and the `type[OptionNS]` call sites in `schema.py`) is unchanged, and mypy/ruff pass.

### Types of change

Code quality / typing fix (removes a `type: ignore` at its root cause). No functional or documentation changes.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.