### PR TITLE
[codex] Remove file upload type ignore

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -44,7 +44,8 @@ def test_import_url(root_page: uno.Page, notion: uno.Session) -> None:
     assert uploaded_file.expiry_time is not None
     assert uploaded_file.status == uno.FileUploadStatus.UPLOADED
     assert uploaded_file.content_type == 'application/mp4'
-    assert uploaded_file.content_length >= 20_000_000  # type: ignore[operator]
+    assert uploaded_file.content_length is not None
+    assert uploaded_file.content_length >= 20_000_000
 
 
 @pytest.mark.file_upload


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description
Removes a `type: ignore[operator]` from the file import test by explicitly asserting that `content_length` is present before comparing it.
This keeps the public `UploadedFile.content_length` optional type intact while documenting the expected API response for successful URL imports.
Validated with `hatch run lint:typing tests/test_file.py` and `hatch run lint:style tests/test_file.py`.

### Types of change
Test typing cleanup.

## Checklist
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
