### PR TITLE
Remove redundant GenericObject hash ignore

### DIFF
--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -153,7 +153,6 @@ def extract_id(text: str) -> str | None:
 class GenericObject(BaseModel):
     """The base for all API objects."""
 
-    __hash__: ClassVar[None] = None  # type: ignore[assignment]
     _frozen: bool = False  # for computing hash and equality
     model_config = ConfigDict(extra='ignore' if is_stable_release() else 'forbid')
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description
Remove the explicit `__hash__: ClassVar[None] = None` assignment from `GenericObject`, since Python already makes the class unhashable when it defines `__eq__` without `__hash__`.
This keeps low-level objects unhashable while removing an unnecessary `type: ignore[assignment]`.

Validation: `uv run --with mypy==1.18.2 --with pydantic mypy src/ultimate_notion/obj_api/core.py`, `uv run --with ruff==0.14.5 ruff check src/ultimate_notion/obj_api/core.py`, and a runtime check that `hash(SelectOption(...))` still raises `TypeError`.
Targeted pytest setup could not complete in this workspace because no Notion token is configured.

### Types of change
Typing cleanup / maintenance.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
