### PR TITLE
Drop metaclass type: ignores by moving get_props onto SchemaType

### DIFF
--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -782,6 +782,11 @@ class SchemaType(ABCMeta):
     letting it behave like a dictionary for the properties although it is a class, not an instance.
     """
 
+    # The properties live on the schema class itself, so `_props` and the methods operating on it
+    # belong on the metaclass. Defining them here (rather than annotating `cls` as `type[Schema]`
+    # on instance-less metaclass methods) lets mypy resolve them without a `type: ignore`.
+    _props: list[Property]
+
     # ToDo: When mypy is smart enough to understand metaclasses, we can remove the `type: ignore` comments
     def __new__(metacls, name: str, bases: tuple[type, ...], namespace: dict[str, object], **kwargs: Any) -> SchemaType:
         # This collects all schema properties under `_props`. Using __prepare__ doesn't work as referencing
@@ -805,6 +810,10 @@ class SchemaType(ABCMeta):
             prop._owner = cast(type[Schema], cls)
 
         return cls
+
+    def get_props(cls) -> list[Property]:
+        """Get all properties of this schema."""
+        return cls._props
 
     def __str__(cls: type[Schema]) -> str:  # type: ignore[misc]
         # We can only overwrite __str__ for a class in a metaclass
@@ -844,7 +853,7 @@ class SchemaType(ABCMeta):
         if isinstance(prop_type, Relation) and (prop_type._two_way_prop is not None):
             prop_type._rename_two_way_prop(prop if isinstance(prop := prop_type._two_way_prop, str) else prop.name)
 
-    def __getattr__(cls: type[Schema], name: str) -> Property:  # type: ignore[misc]
+    def __getattr__(cls, name: str) -> Property:
         attr_name_props = SList([prop for prop in cls.get_props() if prop._attr_name == name])
         try:
             return attr_name_props.item()
@@ -880,10 +889,10 @@ class SchemaType(ABCMeta):
         else:
             super().__setattr__(name, value)  # type: ignore[misc]  # no clue why this results in a type problem
 
-    def __len__(cls: type[Schema]) -> int:  # type: ignore[misc]
+    def __len__(cls) -> int:
         return len(cls.get_props())
 
-    def __iter__(cls: type[Schema]) -> Iterator[Property]:  # type: ignore[misc]
+    def __iter__(cls) -> Iterator[Property]:
         return (prop for prop in cls.get_props())
 
 
@@ -955,11 +964,6 @@ class Schema(metaclass=SchemaType):
     def create(cls, **kwargs: Any) -> Page:
         """Create a page using this schema with a bound database."""
         return cls.get_db().create_page(**kwargs)
-
-    @classmethod
-    def get_props(cls) -> list[Property]:
-        """Get all properties of this schema."""
-        return cls._props
 
     @overload
     @classmethod


### PR DESCRIPTION
## Description

The `SchemaType.__len__`, `__iter__`, and `__getattr__` metaclass methods annotated their receiver as `cls: type[Schema]` so their bodies could call `cls.get_props()`, but mypy requires that receiver to be a supertype of the containing metaclass, producing `[misc]` "Self argument missing" errors that were suppressed with `type: ignore`. Since `get_props` operates on the schema class itself (not on instances), it belongs on the metaclass: moving it from a `@classmethod` on `Schema` onto `SchemaType` and declaring `_props` there lets mypy infer `cls` as the metaclass instance and resolve `get_props` without the ignore or the inaccurate annotation — no `cast`, `__mro__`, or `getattr` hacks. This removes three `type: ignore[misc]` comments; public behaviour (`Schema.get_props()`, `len(MySchema)`, iteration, attribute access) is unchanged. Verified with `mypy` (no new errors), `ruff`, and a runtime check of all affected operations.

### Types of change

Internal type-checking cleanup (no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.