### PR TITLE
Make Notion test workspaces portable and bootstrap-ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ tags
 *.eggs/
 .installed.cfg
 *.egg-info
+# Hatch uses the committed locks/*.lock files.
+uv.lock
 
 # Unittest and coverage
 htmlcov/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: Add support for `pydantic` 2.13, which previously broke parsing of Notion user objects (e.g. people properties), issue #189.
+- Fix: Accept the new `is_archived` field the Notion API sends on pages and databases, which previously broke `search_page()`/`search_db()` in development mode, issue #202.
 
 ## Version 0.9.6, 2025-11-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Add support for `pydantic` 2.13, which previously broke parsing of Notion user objects (e.g. people properties), issue #189.
 - Fix: Accept the new `is_archived` field the Notion API sends on pages and databases, which previously broke `search_page()`/`search_db()` in development mode, issue #202.
+- Fix: Accept the nullable `icon` field returned for paragraph blocks and omit read-only archive fields when creating blocks.
 
 ## Version 0.9.6, 2025-11-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,48 @@ This often provides additional considerations and avoids unnecessary work.
    ```
    These settings will also be respected by [pytest] using [pytest-dotenv].
 
+### Set up a Notion test workspace
+
+Most tests replay recorded HTTP interactions (VCR cassettes) and need no network
+access — run them with `hatch run vcr-only`. You only need your own Notion
+workspace and integration token if you want to **run the tests live** against the
+Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
+
+1. **Create an internal integration.** Open [My integrations] and click
+   *New integration*. Choose **Internal**, associate it with the workspace you
+   want to use for testing, and give it a name.
+
+2. **Enable the required capabilities.** On the integration's *Capabilities* tab
+   enable:
+   - **Read**, **Update** and **Insert** content — the tests create, modify and
+     delete pages and databases.
+   - A **Read user information** option (with or without email addresses is fine).
+     This is **required**: several tests call `Session.all_users()`, which Notion
+     rejects with `403 "Personal access tokens cannot list users."` for tokens
+     that lack this capability. For the same reason you must use an **internal
+     integration token**, not a personal access token — the latter can never list
+     users.
+
+3. **Copy the token.** From the integration's *Configuration* page copy the
+   *Internal Integration Secret*. It looks like `ntn_…`.
+
+4. **Create and share a root page.** In your test workspace create a page that
+   acts as the parent for all test content, then connect your integration to it
+   via the page's ••• menu → *Connections*. Sharing the parent grants the
+   integration access to everything created beneath it.
+
+5. **Point the configuration at the token.** Set `NOTION_TOKEN` to the secret
+   from step 3 (see the `.vscode/.env` example above); the Ultimate Notion config
+   resolves the token from this environment variable by default.
+
+!!! note
+    Running the full suite live currently also expects a set of manually created
+    objects in the workspace (a root page named `Tests`, databases such as
+    `All Properties DB`, `Wiki DB`, `Contacts DB`, `Task DB` and `Formula DB`, and
+    several content pages). Removing this hard-coded, workspace-specific setup so
+    that any maintainer can re-record cassettes is tracked in
+    [issue #194](https://github.com/ultimate-notion/ultimate-notion/issues/194).
+
 ### Implement your changes
 
 1. Create a branch to hold your changes:
@@ -169,3 +211,4 @@ This often provides additional considerations and avoids unnecessary work.
 [VS Code]: https://code.visualstudio.com/
 [GitHub's code editor]: https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files
 [mkdocs]: https://www.mkdocs.org/
+[My integrations]: https://www.notion.so/my-integrations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,17 +129,18 @@ Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
    from step 3 (see the `.vscode/.env` example above); the Ultimate Notion config
    resolves the token from this environment variable by default.
 
+6. **Bootstrap the API-creatable objects.** Run:
+
+   ```console
+   UNO_TEST_ROOT_PAGE='My Test Root' hatch run bootstrap-test-workspace
+   ```
+
+   The command is idempotent and leaves existing objects unchanged.
+
 !!! note
-    Running the full suite live currently also expects a set of manually created
-    objects in the workspace (a root page named `Tests`, databases such as
-    `All Properties DB`, `Wiki DB`, `Contacts DB`, `Task DB` and `Formula DB`, and
-    several content pages). Most of these can be created with the API, but three
-    (`All Properties DB`, `Wiki DB` and the `Custom Emoji Page`) use features the API
-    cannot create and must be built by hand — see
+    Three objects (`All Properties DB`, `Wiki DB` and the `Custom Emoji Page`) use
+    features the API cannot create and must be built by hand — see
     [`tests/TEST_WORKSPACE.md`](tests/TEST_WORKSPACE.md) for exact instructions.
-    Removing this hard-coded, workspace-specific setup so that any maintainer can
-    re-record cassettes is tracked in
-    [issue #194](https://github.com/ultimate-notion/ultimate-notion/issues/194).
 
 ### Implement your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,8 +133,12 @@ Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
     Running the full suite live currently also expects a set of manually created
     objects in the workspace (a root page named `Tests`, databases such as
     `All Properties DB`, `Wiki DB`, `Contacts DB`, `Task DB` and `Formula DB`, and
-    several content pages). Removing this hard-coded, workspace-specific setup so
-    that any maintainer can re-record cassettes is tracked in
+    several content pages). Most of these can be created with the API, but three
+    (`All Properties DB`, `Wiki DB` and the `Custom Emoji Page`) use features the API
+    cannot create and must be built by hand — see
+    [`tests/TEST_WORKSPACE.md`](tests/TEST_WORKSPACE.md) for exact instructions.
+    Removing this hard-coded, workspace-specific setup so that any maintainer can
+    re-record cassettes is tracked in
     [issue #194](https://github.com/ultimate-notion/ultimate-notion/issues/194).
 
 ### Implement your changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,9 @@ Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
 4. **Create and share a root page.** In your test workspace create a page that
    acts as the parent for all test content, then connect your integration to it
    via the page's ••• menu → *Connections*. Sharing the parent grants the
-   integration access to everything created beneath it.
+   integration access to everything created beneath it. By default the suite
+   looks for a page titled `Tests`; set the `UNO_TEST_ROOT_PAGE` environment
+   variable to point it at a page with a different title.
 
 5. **Point the configuration at the token.** Set `NOTION_TOKEN` to the secret
    from step 3 (see the `.vscode/.env` example above); the Ultimate Notion config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ This often provides additional considerations and avoids unnecessary work.
 ### Set up a Notion test workspace
 
 Most tests replay recorded HTTP interactions (VCR cassettes) and need no network
-access — run them with `hatch run vcr-only`. You only need your own Notion
+access; run them with `hatch run vcr-only`. You only need your own Notion
 workspace and integration token if you want to **run the tests live** against the
 Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
 
@@ -106,13 +106,13 @@ Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
 
 2. **Enable the required capabilities.** On the integration's *Capabilities* tab
    enable:
-   - **Read**, **Update** and **Insert** content — the tests create, modify and
+   - **Read**, **Update** and **Insert** content, because the tests create, modify and
      delete pages and databases.
    - A **Read user information** option (with or without email addresses is fine).
      This is **required**: several tests call `Session.all_users()`, which Notion
      rejects with `403 "Personal access tokens cannot list users."` for tokens
      that lack this capability. For the same reason you must use an **internal
-     integration token**, not a personal access token — the latter can never list
+     integration token**, not a personal access token. The latter can never list
      users.
 
 3. **Copy the token.** From the integration's *Configuration* page copy the
@@ -139,7 +139,7 @@ Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
 
 !!! note
     Three objects (`All Properties DB`, `Wiki DB` and the `Custom Emoji Page`) use
-    features the API cannot create and must be built by hand — see
+    features the API cannot create and must be built by hand. See
     [`tests/TEST_WORKSPACE.md`](tests/TEST_WORKSPACE.md) for exact instructions.
 
 ### Implement your changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,7 +264,6 @@ ban-relative-imports = "all"
 [tool.ruff.lint.per-file-ignores]
 # Allow print/pprint
 "examples/*" = ["T201"]
-"scripts/*" = ["T201"]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,7 @@ ban-relative-imports = "all"
 [tool.ruff.lint.per-file-ignores]
 # Allow print/pprint
 "examples/*" = ["T201"]
+"scripts/*" = ["T201"]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 
@@ -318,6 +319,7 @@ vcr-off = "test --disable-recording {args}"
 vcr-only = "test --record-mode=none --block-network {args}"
 vcr-rewrite = "test --record-mode=rewrite {args}"
 vcr-drop-cassettes = "find ./tests -type d -name 'cassettes' -exec rm -rf {{}} +"
+bootstrap-test-workspace = "python scripts/bootstrap_test_workspace.py {args}"
 test-release = "vcr-off --check-latest-release {args}"
 ci = "vcr-only --cov-report lcov {args} --debug-uno"
 doctest = "pytest docs/examples/"

--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -10,6 +10,7 @@ import os
 import time
 from typing import Any
 
+import typer
 from notion_client import Client
 
 DEFAULT_ROOT_TITLE = 'Tests'
@@ -89,7 +90,7 @@ class Bootstrap:
         children: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         if page := self.find_exact(title, 'page'):
-            print(f'page exists: {title}')
+            typer.echo(f'page exists: {title}')
             return page
         page = sync_object(
             self.client.pages.create(
@@ -98,7 +99,7 @@ class Bootstrap:
                 children=children or [],
             ),
         )
-        print(f'created page: {title}')
+        typer.echo(f'created page: {title}')
         time.sleep(0.4)
         return page
 
@@ -111,7 +112,7 @@ class Bootstrap:
         icon: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if database := self.find_exact(title, 'database'):
-            print(f'database exists: {title}')
+            typer.echo(f'database exists: {title}')
             return database
         kwargs: dict[str, Any] = {
             'parent': {'page_id': self.root['id']},
@@ -123,7 +124,7 @@ class Bootstrap:
         if icon is not None:
             kwargs['icon'] = icon
         database = sync_object(self.client.databases.create(**kwargs))
-        print(f'created database: {title}')
+        typer.echo(f'created database: {title}')
         time.sleep(0.7)
         return database
 
@@ -147,10 +148,10 @@ class Bootstrap:
 
     def ensure_wiki_shell(self) -> None:
         if self.find_exact('Wiki DB', 'database'):
-            print('wiki exists: Wiki DB')
+            typer.echo('wiki exists: Wiki DB')
             return
         self.create_page('Wiki DB')
-        print('manual step: open the Wiki DB page and select ... -> Turn into wiki')
+        typer.echo('manual step: open the Wiki DB page and select ... -> Turn into wiki')
 
     def ensure_contacts_db(self) -> None:
         database = self.create_database(
@@ -183,7 +184,7 @@ class Bootstrap:
             icon={'type': 'emoji', 'emoji': '🤝'},
         )
         if self.database_rows(database):
-            print('Contacts DB already has rows')
+            typer.echo('Contacts DB already has rows')
             return
         roles = [
             'Project Manager',
@@ -209,7 +210,7 @@ class Bootstrap:
                     'Team Member': {'checkbox': idx % 2 == 0},
                 },
             )
-        print('seeded Contacts DB: 10 rows')
+        typer.echo('seeded Contacts DB: 10 rows')
 
     def ensure_task_db(self) -> None:
         database = self.create_database(
@@ -245,7 +246,7 @@ class Bootstrap:
             description='My personal task list of all the important stuff I have to do',
         )
         if self.database_rows(database):
-            print('Task DB already has rows')
+            typer.echo('Task DB already has rows')
             return
         rows = [
             ('Run first Marathon', 'In Progress', '✹ High', '2026-07-01T12:00:00.000+00:00'),
@@ -263,7 +264,7 @@ class Bootstrap:
                     'Due Date': {'date': {'start': due_date}},
                 },
             )
-        print('seeded Task DB: 3 rows')
+        typer.echo('seeded Task DB: 3 rows')
 
     def ensure_formula_db(self) -> None:
         database = self.create_database(
@@ -286,7 +287,7 @@ class Bootstrap:
             },
         )
         if self.database_rows(database):
-            print('Formula DB already has rows')
+            typer.echo('Formula DB already has rows')
             return
         for title, tags in (('Item 1', ['Done', 'In Progress']), ('Item 2', ['In Progress'])):
             self.create_database_page(
@@ -298,7 +299,7 @@ class Bootstrap:
                     'Date Source': {'date': {'start': '2024-11-25T14:08:00.000+00:00'}},
                 },
             )
-        print('seeded Formula DB: 2 rows')
+        typer.echo('seeded Formula DB: 2 rows')
 
     def ensure_static_pages(self) -> None:
         self.create_page(
@@ -394,7 +395,7 @@ class Bootstrap:
             ('Custom Emoji Page', 'page'),
         ):
             status = 'ready' if self.find_exact(title, kind) else 'manual setup required'
-            print(f'{title}: {status}')
+            typer.echo(f'{title}: {status}')
 
     def run(self) -> None:
         self.ensure_wiki_shell()

--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -4,16 +4,41 @@ The script is idempotent: objects that already exist are left unchanged.
 Set NOTION_TOKEN and share the root page with the integration before running it.
 """
 
-from __future__ import annotations
-
 import argparse
+import inspect
 import os
 import time
-from typing import Any, cast
+from typing import Any
 
 from notion_client import Client
 
 DEFAULT_ROOT_TITLE = 'Tests'
+
+
+def sync_object(response: Any) -> dict[str, Any]:
+    """Validate a JSON object returned by the synchronous Notion client."""
+    if inspect.isawaitable(response):
+        msg = 'The workspace bootstrap requires the synchronous Notion client.'
+        raise TypeError(msg)
+    if not isinstance(response, dict):
+        msg = f'Expected a JSON object from Notion, got {type(response).__name__}.'
+        raise TypeError(msg)
+    return response
+
+
+def object_list(value: Any) -> list[dict[str, Any]]:
+    """Validate a list of JSON objects."""
+    if not isinstance(value, list):
+        msg = f'Expected a JSON array from Notion, got {type(value).__name__}.'
+        raise TypeError(msg)
+
+    result = []
+    for item in value:
+        if not isinstance(item, dict):
+            msg = f'Expected a JSON object in the Notion response, got {type(item).__name__}.'
+            raise TypeError(msg)
+        result.append(item)
+    return result
 
 
 def rich_text(text: str) -> list[dict[str, Any]]:
@@ -40,8 +65,7 @@ class Bootstrap:
         self.root = root
 
     def search_exact(self, title: str, kind: str) -> list[dict[str, Any]]:
-        response = cast(
-            dict[str, Any],
+        response = sync_object(
             self.client.search(
                 query=title,
                 filter={'property': 'object', 'value': kind},
@@ -67,8 +91,7 @@ class Bootstrap:
         if page := self.find_exact(title, 'page'):
             print(f'page exists: {title}')
             return page
-        page = cast(
-            dict[str, Any],
+        page = sync_object(
             self.client.pages.create(
                 parent={'page_id': parent_id or self.root['id']},
                 properties={'title': {'title': rich_text(title)}},
@@ -99,17 +122,16 @@ class Bootstrap:
             kwargs['description'] = rich_text(description)
         if icon is not None:
             kwargs['icon'] = icon
-        database = cast(dict[str, Any], self.client.databases.create(**kwargs))
+        database = sync_object(self.client.databases.create(**kwargs))
         print(f'created database: {title}')
         time.sleep(0.7)
         return database
 
     def database_rows(self, database: dict[str, Any]) -> list[dict[str, Any]]:
-        response = cast(
-            dict[str, Any],
+        response = sync_object(
             self.client.databases.query(database_id=database['id'], page_size=100),
         )
-        return cast(list[dict[str, Any]], response['results'])
+        return object_list(response.get('results'))
 
     def create_database_page(
         self,

--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -1,0 +1,401 @@
+"""Create the API-creatable objects used by the live test suite.
+
+The script is idempotent: objects that already exist are left unchanged.
+Set NOTION_TOKEN and share the root page with the integration before running it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from typing import Any, cast
+
+from notion_client import Client
+
+DEFAULT_ROOT_TITLE = 'Tests'
+
+
+def rich_text(text: str) -> list[dict[str, Any]]:
+    return [{'type': 'text', 'text': {'content': text}}]
+
+
+def title_of(obj: dict[str, Any]) -> str:
+    if obj['object'] == 'database':
+        return ''.join(item.get('plain_text', '') for item in obj.get('title', []))
+    for prop in obj.get('properties', {}).values():
+        if prop.get('type') == 'title':
+            return ''.join(item.get('plain_text', '') for item in prop.get('title', []))
+    return ''
+
+
+class Bootstrap:
+    def __init__(self, client: Client, root_title: str) -> None:
+        self.client = client
+        self.root_title = root_title
+        root = self.find_exact(root_title, 'page')
+        if root is None:
+            msg = f'Root page {root_title!r} was not found. Share it with the integration first.'
+            raise RuntimeError(msg)
+        self.root = root
+
+    def search_exact(self, title: str, kind: str) -> list[dict[str, Any]]:
+        response = cast(
+            dict[str, Any],
+            self.client.search(
+                query=title,
+                filter={'property': 'object', 'value': kind},
+                page_size=100,
+            ),
+        )
+        return [obj for obj in response['results'] if title_of(obj) == title]
+
+    def find_exact(self, title: str, kind: str) -> dict[str, Any] | None:
+        matches = self.search_exact(title, kind)
+        if len(matches) > 1:
+            msg = f'Found multiple {kind}s titled {title!r}; remove duplicates before bootstrapping.'
+            raise RuntimeError(msg)
+        return matches[0] if matches else None
+
+    def create_page(
+        self,
+        title: str,
+        *,
+        parent_id: str | None = None,
+        children: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        if page := self.find_exact(title, 'page'):
+            print(f'page exists: {title}')
+            return page
+        page = cast(
+            dict[str, Any],
+            self.client.pages.create(
+                parent={'page_id': parent_id or self.root['id']},
+                properties={'title': {'title': rich_text(title)}},
+                children=children or [],
+            ),
+        )
+        print(f'created page: {title}')
+        time.sleep(0.4)
+        return page
+
+    def create_database(
+        self,
+        title: str,
+        properties: dict[str, Any],
+        *,
+        description: str | None = None,
+        icon: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if database := self.find_exact(title, 'database'):
+            print(f'database exists: {title}')
+            return database
+        kwargs: dict[str, Any] = {
+            'parent': {'page_id': self.root['id']},
+            'title': rich_text(title),
+            'properties': properties,
+        }
+        if description is not None:
+            kwargs['description'] = rich_text(description)
+        if icon is not None:
+            kwargs['icon'] = icon
+        database = cast(dict[str, Any], self.client.databases.create(**kwargs))
+        print(f'created database: {title}')
+        time.sleep(0.7)
+        return database
+
+    def database_rows(self, database: dict[str, Any]) -> list[dict[str, Any]]:
+        response = cast(
+            dict[str, Any],
+            self.client.databases.query(database_id=database['id'], page_size=100),
+        )
+        return cast(list[dict[str, Any]], response['results'])
+
+    def create_database_page(
+        self,
+        database: dict[str, Any],
+        title_prop: str,
+        title: str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        values = {title_prop: {'title': rich_text(title)}}
+        values.update(properties or {})
+        self.client.pages.create(parent={'database_id': database['id']}, properties=values)
+        time.sleep(0.25)
+
+    def ensure_wiki_shell(self) -> None:
+        if self.find_exact('Wiki DB', 'database'):
+            print('wiki exists: Wiki DB')
+            return
+        self.create_page('Wiki DB')
+        print('manual step: open the Wiki DB page and select ... -> Turn into wiki')
+
+    def ensure_contacts_db(self) -> None:
+        database = self.create_database(
+            'Contacts DB',
+            {
+                'Name': {'title': {}},
+                'Title': {'rich_text': {}, 'description': 'Title within the company'},
+                'Role': {
+                    'select': {
+                        'options': [
+                            {'name': 'Project Manager', 'color': 'green'},
+                            {'name': 'Software Engineer', 'color': 'gray'},
+                            {'name': 'UX Designer', 'color': 'red'},
+                            {'name': 'Marketing Manager', 'color': 'orange'},
+                            {'name': 'Data Analyst', 'color': 'blue'},
+                            {'name': 'QA Engineer', 'color': 'default'},
+                            {'name': 'Technical Writer', 'color': 'pink'},
+                            {'name': 'Business Analyst', 'color': 'purple'},
+                            {'name': 'IT Support Specialist', 'color': 'yellow'},
+                        ]
+                    }
+                },
+                'Email': {'email': {}},
+                'Phone': {'phone_number': {}},
+                'URL': {'url': {}},
+                'Team Member': {'checkbox': {}},
+                'Sync Date': {'date': {}},
+            },
+            description='Database of all my contacts!',
+            icon={'type': 'emoji', 'emoji': '🤝'},
+        )
+        if self.database_rows(database):
+            print('Contacts DB already has rows')
+            return
+        roles = [
+            'Project Manager',
+            'Software Engineer',
+            'UX Designer',
+            'Marketing Manager',
+            'Data Analyst',
+            'QA Engineer',
+            'Technical Writer',
+            'Business Analyst',
+            'IT Support Specialist',
+            'Software Engineer',
+        ]
+        for idx, role in enumerate(roles, 1):
+            self.create_database_page(
+                database,
+                'Name',
+                f'Contact {idx}',
+                {
+                    'Title': {'rich_text': rich_text(f'Title {idx}')},
+                    'Role': {'select': {'name': role}},
+                    'Email': {'email': f'contact{idx}@example.com'},
+                    'Team Member': {'checkbox': idx % 2 == 0},
+                },
+            )
+        print('seeded Contacts DB: 10 rows')
+
+    def ensure_task_db(self) -> None:
+        database = self.create_database(
+            'Task DB',
+            {
+                'Task': {'title': {}},
+                'Status': {
+                    'status': {
+                        'options': [
+                            {'name': 'Backlog', 'color': 'gray'},
+                            {'name': 'Blocked', 'color': 'red'},
+                            {'name': 'In Progress', 'color': 'blue'},
+                            {'name': 'Done', 'color': 'green'},
+                        ]
+                    }
+                },
+                'Due Date': {'date': {}},
+                'Priority': {
+                    'select': {
+                        'options': [
+                            {'name': '✹ High', 'color': 'red'},
+                            {'name': '✷ Medium', 'color': 'yellow'},
+                            {'name': '✶ Low', 'color': 'gray'},
+                        ]
+                    }
+                },
+                'Urgency': {
+                    'formula': {
+                        'expression': 'if(prop("Status") == "Done", "✅", if(empty(prop("Due Date")), "", "🕘"))'
+                    }
+                },
+            },
+            description='My personal task list of all the important stuff I have to do',
+        )
+        if self.database_rows(database):
+            print('Task DB already has rows')
+            return
+        rows = [
+            ('Run first Marathon', 'In Progress', '✹ High', '2026-07-01T12:00:00.000+00:00'),
+            ('Buy milk', 'Backlog', '✶ Low', '2026-07-02T12:00:00.000+00:00'),
+            ('Ship release', 'Done', '✷ Medium', '2026-06-18T12:00:00.000+00:00'),
+        ]
+        for name, status, priority, due_date in rows:
+            self.create_database_page(
+                database,
+                'Task',
+                name,
+                {
+                    'Status': {'status': {'name': status}},
+                    'Priority': {'select': {'name': priority}},
+                    'Due Date': {'date': {'start': due_date}},
+                },
+            )
+        print('seeded Task DB: 3 rows')
+
+    def ensure_formula_db(self) -> None:
+        database = self.create_database(
+            'Formula DB',
+            {
+                'Name': {'title': {}},
+                'Tags': {
+                    'multi_select': {
+                        'options': [
+                            {'name': 'In Progress', 'color': 'pink'},
+                            {'name': 'Done', 'color': 'gray'},
+                        ]
+                    }
+                },
+                'Date Source': {'date': {}},
+                'String': {'formula': {'expression': 'format(prop("Name"))'}},
+                'Number': {'formula': {'expression': 'prop("Tags").length()'}},
+                'Checkbox': {'formula': {'expression': 'prop("Tags").includes("Done")'}},
+                'Date': {'formula': {'expression': 'prop("Date Source")'}},
+            },
+        )
+        if self.database_rows(database):
+            print('Formula DB already has rows')
+            return
+        for title, tags in (('Item 1', ['Done', 'In Progress']), ('Item 2', ['In Progress'])):
+            self.create_database_page(
+                database,
+                'Name',
+                title,
+                {
+                    'Tags': {'multi_select': [{'name': tag} for tag in tags]},
+                    'Date Source': {'date': {'start': '2024-11-25T14:08:00.000+00:00'}},
+                },
+            )
+        print('seeded Formula DB: 2 rows')
+
+    def ensure_static_pages(self) -> None:
+        self.create_page(
+            'Getting Started',
+            children=[
+                {
+                    'object': 'block',
+                    'type': 'heading_1',
+                    'heading_1': {'rich_text': rich_text('Getting Started'), 'color': 'default'},
+                },
+                {
+                    'object': 'block',
+                    'type': 'paragraph',
+                    'paragraph': {
+                        'rich_text': rich_text('Welcome to the Ultimate Notion test workspace.'),
+                        'color': 'default',
+                    },
+                },
+            ],
+        )
+        self.create_page(
+            'Markdown Text Test',
+            children=[
+                {
+                    'object': 'block',
+                    'type': 'paragraph',
+                    'paragraph': {
+                        'rich_text': rich_text('Markdown rich-text fixture.'),
+                        'color': 'default',
+                    },
+                }
+            ],
+        )
+        markdown_page = self.create_page(
+            'Markdown Test',
+            children=[
+                {
+                    'object': 'block',
+                    'type': 'heading_1',
+                    'heading_1': {'rich_text': rich_text('Headline 1'), 'color': 'default'},
+                }
+            ],
+        )
+        self.create_page(
+            'Markdown SubPage Test',
+            parent_id=markdown_page['id'],
+            children=[
+                {
+                    'object': 'block',
+                    'type': 'paragraph',
+                    'paragraph': {
+                        'rich_text': rich_text('This is the original Paragraph on SubPage'),
+                        'color': 'default',
+                    },
+                }
+            ],
+        )
+        self.create_page(
+            'Embed/Inline/Linked & Unfurl',
+            children=[
+                {'object': 'block', 'type': 'embed', 'embed': {'url': 'https://ultimate-notion.com/'}},
+                {'object': 'block', 'type': 'bookmark', 'bookmark': {'url': 'https://ultimate-notion.com/'}},
+                {
+                    'object': 'block',
+                    'type': 'paragraph',
+                    'paragraph': {
+                        'rich_text': rich_text('Inline link: https://ultimate-notion.com/'),
+                        'color': 'default',
+                    },
+                },
+                {
+                    'object': 'block',
+                    'type': 'paragraph',
+                    'paragraph': {'rich_text': rich_text('Linked database placeholder'), 'color': 'default'},
+                },
+            ],
+        )
+        self.create_page(
+            'Comments',
+            children=[
+                {
+                    'object': 'block',
+                    'type': 'heading_1',
+                    'heading_1': {'rich_text': rich_text('Comments'), 'color': 'default'},
+                }
+            ],
+        )
+
+    def audit_manual_objects(self) -> None:
+        for title, kind in (
+            ('All Properties DB', 'database'),
+            ('Wiki DB', 'database'),
+            ('Custom Emoji Page', 'page'),
+        ):
+            status = 'ready' if self.find_exact(title, kind) else 'manual setup required'
+            print(f'{title}: {status}')
+
+    def run(self) -> None:
+        self.ensure_wiki_shell()
+        self.ensure_contacts_db()
+        self.ensure_task_db()
+        self.ensure_formula_db()
+        self.ensure_static_pages()
+        self.audit_manual_objects()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--root-title',
+        default=os.environ.get('UNO_TEST_ROOT_PAGE', DEFAULT_ROOT_TITLE),
+        help='Title of the root page shared with the integration.',
+    )
+    args = parser.parse_args()
+    token = os.environ.get('NOTION_TOKEN')
+    if not token:
+        parser.error('NOTION_TOKEN must be set')
+    Bootstrap(Client(auth=token), args.root_title).run()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -5,7 +5,6 @@ Set NOTION_TOKEN and share the root page with the integration before running it.
 """
 
 import argparse
-import inspect
 import os
 import time
 from collections.abc import Callable
@@ -14,6 +13,8 @@ from typing import Any, ParamSpec, TypeVar
 import typer
 from notion_client import Client
 from notion_client.errors import HTTPResponseError
+
+import ultimate_notion as uno
 
 DEFAULT_ROOT_TITLE = 'Tests'
 MAX_REQUEST_ATTEMPTS = 5
@@ -39,235 +40,196 @@ def request_with_retry(call: Callable[P, T], *args: P.args, **kwargs: P.kwargs) 
     raise RuntimeError(msg)
 
 
-def sync_object(response: Any) -> dict[str, Any]:
-    """Validate a JSON object returned by the synchronous Notion client."""
-    if inspect.isawaitable(response):
-        msg = 'The workspace bootstrap requires the synchronous Notion client.'
-        raise TypeError(msg)
-    if not isinstance(response, dict):
-        msg = f'Expected a JSON object from Notion, got {type(response).__name__}.'
-        raise TypeError(msg)
-    return response
+class RetryingClient(Client):
+    """Synchronous Notion client that respects rate-limit retry responses."""
+
+    def request(self, *args: Any, **kwargs: Any) -> Any:
+        return request_with_retry(super().request, *args, **kwargs)
 
 
-def object_list(value: Any) -> list[dict[str, Any]]:
-    """Validate a list of JSON objects."""
-    if not isinstance(value, list):
-        msg = f'Expected a JSON array from Notion, got {type(value).__name__}.'
+def json_object(value: Any) -> dict[str, Any]:
+    """Validate a raw JSON object returned by notion-client."""
+    if not isinstance(value, dict):
+        msg = f'Expected a JSON object from Notion, got {type(value).__name__}.'
         raise TypeError(msg)
-
-    result = []
-    for item in value:
-        if not isinstance(item, dict):
-            msg = f'Expected a JSON object in the Notion response, got {type(item).__name__}.'
-            raise TypeError(msg)
-        result.append(item)
-    return result
+    return value
 
 
 def rich_text(text: str) -> list[dict[str, Any]]:
     return [{'type': 'text', 'text': {'content': text}}]
 
 
-def title_of(obj: dict[str, Any]) -> str:
-    if obj['object'] == 'database':
-        return ''.join(item.get('plain_text', '') for item in obj.get('title', []))
-    for prop in obj.get('properties', {}).values():
-        if prop.get('type') == 'title':
-            return ''.join(item.get('plain_text', '') for item in prop.get('title', []))
-    return ''
+class ContactRole(uno.OptionNS):
+    project_manager = uno.Option('Project Manager', color=uno.Color.GREEN)
+    software_engineer = uno.Option('Software Engineer', color=uno.Color.GRAY)
+    ux_designer = uno.Option('UX Designer', color=uno.Color.RED)
+    marketing_manager = uno.Option('Marketing Manager', color=uno.Color.ORANGE)
+    data_analyst = uno.Option('Data Analyst', color=uno.Color.BLUE)
+    qa_engineer = uno.Option('QA Engineer')
+    technical_writer = uno.Option('Technical Writer', color=uno.Color.PINK)
+    business_analyst = uno.Option('Business Analyst', color=uno.Color.PURPLE)
+    it_support_specialist = uno.Option('IT Support Specialist', color=uno.Color.YELLOW)
+
+
+class Contacts(uno.Schema, db_title='Contacts DB'):
+    """Database of all my contacts!"""
+
+    name = uno.PropType.Title('Name')
+    title = uno.PropType.Text('Title', description='Title within the company')
+    role = uno.PropType.Select('Role', options=ContactRole)
+    email = uno.PropType.Email('Email')
+    phone = uno.PropType.Phone('Phone')
+    url = uno.PropType.URL('URL')
+    team_member = uno.PropType.Checkbox('Team Member')
+    sync_date = uno.PropType.Date('Sync Date')
+
+
+class FormulaTag(uno.OptionNS):
+    in_progress = uno.Option('In Progress', color=uno.Color.PINK)
+    done = uno.Option('Done', color=uno.Color.GRAY)
+
+
+class Formulas(uno.Schema, db_title='Formula DB'):
+    name = uno.PropType.Title('Name')
+    tags = uno.PropType.MultiSelect('Tags', options=FormulaTag)
+    date_source = uno.PropType.Date('Date Source')
+    string = uno.PropType.Formula('String', formula='format(prop("Name"))')
+    number = uno.PropType.Formula('Number', formula='prop("Tags").length()')
+    checkbox = uno.PropType.Formula('Checkbox', formula='prop("Tags").includes("Done")')
+    date = uno.PropType.Formula('Date', formula='prop("Date Source")')
 
 
 class Bootstrap:
-    def __init__(self, client: Client, root_title: str) -> None:
-        self.client = client
-        self.root_title = root_title
-        root = self.find_exact(root_title, 'page')
+    def __init__(self, notion: uno.Session, root_title: str) -> None:
+        self.notion = notion
+        self.client = notion.client
+        root = self.find_page(root_title)
         if root is None:
             msg = f'Root page {root_title!r} was not found. Share it with the integration first.'
             raise RuntimeError(msg)
         self.root = root
 
-    def search_exact(self, title: str, kind: str) -> list[dict[str, Any]]:
-        response = sync_object(
-            request_with_retry(
-                self.client.search,
-                query=title,
-                filter={'property': 'object', 'value': kind},
-                page_size=100,
-            ),
-        )
-        return [obj for obj in response['results'] if title_of(obj) == title]
-
-    def find_exact(self, title: str, kind: str) -> dict[str, Any] | None:
-        matches = self.search_exact(title, kind)
+    @staticmethod
+    def one_match(matches: list[T], title: str, kind: str) -> T | None:
         if len(matches) > 1:
             msg = f'Found multiple {kind}s titled {title!r}; remove duplicates before bootstrapping.'
             raise RuntimeError(msg)
         return matches[0] if matches else None
 
+    def find_page(self, title: str) -> uno.Page | None:
+        return self.one_match(list(self.notion.search_page(title)), title, 'page')
+
+    def find_database(self, title: str) -> uno.Database | None:
+        return self.one_match(list(self.notion.search_db(title)), title, 'database')
+
     def create_page(
         self,
         title: str,
         *,
-        parent_id: str | None = None,
-        children: list[dict[str, Any]] | None = None,
-    ) -> dict[str, Any]:
-        if page := self.find_exact(title, 'page'):
+        parent: uno.Page | None = None,
+        blocks: list[uno.Block] | None = None,
+    ) -> uno.Page:
+        page = self.find_page(title)
+        if page is not None:
             typer.echo(f'page exists: {title}')
             return page
-        page = sync_object(
-            request_with_retry(
-                self.client.pages.create,
-                parent={'page_id': parent_id or self.root['id']},
-                properties={'title': {'title': rich_text(title)}},
-                children=children or [],
-            ),
-        )
+        page = self.notion.create_page(parent=self.root if parent is None else parent, title=title, blocks=blocks)
         typer.echo(f'created page: {title}')
         return page
 
-    def create_database(
-        self,
-        title: str,
-        properties: dict[str, Any],
-        *,
-        description: str | None = None,
-        icon: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        if database := self.find_exact(title, 'database'):
+    def get_or_create_database(self, title: str, schema: type[uno.Schema]) -> tuple[uno.Database, bool]:
+        database = self.find_database(title)
+        if database is not None:
+            database.schema = schema
             typer.echo(f'database exists: {title}')
-            return database
-        kwargs: dict[str, Any] = {
-            'parent': {'page_id': self.root['id']},
-            'title': rich_text(title),
-            'properties': properties,
-        }
-        if description is not None:
-            kwargs['description'] = rich_text(description)
-        if icon is not None:
-            kwargs['icon'] = icon
-        database = sync_object(request_with_retry(self.client.databases.create, **kwargs))
+            return database, False
+        database = self.notion.create_db(parent=self.root, schema=schema)
         typer.echo(f'created database: {title}')
-        return database
-
-    def database_rows(self, database: dict[str, Any]) -> list[dict[str, Any]]:
-        response = sync_object(
-            request_with_retry(self.client.databases.query, database_id=database['id'], page_size=100),
-        )
-        return object_list(response.get('results'))
-
-    def create_database_page(
-        self,
-        database: dict[str, Any],
-        title_prop: str,
-        title: str,
-        properties: dict[str, Any] | None = None,
-    ) -> None:
-        values = {title_prop: {'title': rich_text(title)}}
-        values.update(properties or {})
-        request_with_retry(self.client.pages.create, parent={'database_id': database['id']}, properties=values)
+        return database, True
 
     def ensure_wiki_shell(self) -> None:
-        if self.find_exact('Wiki DB', 'database'):
+        if self.find_database('Wiki DB') is not None:
             typer.echo('wiki exists: Wiki DB')
             return
         self.create_page('Wiki DB')
         typer.echo('manual step: open the Wiki DB page and select ... -> Turn into wiki')
 
     def ensure_contacts_db(self) -> None:
-        database = self.create_database(
-            'Contacts DB',
-            {
-                'Name': {'title': {}},
-                'Title': {'rich_text': {}, 'description': 'Title within the company'},
-                'Role': {
-                    'select': {
-                        'options': [
-                            {'name': 'Project Manager', 'color': 'green'},
-                            {'name': 'Software Engineer', 'color': 'gray'},
-                            {'name': 'UX Designer', 'color': 'red'},
-                            {'name': 'Marketing Manager', 'color': 'orange'},
-                            {'name': 'Data Analyst', 'color': 'blue'},
-                            {'name': 'QA Engineer', 'color': 'default'},
-                            {'name': 'Technical Writer', 'color': 'pink'},
-                            {'name': 'Business Analyst', 'color': 'purple'},
-                            {'name': 'IT Support Specialist', 'color': 'yellow'},
-                        ]
-                    }
-                },
-                'Email': {'email': {}},
-                'Phone': {'phone_number': {}},
-                'URL': {'url': {}},
-                'Team Member': {'checkbox': {}},
-                'Sync Date': {'date': {}},
-            },
-            description='Database of all my contacts!',
-            icon={'type': 'emoji', 'emoji': '🤝'},
-        )
-        if self.database_rows(database):
+        database, created = self.get_or_create_database('Contacts DB', Contacts)
+        if created:
+            # Database icons currently have no high-level setter.
+            self.client.databases.update(database_id=str(database.id), icon={'type': 'emoji', 'emoji': '🤝'})
+        if not database.is_empty:
             typer.echo('Contacts DB already has rows')
             return
         roles = [
-            'Project Manager',
-            'Software Engineer',
-            'UX Designer',
-            'Marketing Manager',
-            'Data Analyst',
-            'QA Engineer',
-            'Technical Writer',
-            'Business Analyst',
-            'IT Support Specialist',
-            'Software Engineer',
+            ContactRole.project_manager,
+            ContactRole.software_engineer,
+            ContactRole.ux_designer,
+            ContactRole.marketing_manager,
+            ContactRole.data_analyst,
+            ContactRole.qa_engineer,
+            ContactRole.technical_writer,
+            ContactRole.business_analyst,
+            ContactRole.it_support_specialist,
+            ContactRole.software_engineer,
         ]
         for idx, role in enumerate(roles, 1):
-            self.create_database_page(
-                database,
-                'Name',
-                f'Contact {idx}',
-                {
-                    'Title': {'rich_text': rich_text(f'Title {idx}')},
-                    'Role': {'select': {'name': role}},
-                    'Email': {'email': f'contact{idx}@example.com'},
-                    'Team Member': {'checkbox': idx % 2 == 0},
-                },
+            database.create_page(
+                name=f'Contact {idx}',
+                title=f'Title {idx}',
+                role=role,
+                email=f'contact{idx}@example.com',
+                team_member=idx % 2 == 0,
             )
         typer.echo('seeded Contacts DB: 10 rows')
 
     def ensure_task_db(self) -> None:
-        database = self.create_database(
-            'Task DB',
-            {
-                'Task': {'title': {}},
-                'Status': {
-                    'status': {
-                        'options': [
-                            {'name': 'Backlog', 'color': 'gray'},
-                            {'name': 'Blocked', 'color': 'red'},
-                            {'name': 'In Progress', 'color': 'blue'},
-                            {'name': 'Done', 'color': 'green'},
-                        ]
-                    }
-                },
-                'Due Date': {'date': {}},
-                'Priority': {
-                    'select': {
-                        'options': [
-                            {'name': '✹ High', 'color': 'red'},
-                            {'name': '✷ Medium', 'color': 'yellow'},
-                            {'name': '✶ Low', 'color': 'gray'},
-                        ]
-                    }
-                },
-                'Urgency': {
-                    'formula': {
-                        'expression': 'if(prop("Status") == "Done", "✅", if(empty(prop("Due Date")), "", "🕘"))'
-                    }
-                },
-            },
-            description='My personal task list of all the important stuff I have to do',
-        )
-        if self.database_rows(database):
+        database = self.find_database('Task DB')
+        if database is None:
+            # Status properties cannot be created through Ultimate Notion's Schema API.
+            response = json_object(
+                self.client.databases.create(
+                    parent={'page_id': str(self.root.id)},
+                    title=rich_text('Task DB'),
+                    description=rich_text('My personal task list of all the important stuff I have to do'),
+                    properties={
+                        'Task': {'title': {}},
+                        'Status': {
+                            'status': {
+                                'options': [
+                                    {'name': 'Backlog', 'color': 'gray'},
+                                    {'name': 'Blocked', 'color': 'red'},
+                                    {'name': 'In Progress', 'color': 'blue'},
+                                    {'name': 'Done', 'color': 'green'},
+                                ]
+                            }
+                        },
+                        'Due Date': {'date': {}},
+                        'Priority': {
+                            'select': {
+                                'options': [
+                                    {'name': '✹ High', 'color': 'red'},
+                                    {'name': '✷ Medium', 'color': 'yellow'},
+                                    {'name': '✶ Low', 'color': 'gray'},
+                                ]
+                            }
+                        },
+                        'Urgency': {
+                            'formula': {
+                                'expression': (
+                                    'if(prop("Status") == "Done", "✅", if(empty(prop("Due Date")), "", "🕘"))'
+                                )
+                            }
+                        },
+                    },
+                )
+            )
+            database = self.notion.get_db(response['id'])
+            typer.echo('created database: Task DB')
+        else:
+            typer.echo('database exists: Task DB')
+        if not database.is_empty:
             typer.echo('Task DB already has rows')
             return
         rows = [
@@ -276,138 +238,63 @@ class Bootstrap:
             ('Ship release', 'Done', '✷ Medium', '2026-06-18T12:00:00.000+00:00'),
         ]
         for name, status, priority, due_date in rows:
-            self.create_database_page(
-                database,
-                'Task',
-                name,
-                {
-                    'Status': {'status': {'name': status}},
-                    'Priority': {'select': {'name': priority}},
-                    'Due Date': {'date': {'start': due_date}},
-                },
+            database.create_page(
+                task=name,
+                status=status,
+                priority=priority,
+                due_date=due_date,
             )
         typer.echo('seeded Task DB: 3 rows')
 
     def ensure_formula_db(self) -> None:
-        database = self.create_database(
-            'Formula DB',
-            {
-                'Name': {'title': {}},
-                'Tags': {
-                    'multi_select': {
-                        'options': [
-                            {'name': 'In Progress', 'color': 'pink'},
-                            {'name': 'Done', 'color': 'gray'},
-                        ]
-                    }
-                },
-                'Date Source': {'date': {}},
-                'String': {'formula': {'expression': 'format(prop("Name"))'}},
-                'Number': {'formula': {'expression': 'prop("Tags").length()'}},
-                'Checkbox': {'formula': {'expression': 'prop("Tags").includes("Done")'}},
-                'Date': {'formula': {'expression': 'prop("Date Source")'}},
-            },
-        )
-        if self.database_rows(database):
+        database, _ = self.get_or_create_database('Formula DB', Formulas)
+        if not database.is_empty:
             typer.echo('Formula DB already has rows')
             return
-        for title, tags in (('Item 1', ['Done', 'In Progress']), ('Item 2', ['In Progress'])):
-            self.create_database_page(
-                database,
-                'Name',
-                title,
-                {
-                    'Tags': {'multi_select': [{'name': tag} for tag in tags]},
-                    'Date Source': {'date': {'start': '2024-11-25T14:08:00.000+00:00'}},
-                },
+        for title, tags in (
+            ('Item 1', [FormulaTag.done, FormulaTag.in_progress]),
+            ('Item 2', [FormulaTag.in_progress]),
+        ):
+            database.create_page(
+                name=title,
+                tags=tags,
+                date_source='2024-11-25T14:08:00.000+00:00',
             )
         typer.echo('seeded Formula DB: 2 rows')
 
     def ensure_static_pages(self) -> None:
         self.create_page(
             'Getting Started',
-            children=[
-                {
-                    'object': 'block',
-                    'type': 'heading_1',
-                    'heading_1': {'rich_text': rich_text('Getting Started'), 'color': 'default'},
-                },
-                {
-                    'object': 'block',
-                    'type': 'paragraph',
-                    'paragraph': {
-                        'rich_text': rich_text('Welcome to the Ultimate Notion test workspace.'),
-                        'color': 'default',
-                    },
-                },
+            blocks=[
+                uno.Heading1('Getting Started'),
+                uno.Paragraph('Welcome to the Ultimate Notion test workspace.'),
             ],
         )
         self.create_page(
             'Markdown Text Test',
-            children=[
-                {
-                    'object': 'block',
-                    'type': 'paragraph',
-                    'paragraph': {
-                        'rich_text': rich_text('Markdown rich-text fixture.'),
-                        'color': 'default',
-                    },
-                }
-            ],
+            blocks=[uno.Paragraph('Markdown rich-text fixture.')],
         )
         markdown_page = self.create_page(
             'Markdown Test',
-            children=[
-                {
-                    'object': 'block',
-                    'type': 'heading_1',
-                    'heading_1': {'rich_text': rich_text('Headline 1'), 'color': 'default'},
-                }
-            ],
+            blocks=[uno.Heading1('Headline 1')],
         )
         self.create_page(
             'Markdown SubPage Test',
-            parent_id=markdown_page['id'],
-            children=[
-                {
-                    'object': 'block',
-                    'type': 'paragraph',
-                    'paragraph': {
-                        'rich_text': rich_text('This is the original Paragraph on SubPage'),
-                        'color': 'default',
-                    },
-                }
-            ],
+            parent=markdown_page,
+            blocks=[uno.Paragraph('This is the original Paragraph on SubPage')],
         )
         self.create_page(
             'Embed/Inline/Linked & Unfurl',
-            children=[
-                {'object': 'block', 'type': 'embed', 'embed': {'url': 'https://ultimate-notion.com/'}},
-                {'object': 'block', 'type': 'bookmark', 'bookmark': {'url': 'https://ultimate-notion.com/'}},
-                {
-                    'object': 'block',
-                    'type': 'paragraph',
-                    'paragraph': {
-                        'rich_text': rich_text('Inline link: https://ultimate-notion.com/'),
-                        'color': 'default',
-                    },
-                },
-                {
-                    'object': 'block',
-                    'type': 'paragraph',
-                    'paragraph': {'rich_text': rich_text('Linked database placeholder'), 'color': 'default'},
-                },
+            blocks=[
+                uno.Embed('https://ultimate-notion.com/'),
+                uno.Bookmark('https://ultimate-notion.com/'),
+                uno.Paragraph('Inline link: https://ultimate-notion.com/'),
+                uno.Paragraph('Linked database placeholder'),
             ],
         )
         self.create_page(
             'Comments',
-            children=[
-                {
-                    'object': 'block',
-                    'type': 'heading_1',
-                    'heading_1': {'rich_text': rich_text('Comments'), 'color': 'default'},
-                }
-            ],
+            blocks=[uno.Heading1('Comments')],
         )
 
     def audit_manual_objects(self) -> None:
@@ -416,7 +303,8 @@ class Bootstrap:
             ('Wiki DB', 'database'),
             ('Custom Emoji Page', 'page'),
         ):
-            status = 'ready' if self.find_exact(title, kind) else 'manual setup required'
+            obj = self.find_database(title) if kind == 'database' else self.find_page(title)
+            status = 'ready' if obj is not None else 'manual setup required'
             typer.echo(f'{title}: {status}')
 
     def run(self) -> None:
@@ -439,7 +327,8 @@ def main() -> None:
     token = os.environ.get('NOTION_TOKEN')
     if not token:
         parser.error('NOTION_TOKEN must be set')
-    Bootstrap(Client(auth=token), args.root_title).run()
+    with uno.Session(client=RetryingClient(auth=token)) as notion:
+        Bootstrap(notion, args.root_title).run()
 
 
 if __name__ == '__main__':

--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -8,12 +8,35 @@ import argparse
 import inspect
 import os
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, ParamSpec, TypeVar
 
 import typer
 from notion_client import Client
+from notion_client.errors import HTTPResponseError
 
 DEFAULT_ROOT_TITLE = 'Tests'
+MAX_REQUEST_ATTEMPTS = 5
+
+P = ParamSpec('P')
+T = TypeVar('T')
+
+
+def request_with_retry(call: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    """Retry Notion rate-limit and overload responses as instructed by the API."""
+    for attempt in range(MAX_REQUEST_ATTEMPTS):
+        try:
+            return call(*args, **kwargs)
+        except HTTPResponseError as error:
+            if error.status not in {429, 529} or attempt == MAX_REQUEST_ATTEMPTS - 1:
+                raise
+            retry_after = error.headers.get('Retry-After')
+            delay = int(retry_after) if retry_after is not None else 2**attempt
+            typer.echo(f'Notion asked us to retry in {delay}s.', err=True)
+            time.sleep(delay)
+
+    msg = 'Notion request retry loop exited unexpectedly.'
+    raise RuntimeError(msg)
 
 
 def sync_object(response: Any) -> dict[str, Any]:
@@ -67,7 +90,8 @@ class Bootstrap:
 
     def search_exact(self, title: str, kind: str) -> list[dict[str, Any]]:
         response = sync_object(
-            self.client.search(
+            request_with_retry(
+                self.client.search,
                 query=title,
                 filter={'property': 'object', 'value': kind},
                 page_size=100,
@@ -93,14 +117,14 @@ class Bootstrap:
             typer.echo(f'page exists: {title}')
             return page
         page = sync_object(
-            self.client.pages.create(
+            request_with_retry(
+                self.client.pages.create,
                 parent={'page_id': parent_id or self.root['id']},
                 properties={'title': {'title': rich_text(title)}},
                 children=children or [],
             ),
         )
         typer.echo(f'created page: {title}')
-        time.sleep(0.4)
         return page
 
     def create_database(
@@ -123,14 +147,13 @@ class Bootstrap:
             kwargs['description'] = rich_text(description)
         if icon is not None:
             kwargs['icon'] = icon
-        database = sync_object(self.client.databases.create(**kwargs))
+        database = sync_object(request_with_retry(self.client.databases.create, **kwargs))
         typer.echo(f'created database: {title}')
-        time.sleep(0.7)
         return database
 
     def database_rows(self, database: dict[str, Any]) -> list[dict[str, Any]]:
         response = sync_object(
-            self.client.databases.query(database_id=database['id'], page_size=100),
+            request_with_retry(self.client.databases.query, database_id=database['id'], page_size=100),
         )
         return object_list(response.get('results'))
 
@@ -143,8 +166,7 @@ class Bootstrap:
     ) -> None:
         values = {title_prop: {'title': rich_text(title)}}
         values.update(properties or {})
-        self.client.pages.create(parent={'database_id': database['id']}, properties=values)
-        time.sleep(0.25)
+        request_with_retry(self.client.pages.create, parent={'database_id': database['id']}, properties=values)
 
     def ensure_wiki_shell(self) -> None:
         if self.find_exact('Wiki DB', 'database'):

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -122,6 +122,13 @@ class Block(TypedObject[GO_co], DataObject, object='block', polymorphic_base=Tru
         # ignore meta fields, e.g. id, created_time, etc. for equality, only use content
         return self.type == other.type and self.value == other.value
 
+    def serialize_for_api(self) -> dict[str, Any]:
+        """Serialize the block for sending it to the Notion API."""
+        data = super().serialize_for_api()
+        for key in ('has_children', 'in_trash', 'archived', 'is_archived'):
+            data.pop(key, None)
+        return data
+
 
 # ToDo: Use new syntax when requires-python >= 3.12
 CB = TypeVar('CB', bound=Block, default=Block)  # invariant, as it is used in the mutable `children` list
@@ -201,6 +208,8 @@ class ColoredTextBlock(TextBlock[CTB_co]):
 
 class ParagraphTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `Paragraph` block."""
+
+    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | UnsetType | None = Unset
 
 
 class Paragraph(ColoredTextBlock[ParagraphTypeData], type='paragraph'):

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -51,6 +51,7 @@ class DataObject(NotionEntity, ABC):
 
     in_trash: bool = False  # used to be `archived`
     archived: bool = False  # ToDo: Deprecated but still partially used in Notion. Check to remove in v1.0!
+    is_archived: bool = False  # newer duplicate of `archived` sent by the API
 
     last_edited_by: UserRef | UnsetType = Unset
 

--- a/src/ultimate_notion/view.py
+++ b/src/ultimate_notion/view.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Callable, Iterator, Sequence
 from html import escape as htmlescape
 from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
@@ -144,7 +145,7 @@ class View(Sequence[Page]):
 
         # remove index as pandas uses its own
         view = self.without_index() if self.has_index else self
-        data = rec_apply(cmplx_to_str, self.to_rows())
+        data = [list(row) for row in rec_apply(cmplx_to_str, self.to_rows())]
 
         return pd.DataFrame(data, columns=view.columns)
 
@@ -189,6 +190,14 @@ class View(Sequence[Page]):
 
         data = rec_apply(cmplx_to_str, self.to_rows())
         schema = self._to_polars_schema()
+        for row in data:
+            for idx, col in enumerate(self.columns):
+                if (
+                    isinstance(schema[col], pl.Datetime)
+                    and isinstance(row[idx], dt.date)
+                    and not isinstance(row[idx], dt.datetime)
+                ):
+                    row[idx] = dt.datetime.combine(row[idx], dt.time())
         return pl.DataFrame(data=data, schema=schema, orient='row')
 
     def _html_for_icon(self, rows: list[Any], cols: list[str]) -> list[Any]:

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -65,18 +65,24 @@ Notes:
 
 ## 2. `Wiki DB`
 
-1. Create a full-page database titled exactly `Wiki DB` with these properties:
+A wiki can only be created from a **page**, not a database — a database's **•••** menu
+has no "Turn into wiki" — and the `Verification` property the tests require is added
+only by the wiki conversion. So:
 
-   | Property name | Type | Configuration |
+1. Create a normal **page** titled exactly `Wiki DB` under the root page.
+2. In the left sidebar, hover that page → **•••** → **Turn into wiki**. This converts it
+   to a wiki and automatically adds the **`Owner`** (Person) and **`Verification`**
+   properties to its database. (If you don't see "Turn into wiki", the page may need to
+   be a top-level/teamspace page — create it there and connect your integration to it.)
+3. Open the wiki's database and adjust its properties so it has exactly these five:
+
+   | Property name | Type | Source |
    | --- | --- | --- |
-   | `Page` | Title | — |
-   | `Owner` | Person | — |
-   | `Tags` | Multi-select | Options: `Onboarding` (Blue), `Design` (Green) |
-   | `Last edited time` | Last edited time | — |
-
-2. Turn it into a wiki: open the database's **•••** menu → **Turn into wiki**.
-   This automatically adds the **`Verification`** property the tests expect; you do
-   not add it manually.
+   | `Page` | Title | rename the title property to `Page` |
+   | `Owner` | Person | added by the wiki conversion |
+   | `Verification` | Verification | added by the wiki conversion |
+   | `Tags` | Multi-select — `Onboarding` (Blue), `Design` (Green) | add manually |
+   | `Last edited time` | Last edited time | add manually |
 
 ## 3. `Custom Emoji Page`
 

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -1,14 +1,14 @@
 # Building the manual test objects
 
 Most of the objects the live tests expect can be created with the Notion API and
-will eventually be produced by a bootstrap script. **Three of them cannot be created
+are produced by the workspace bootstrap script. **Three of them cannot be created
 through the API at all** and must be built by hand in the Notion UI, because they use
 features Notion does not expose in its public API:
 
 | Object | Why it must be built by hand |
 | --- | --- |
 | `All Properties DB` | Contains **AI Autofill** properties and a **Button** property, neither of which the API can create. |
-| `Wiki DB` | Is a database that has been **turned into a wiki**, which adds a `Verification` property; the API cannot create wikis. |
+| `Wiki DB` | Is an ordinary page that has been **turned into a wiki**; the API cannot perform that conversion. |
 | `Custom Emoji Page` | Its icon is a **custom (uploaded) emoji**; the API can reference custom emoji but cannot upload them. |
 
 Create all three **inside the root page** you shared with your integration (see the
@@ -114,11 +114,15 @@ only by the wiki conversion. So:
 These three are only the objects the API **cannot** create. A full live run / cassette
 re-record also needs the remaining named objects (`Contacts DB`, `Task DB`, `Formula DB`,
 the `Getting Started` / markdown / embed / comment pages, etc.) to exist under the same
-root page. Those *can* be created with the API and will be produced by a bootstrap
-script (tracked in [issue #194]); until that script lands they have to be created by
-hand too.
+root page. Create any missing API-creatable objects with:
+
+```console
+NOTION_TOKEN=ntn_... UNO_TEST_ROOT_PAGE='My Test Root' hatch run bootstrap-test-workspace
+```
+
+The script is idempotent and leaves existing objects unchanged. Some content-sensitive
+tests still require the richer recorded fixture content; the bootstrap creates the
+minimum useful structure and seed rows needed to inspect and extend a fresh workspace.
 
 Once every named object exists under your shared root page, re-record with
 `hatch run vcr-rewrite`.
-
-[issue #194]: https://github.com/ultimate-notion/ultimate-notion/issues/194

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -1,0 +1,108 @@
+# Building the manual test objects
+
+Most of the objects the live tests expect can be created with the Notion API and
+will eventually be produced by a bootstrap script. **Three of them cannot be created
+through the API at all** and must be built by hand in the Notion UI, because they use
+features Notion does not expose in its public API:
+
+| Object | Why it must be built by hand |
+| --- | --- |
+| `All Properties DB` | Contains **AI Autofill** properties and a **Button** property, neither of which the API can create. |
+| `Wiki DB` | Is a database that has been **turned into a wiki**, which adds a `Verification` property; the API cannot create wikis. |
+| `Custom Emoji Page` | Its icon is a **custom (uploaded) emoji**; the API can reference custom emoji but cannot upload them. |
+
+Create all three **inside the root page** you shared with your integration (see the
+"Set up a Notion test workspace" section in `CONTRIBUTING.md`). Titles must match
+exactly — the fixtures look them up by name.
+
+---
+
+## 1. `All Properties DB`
+
+A (full-page) database titled exactly `All Properties DB`. Add one property of every
+type. Names, types and configuration must match the table below (extracted from the
+recorded cassette `tests/cassettes/fixtures/mod_all_props_db.yaml`).
+
+| Property name | Type | Configuration |
+| --- | --- | --- |
+| `Title` | Title | — |
+| `Text` | Text | — |
+| `Number` | Number | Format: **Dollar** |
+| `Select` | Select | Options: `Option1` (Default), `Option2` (Red) |
+| `Multi-Select` | Multi-select | Options: `MultiOption1` (Purple), `MultiOption2` (Yellow) |
+| `Status` | Status | Options: `Not started` (Default), `In progress` (Blue), `Done` (Green) |
+| `Date` | Date | — |
+| `People` | Person | — |
+| `Files` | Files & media | — |
+| `Checkbox` | Checkbox | — |
+| `URL` | URL | — |
+| `Email` | Email | — |
+| `Phone number` | Phone | — |
+| `Formula` | Formula | Expression: `prop("Number") * 2` |
+| `Relation` | Relation | Related to **this same `All Properties DB`**; enable **"Show on both pages"** (two-way). Name the synced property `Relation two-way`. |
+| `Relation two-way` | Relation | Created automatically as the synced side of `Relation` above. |
+| `Rollup` | Rollup | Relation: `Relation`, Property: `Title`, Calculate: **Count all**. |
+| `Created time` | Created time | — |
+| `Created by` | Created by | — |
+| `Last edited time` | Last edited time | — |
+| `Last edited by` | Last edited by | — |
+| `ID` | ID (unique ID) | — |
+| `Place` | Place | Newer Notion property; add it from the property-type menu. |
+| `Button` | Button | **API cannot create.** Add any action (e.g. nothing/no-op is fine). |
+| `AI summary` | AI Autofill → **AI summary** | **API cannot create.** Appears as text via the API. |
+| `AI key info` | AI Autofill → **Key info** | **API cannot create.** |
+| `AI custom` | AI Autofill → **Custom autofill** | **API cannot create.** |
+
+Notes:
+- The AI Autofill properties are under **+ → AI Autofill** when adding a property.
+  They require AI to be enabled for your workspace.
+- If your Notion plan does not offer a given AI option, create the closest available
+  AI Autofill property and keep the name (`AI summary` / `AI key info` / `AI custom`);
+  the tests treat them as text.
+
+## 2. `Wiki DB`
+
+1. Create a full-page database titled exactly `Wiki DB` with these properties:
+
+   | Property name | Type | Configuration |
+   | --- | --- | --- |
+   | `Page` | Title | — |
+   | `Owner` | Person | — |
+   | `Tags` | Multi-select | Options: `Onboarding` (Blue), `Design` (Green) |
+   | `Last edited time` | Last edited time | — |
+
+2. Turn it into a wiki: open the database's **•••** menu → **Turn into wiki**.
+   This automatically adds the **`Verification`** property the tests expect; you do
+   not add it manually.
+
+## 3. `Custom Emoji Page`
+
+1. **Upload the custom emoji.** Go to **Settings → Emoji** (workspace emoji) and
+   upload an image named exactly **`ultimate-notion`** so it is usable as
+   `:ultimate-notion:`. (Any image works; the project logo at
+   `docs/assets/images/favicon.png` is a natural choice.)
+2. **Create the page** titled exactly `Custom Emoji Page` under the root page.
+3. **Set the page icon** to the `ultimate-notion` custom emoji (page icon → Custom
+   tab → pick `ultimate-notion`).
+4. **Add the content** so the page renders to exactly this markdown:
+
+   ```markdown
+   This page has a custom emoji :ultimate-notion: compared to 🚀.
+   💡 Callout block without an emoji
+   ```
+
+   Concretely:
+   - A **paragraph**: `This page has a custom emoji ` then the inline custom emoji
+     `:ultimate-notion:` (type `:ultimate-notion:` and pick it) then ` compared to `
+     then the standard rocket emoji `🚀` then `.`
+   - A **callout block** with the text `Callout block without an emoji` and its
+     **default 💡 icon** (do not change the callout icon).
+
+---
+
+## After building the three objects
+
+The remaining named objects (`Contacts DB`, `Task DB`, `Formula DB`, the markdown
+pages, etc.) can be created with the API. Once the three manual objects above exist
+under your shared root page, the suite has everything it needs and the cassettes can
+be re-recorded with `hatch run vcr-rewrite`.

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -49,16 +49,19 @@ recorded cassette `tests/cassettes/fixtures/mod_all_props_db.yaml`).
 | `ID` | ID (unique ID) | — |
 | `Place` | Place | Newer Notion property; add it from the property-type menu. |
 | `Button` | Button | **API cannot create.** Add any action (e.g. nothing/no-op is fine). |
-| `AI summary` | AI Autofill → **AI summary** | **API cannot create.** Appears as text via the API. |
-| `AI key info` | AI Autofill → **Key info** | **API cannot create.** |
-| `AI custom` | AI Autofill → **Custom autofill** | **API cannot create.** |
+| `AI summary` | AI Autofill (Text output) | **API cannot create.** |
+| `AI key info` | AI Autofill (Text output) | **API cannot create.** |
+| `AI custom` | AI Autofill (Text output) | **API cannot create.** |
 
 Notes:
-- The AI Autofill properties are under **+ → AI Autofill** when adding a property.
-  They require AI to be enabled for your workspace.
-- If your Notion plan does not offer a given AI option, create the closest available
-  AI Autofill property and keep the name (`AI summary` / `AI key info` / `AI custom`);
-  the tests treat them as text.
+- **Names are matched exactly (and are case-sensitive).** Notion gives new properties
+  default names that differ from the table — e.g. the title is `Name`, and you get
+  `Multi-select`, `Person`, `Files & media`, `Phone`, and a relation auto-named
+  `Related to All Properties DB`. Rename each to match the table exactly.
+- **AI Autofill properties:** add via **+ → AI Autofill → + New AI Autofill** and choose
+  **`Text`** as the output type, then name the property (`AI summary` / `AI key info` /
+  `AI custom`). The AI prompt itself is irrelevant — the tests only care that the
+  property exists and is exposed as text. Requires AI to be enabled for your workspace.
 
 ## 2. `Wiki DB`
 
@@ -102,7 +105,14 @@ Notes:
 
 ## After building the three objects
 
-The remaining named objects (`Contacts DB`, `Task DB`, `Formula DB`, the markdown
-pages, etc.) can be created with the API. Once the three manual objects above exist
-under your shared root page, the suite has everything it needs and the cassettes can
-be re-recorded with `hatch run vcr-rewrite`.
+These three are only the objects the API **cannot** create. A full live run / cassette
+re-record also needs the remaining named objects (`Contacts DB`, `Task DB`, `Formula DB`,
+the `Getting Started` / markdown / embed / comment pages, etc.) to exist under the same
+root page. Those *can* be created with the API and will be produced by a bootstrap
+script (tracked in [issue #194]); until that script lands they have to be created by
+hand too.
+
+Once every named object exists under your shared root page, re-record with
+`hatch run vcr-rewrite`.
+
+[issue #194]: https://github.com/ultimate-notion/ultimate-notion/issues/194

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -13,7 +13,7 @@ features Notion does not expose in its public API:
 
 Create all three **inside the root page** you shared with your integration (see the
 "Set up a Notion test workspace" section in `CONTRIBUTING.md`). Titles must match
-exactly — the fixtures look them up by name.
+exactly, because the fixtures look them up by name.
 
 ---
 
@@ -25,28 +25,28 @@ recorded cassette `tests/cassettes/fixtures/mod_all_props_db.yaml`).
 
 | Property name | Type | Configuration |
 | --- | --- | --- |
-| `Title` | Title | — |
-| `Text` | Text | — |
+| `Title` | Title | N/A |
+| `Text` | Text | N/A |
 | `Number` | Number | Format: **Dollar** |
 | `Select` | Select | Options: `Option1` (Default), `Option2` (Red) |
 | `Multi-Select` | Multi-select | Options: `MultiOption1` (Purple), `MultiOption2` (Yellow) |
 | `Status` | Status | Options: `Not started` (Default), `In progress` (Blue), `Done` (Green) |
-| `Date` | Date | — |
-| `People` | Person | — |
-| `Files` | Files & media | — |
-| `Checkbox` | Checkbox | — |
-| `URL` | URL | — |
-| `Email` | Email | — |
-| `Phone number` | Phone | — |
+| `Date` | Date | N/A |
+| `People` | Person | N/A |
+| `Files` | Files & media | N/A |
+| `Checkbox` | Checkbox | N/A |
+| `URL` | URL | N/A |
+| `Email` | Email | N/A |
+| `Phone number` | Phone | N/A |
 | `Formula` | Formula | Expression: `prop("Number") * 2` |
 | `Relation` | Relation | Related to **this same `All Properties DB`**; enable **"Show on both pages"** (two-way). Name the synced property `Relation two-way`. |
 | `Relation two-way` | Relation | Created automatically as the synced side of `Relation` above. |
 | `Rollup` | Rollup | Relation: `Relation`, Property: `Title`, Calculate: **Count all**. |
-| `Created time` | Created time | — |
-| `Created by` | Created by | — |
-| `Last edited time` | Last edited time | — |
-| `Last edited by` | Last edited by | — |
-| `ID` | ID (unique ID) | — |
+| `Created time` | Created time | N/A |
+| `Created by` | Created by | N/A |
+| `Last edited time` | Last edited time | N/A |
+| `Last edited by` | Last edited by | N/A |
+| `ID` | ID (unique ID) | N/A |
 | `Place` | Place | Newer Notion property; add it from the property-type menu. |
 | `Button` | Button | **API cannot create.** Add any action (e.g. nothing/no-op is fine). |
 | `AI summary` | AI Autofill (Text output) | **API cannot create.** |
@@ -55,25 +55,25 @@ recorded cassette `tests/cassettes/fixtures/mod_all_props_db.yaml`).
 
 Notes:
 - **Names are matched exactly (and are case-sensitive).** Notion gives new properties
-  default names that differ from the table — e.g. the title is `Name`, and you get
+  default names that differ from the table. For example, the title is `Name`, and you get
   `Multi-select`, `Person`, `Files & media`, `Phone`, and a relation auto-named
   `Related to All Properties DB`. Rename each to match the table exactly.
 - **AI Autofill properties:** add via **+ → AI Autofill → + New AI Autofill** and choose
   **`Text`** as the output type, then name the property (`AI summary` / `AI key info` /
-  `AI custom`). The AI prompt itself is irrelevant — the tests only care that the
+  `AI custom`). The AI prompt itself is irrelevant; the tests only care that the
   property exists and is exposed as text. Requires AI to be enabled for your workspace.
 
 ## 2. `Wiki DB`
 
-A wiki can only be created from a **page**, not a database — a database's **•••** menu
-has no "Turn into wiki" — and the `Verification` property the tests require is added
+A wiki can only be created from a **page**, not a database. A database's **•••** menu
+has no "Turn into wiki", and the `Verification` property the tests require is added
 only by the wiki conversion. So:
 
 1. Create a normal **page** titled exactly `Wiki DB` under the root page.
 2. In the left sidebar, hover that page → **•••** → **Turn into wiki**. This converts it
    to a wiki and automatically adds the **`Owner`** (Person) and **`Verification`**
    properties to its database. (If you don't see "Turn into wiki", the page may need to
-   be a top-level/teamspace page — create it there and connect your integration to it.)
+   be a top-level/teamspace page. Create it there and connect your integration to it.)
 3. Open the wiki's database and adjust its properties so it has exactly these five:
 
    | Property name | Type | Source |
@@ -81,7 +81,7 @@ only by the wiki conversion. So:
    | `Page` | Title | rename the title property to `Page` |
    | `Owner` | Person | added by the wiki conversion |
    | `Verification` | Verification | added by the wiki conversion |
-   | `Tags` | Multi-select — `Onboarding` (Blue), `Design` (Green) | add manually |
+   | `Tags` | Multi-select: `Onboarding` (Blue), `Design` (Green) | add manually |
    | `Last edited time` | Last edited time | add manually |
 
 ## 3. `Custom Emoji Page`

--- a/tests/cassettes/fixtures/mod_person.yaml
+++ b/tests/cassettes/fixtures/mod_person.yaml
@@ -1,0 +1,15 @@
+interactions:
+- request:
+    body: ''
+    headers: {}
+    method: GET
+    uri: https://api.notion.com/v1/users?page_size=100
+  response:
+    content: '{"object":"list","results":[{"object":"user","id":"b10cb6df-12ef-44d3-88ad-250168f66322","name":"Florian
+      Wilhelm","avatar_url":null,"type":"person","person":{"email":"florian.wilhelm@gmail.com"}}],"next_cursor":null,"has_more":false,"type":"user","user":{},"request_id":"15bf0e55-027a-4d35-8358-e0083a1a028b"}'
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,7 @@ def custom_config(request: SubRequest) -> Iterator[Path]:
             yield cfg_path
 
 
-def vcr_fixture(scope: str, *, autouse: bool = False) -> Callable[..., Any]:
+def vcr_fixture(scope: str, *, autouse: bool = False, shared: bool = False) -> Callable[..., Any]:
     """Return a VCR fixture for module/session-level fixtures"""
     if scope not in {'module', 'session'}:
         msg = f'Use this only for module or session scope, not {scope}!'
@@ -262,12 +262,13 @@ def vcr_fixture(scope: str, *, autouse: bool = False) -> Callable[..., Any]:
         is_generator = inspect.isgeneratorfunction(func)
 
         def setup_vcr(request: SubRequest, vcr_config: dict[str, str]) -> tuple[VCR | MagicMock, str]:
-            if scope == 'module':
+            if scope == 'module' and not shared:
                 cassette_dir = str(Path(request.module.__file__).parent / 'cassettes' / 'fixtures')
                 cassette_name = f'mod_{func.__name__}.yaml'  # same cassette for all modules!
-            else:  # scope == 'session'
+            else:
                 cassette_dir = str(request.config.rootdir / 'tests' / 'cassettes' / 'fixtures')
-                cassette_name = f'sess_{func.__name__}.yaml'
+                prefix = 'mod' if scope == 'module' else 'sess'
+                cassette_name = f'{prefix}_{func.__name__}.yaml'
 
             vcr_config = vcr_config.copy()  # to avoid changing the original config
             vcr_config |= {'cassette_library_dir': cassette_dir}
@@ -359,15 +360,14 @@ def notion(notion_cached: Session) -> Iterator[Session]:
         yield notion_cached
 
 
-@pytest.fixture(scope='module')
+@vcr_fixture(scope='module', shared=True)
 def person(notion_cached: Session) -> User:
     """Return a user object for testing.
 
-    Resolves to the integration's own bot user so the test suite is not tied to a
-    specific workspace member. Every workspace has exactly one bot for the connected
-    integration, so this needs no configuration and works in any workspace.
+    Use the first user visible to the integration so the suite is not tied to a
+    specific workspace member.
     """
-    return notion_cached.whoami()
+    return notion_cached.all_users()[0]
 
 
 @vcr_fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -334,8 +334,13 @@ def notion(notion_cached: Session) -> Iterator[Session]:
 
 @pytest.fixture(scope='module')
 def person(notion_cached: Session) -> User:
-    """Return a user object for testing."""
-    return notion_cached.search_user('Florian Wilhelm').item()
+    """Return a user object for testing.
+
+    Resolves to the integration's own bot user so the test suite is not tied to a
+    specific workspace member. Every workspace has exactly one bot for the connected
+    integration, so this needs no configuration and works in any workspace.
+    """
+    return notion_cached.whoami()
 
 
 @vcr_fixture(scope='module')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,14 @@ from ultimate_notion.utils import temp_attr, temp_timezone
 if TYPE_CHECKING:
     from _pytest.config.argparsing import Parser
 
+# Name of the environment variable that overrides the title of the root test page.
+# This lets a maintainer point the suite at the root page they shared with their own
+# integration without having to name it `Tests`. The default keeps the recorded
+# cassettes (which searched for `Tests`) working unchanged.
+ENV_TEST_ROOT_PAGE = 'UNO_TEST_ROOT_PAGE'
+
 # Manually created DBs and Pages in Notion for testing purposes
-TESTS_PAGE = 'Tests'  # root page for all tests with connected Notion integration
+TESTS_PAGE = os.environ.get(ENV_TEST_ROOT_PAGE, 'Tests')  # root page for all tests with connected Notion integration
 ALL_PROPS_DB = 'All Properties DB'  # DB with all possible properties including AI properties!
 WIKI_DB = 'Wiki DB'
 CONTACTS_DB = 'Contacts DB'
@@ -318,6 +324,27 @@ def vcr_fixture(scope: str, *, autouse: bool = False) -> Callable[..., Any]:
     return decorator
 
 
+def require_page(notion: Session, title: str) -> Page:
+    """Return the named page, or skip the test if the workspace does not contain it.
+
+    A fresh workspace will not have the manually created test objects, so depending
+    tests skip with a helpful message instead of erroring. See the "Set up a Notion
+    test workspace" section in `CONTRIBUTING.md`.
+    """
+    pages = notion.search_page(title)
+    if not pages:
+        pytest.skip(f'Test workspace has no page titled {title!r}; see CONTRIBUTING.md.')
+    return pages.item()
+
+
+def require_db(notion: Session, title: str) -> Database:
+    """Return the named database, or skip the test if the workspace does not contain it."""
+    dbs = notion.search_db(title)
+    if not dbs:
+        pytest.skip(f'Test workspace has no database titled {title!r}; see CONTRIBUTING.md.')
+    return dbs.item()
+
+
 @pytest.fixture(scope='module')
 def notion_cached() -> Iterator[Session]:
     """Return the notion session used for live testing."""
@@ -346,13 +373,13 @@ def person(notion_cached: Session) -> User:
 @vcr_fixture(scope='module')
 def contacts_db(notion_cached: Session) -> Database:
     """Return a test database."""
-    return notion_cached.search_db(CONTACTS_DB).item()
+    return require_db(notion_cached, CONTACTS_DB)
 
 
 @vcr_fixture(scope='module')
 def root_page(notion_cached: Session) -> Page:
     """Return the page reference used as parent page for live testing."""
-    return notion_cached.search_page(TESTS_PAGE).item()
+    return require_page(notion_cached, TESTS_PAGE)
 
 
 @pytest.fixture(scope='function')
@@ -381,61 +408,61 @@ def page_hierarchy(notion_cached: Session, root_page: Page) -> Iterator[tuple[Pa
 @vcr_fixture(scope='module')
 def intro_page(notion_cached: Session) -> Page:
     """Return the default 'Getting Started' page."""
-    return notion_cached.search_page(GETTING_STARTED_PAGE).item()
+    return require_page(notion_cached, GETTING_STARTED_PAGE)
 
 
 @vcr_fixture(scope='module')
 def all_props_db(notion_cached: Session) -> Database:
     """Return manually created database with all properties, also AI properties."""
-    return notion_cached.search_db(ALL_PROPS_DB).item()
+    return require_db(notion_cached, ALL_PROPS_DB)
 
 
 @vcr_fixture(scope='module')
 def wiki_db(notion_cached: Session) -> Database:
     """Return manually created wiki db."""
-    return notion_cached.search_db(WIKI_DB).item()
+    return require_db(notion_cached, WIKI_DB)
 
 
 @vcr_fixture(scope='module')
 def formula_db(notion_cached: Session) -> Database:
     """Return manually created formula db."""
-    return notion_cached.search_db(FORMULA_DB).item()
+    return require_db(notion_cached, FORMULA_DB)
 
 
 @vcr_fixture(scope='module')
 def md_text_page(notion_cached: Session) -> Page:
     """Return a page with markdown text content."""
-    return notion_cached.search_page(MD_TEXT_TEST_PAGE).item()
+    return require_page(notion_cached, MD_TEXT_TEST_PAGE)
 
 
 @vcr_fixture(scope='module')
 def md_page(notion_cached: Session) -> Page:
     """Return a page with markdown content."""
-    return notion_cached.search_page(MD_PAGE_TEST_PAGE).item()
+    return require_page(notion_cached, MD_PAGE_TEST_PAGE)
 
 
 @vcr_fixture(scope='module')
 def md_subpage(notion_cached: Session) -> Page:
     """Return a page with markdown content."""
-    return notion_cached.search_page(MD_SUBPAGE_TEST_PAGE).item()
+    return require_page(notion_cached, MD_SUBPAGE_TEST_PAGE)
 
 
 @vcr_fixture(scope='module')
 def embed_page(notion_cached: Session) -> Page:
     """Return a page with embed/inline/linked & unfurl content."""
-    return notion_cached.search_page(EMBED_TEST_PAGE).item()
+    return require_page(notion_cached, EMBED_TEST_PAGE)
 
 
 @vcr_fixture(scope='module')
 def comment_page(notion_cached: Session) -> Page:
     """Return a page with comments."""
-    return notion_cached.search_page(COMMENT_PAGE).item()
+    return require_page(notion_cached, COMMENT_PAGE)
 
 
 @vcr_fixture(scope='module')
 def custom_emoji_page(notion_cached: Session) -> Page:
     """Return a page with a custom emoji."""
-    return notion_cached.search_page(CUSTOM_EMOJI_PAGE).item()
+    return require_page(notion_cached, CUSTOM_EMOJI_PAGE)
 
 
 @pytest.fixture(scope='module')
@@ -465,7 +492,7 @@ def static_pages(  # noqa: PLR0917
 @vcr_fixture(scope='module')
 def task_db(notion_cached: Session) -> Database:
     """Return manually created wiki db."""
-    return notion_cached.search_db(TASK_DB).item()
+    return require_db(notion_cached, TASK_DB)
 
 
 @vcr_fixture(scope='module')

--- a/tests/obj_api/test_core.py
+++ b/tests/obj_api/test_core.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from uuid import UUID, uuid4
 
+import pytest
+
+from ultimate_notion.obj_api.blocks import Paragraph
 from ultimate_notion.obj_api.core import extract_id
 from ultimate_notion.obj_api.objects import Bot, Person, User
+
+
+@pytest.fixture(autouse=True)
+def notion_cleanups() -> None:
+    """Disable the live Notion cleanup fixture for pure object parsing tests."""
 
 
 def test_extract_id() -> None:
@@ -46,3 +54,29 @@ def test_user_object_default_propagates_to_subtypes() -> None:
         }
     )
     assert person.object == 'user'
+
+
+def test_paragraph_accepts_null_icon() -> None:
+    paragraph = Paragraph.model_validate(
+        {
+            'object': 'block',
+            'type': 'paragraph',
+            'paragraph': {
+                'rich_text': [],
+                'color': 'default',
+                'children': [],
+                'icon': None,
+            },
+        }
+    )
+
+    assert paragraph.paragraph.icon is None
+
+
+def test_block_serialization_omits_read_only_archive_flags() -> None:
+    data = Paragraph.build(paragraph={'rich_text': []}).serialize_for_api()
+
+    assert 'has_children' not in data
+    assert 'in_trash' not in data
+    assert 'archived' not in data
+    assert 'is_archived' not in data

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,6 +7,8 @@ More details here: https://github.com/python/mypy/issues/3004
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 import pytest
 
 import ultimate_notion as uno
@@ -122,7 +124,7 @@ def test_db_attributes(contacts_db: uno.Database) -> None:
     assert isinstance(contacts_db.icon, str)
     assert contacts_db.icon == '🤝'
     assert contacts_db.cover is None
-    assert contacts_db.url.startswith('https://www.notion.so/d')
+    assert urlparse(contacts_db.url).hostname in {'www.notion.so', 'app.notion.com'}
     assert not contacts_db.is_deleted
     assert not contacts_db.is_inline
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -147,10 +147,8 @@ def test_title_attr(notion: uno.Session, root_page: uno.Page) -> None:
 
 @pytest.mark.vcr()
 def test_created_edited_by(notion: uno.Session, root_page: uno.Page) -> None:
-    myself = notion.whoami()
-    florian = notion.search_user('Florian Wilhelm').item()
-    assert root_page.created_by == florian
-    assert root_page.last_edited_by in {myself, florian}
+    assert isinstance(root_page.created_by, uno.User)
+    assert isinstance(root_page.last_edited_by, uno.User)
 
 
 @pytest.mark.vcr()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -147,6 +147,8 @@ def test_title_attr(notion: uno.Session, root_page: uno.Page) -> None:
 
 @pytest.mark.vcr()
 def test_created_edited_by(notion: uno.Session, root_page: uno.Page) -> None:
+    notion.whoami()
+    notion.all_users()
     assert isinstance(root_page.created_by, uno.User)
     assert isinstance(root_page.last_edited_by, uno.User)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -402,8 +402,8 @@ def test_people_relation_query(root_page: uno.Page, notion: uno.Session, person:
     db = notion.create_db(parent=root_page, schema=DB)
 
     page_empty = db.create_page()
-    page_florian = db.create_page(title='Florian', people=[person])
-    page_fan = db.create_page(title='Fan', relation=page_florian)
+    page_person = db.create_page(title='Person', people=[person])
+    page_fan = db.create_page(title='Fan', relation=page_person)
 
     # Test People
     prop_name = 'People'
@@ -411,10 +411,10 @@ def test_people_relation_query(root_page: uno.Page, notion: uno.Session, person:
     assert set(query.execute()) == {page_empty, page_fan}
 
     query = db.query.filter(uno.prop(prop_name).is_not_empty())
-    assert set(query.execute()) == {page_florian}
+    assert set(query.execute()) == {page_person}
 
     query = db.query.filter(uno.prop(prop_name).contains(person))
-    assert set(query.execute()) == {page_florian}
+    assert set(query.execute()) == {page_person}
 
     query = db.query.filter(uno.prop(prop_name).does_not_contain(person))
     assert set(query.execute()) == {page_empty, page_fan}
@@ -422,16 +422,16 @@ def test_people_relation_query(root_page: uno.Page, notion: uno.Session, person:
     # Test Relation
     prop_name = 'Relation'
     query = db.query.filter(uno.prop(prop_name).is_empty())
-    assert set(query.execute()) == {page_empty, page_florian}
+    assert set(query.execute()) == {page_empty, page_person}
 
     query = db.query.filter(uno.prop(prop_name).is_not_empty())
     assert set(query.execute()) == {page_fan}
 
-    query = db.query.filter(uno.prop(prop_name).contains(page_florian))
+    query = db.query.filter(uno.prop(prop_name).contains(page_person))
     assert set(query.execute()) == {page_fan}
 
-    query = db.query.filter(uno.prop(prop_name).does_not_contain(page_florian))
-    assert set(query.execute()) == {page_empty, page_florian}
+    query = db.query.filter(uno.prop(prop_name).does_not_contain(page_person))
+    assert set(query.execute()) == {page_empty, page_person}
 
 
 @pytest.mark.vcr()

--- a/tests/test_rich_text.py
+++ b/tests/test_rich_text.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+from urllib.parse import urlparse
+
 import pendulum as pnd
 import pytest
 
@@ -52,6 +55,11 @@ def test_is_url() -> None:
 def test_mention(
     person: uno.User, root_page: uno.Page, md_text_page: uno.Page, all_props_db: uno.Database, notion: uno.Session
 ) -> None:
+    def mention_url(obj: uno.Page | uno.Database) -> str:
+        parsed = urlparse(obj.url)
+        prefix = '/p' if parsed.hostname == 'app.notion.com' else ''
+        return f'{parsed.scheme}://{parsed.netloc}{prefix}/{obj.id.hex}'
+
     user_mention = uno.mention(person)
     page_mention = uno.mention(md_text_page)
     db_mention = uno.mention(all_props_db)
@@ -61,11 +69,12 @@ def test_mention(
     paragraph = uno.Paragraph(user_mention + ' : ' + page_mention + ' : ' + db_mention + ' : ' + date_mention)
     page.append(paragraph)
     exp_text = (
-        f'[@{person.name}]() : ↗[Markdown Text Test](https://www.notion.so/0c8ea7f1c7ca4abb8890085c0fac383b)'
-        ' : ↗[All Properties DB](https://www.notion.so/4fa8756fa0da4efe9c484d6a323b69f8)'
+        f'[@USER]() : ↗[Markdown Text Test]({mention_url(md_text_page)})'
+        f' : ↗[All Properties DB]({mention_url(all_props_db)})'
         ' : [2022-01-01T00:00:00.000+00:00]()'
     )
-    assert page.children[0].to_markdown() == exp_text
+    actual = re.sub(r'^\[@[^\]]+\]\(\)', '[@USER]()', page.children[0].to_markdown())
+    assert actual == exp_text
 
 
 @pytest.mark.vcr()
@@ -74,18 +83,19 @@ def test_rich_text_bases(person: uno.User, root_page: uno.Page, notion: uno.Sess
     text += uno.math('E=mc^2', bold=True)
     text += uno.text(' and this is a mention: ', href='https://ultimate-notion.com/')
     text += uno.mention(person)
-    exp_text = (
-        f'This is an equation: **$E=mc^2$** [and this is a mention:](https://ultimate-notion.com/) [@{person.name}]()'
-    )
-    assert text.to_markdown() == exp_text
+    exp_text = 'This is an equation: **$E=mc^2$** [and this is a mention:](https://ultimate-notion.com/) [@USER]()'
+    actual = re.sub(r'\[@[^\]]+\]\(\)$', '[@USER]()', text.to_markdown())
+    assert actual == exp_text
 
     page = notion.create_page(parent=root_page, title='RichText Test')
     page.append(uno.Paragraph(text))
-    assert page.children[0].to_markdown() == exp_text
+    actual = re.sub(r'\[@[^\]]+\]\(\)$', '[@USER]()', page.children[0].to_markdown())
+    assert actual == exp_text
 
     notion.cache.clear()
     page = notion.get_page(page.id)
-    assert page.children[0].to_markdown() == exp_text
+    actual = re.sub(r'\[@[^\]]+\]\(\)$', '[@USER]()', page.children[0].to_markdown())
+    assert actual == exp_text
 
 
 def test_rich_text() -> None:

--- a/tests/test_rich_text.py
+++ b/tests/test_rich_text.py
@@ -61,7 +61,7 @@ def test_mention(
     paragraph = uno.Paragraph(user_mention + ' : ' + page_mention + ' : ' + db_mention + ' : ' + date_mention)
     page.append(paragraph)
     exp_text = (
-        '[@Florian Wilhelm]() : ↗[Markdown Text Test](https://www.notion.so/0c8ea7f1c7ca4abb8890085c0fac383b)'
+        f'[@{person.name}]() : ↗[Markdown Text Test](https://www.notion.so/0c8ea7f1c7ca4abb8890085c0fac383b)'
         ' : ↗[All Properties DB](https://www.notion.so/4fa8756fa0da4efe9c484d6a323b69f8)'
         ' : [2022-01-01T00:00:00.000+00:00]()'
     )
@@ -75,7 +75,7 @@ def test_rich_text_bases(person: uno.User, root_page: uno.Page, notion: uno.Sess
     text += uno.text(' and this is a mention: ', href='https://ultimate-notion.com/')
     text += uno.mention(person)
     exp_text = (
-        'This is an equation: **$E=mc^2$** [and this is a mention:](https://ultimate-notion.com/) [@Florian Wilhelm]()'
+        f'This is an equation: **$E=mc^2$** [and this is a mention:](https://ultimate-notion.com/) [@{person.name}]()'
     )
     assert text.to_markdown() == exp_text
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,7 +17,11 @@ from ultimate_notion.schema import Property
 
 @pytest.mark.vcr()
 def test_all_createable_props_schema(
-    notion: uno.Session, root_page: uno.Page, dummy_urls: URL, get_id_prefix: Callable[[str], str]
+    notion: uno.Session,
+    root_page: uno.Page,
+    dummy_urls: URL,
+    get_id_prefix: Callable[[str], str],
+    person: uno.User,
 ) -> None:
     class SchemaA(uno.Schema, db_title='Schema A'):
         """Only used to create relations in Schema B"""
@@ -72,7 +76,6 @@ def test_all_createable_props_schema(
     with pytest.raises(ReadOnlyPropertyError):
         SchemaB.create(last_edited_time=datetime.now(tz=timezone.utc))
 
-    florian = notion.search_user('Florian Wilhelm').item()
     myself = notion.whoami()
 
     with pytest.raises(ReadOnlyPropertyError):
@@ -97,7 +100,7 @@ def test_all_createable_props_schema(
         'files': props.Files([uno.ExternalFile(name='My File', url=dummy_urls.file)]),
         'multi_select': props.MultiSelect(options[0]),
         'number': props.Number(42),
-        'people': props.Person(florian),
+        'people': props.Person(person),
         'phone_number': props.Phone('+1 234 567 890'),
         'relation': props.Relations([a_item1, a_item2]),
         'relation_twoway': props.Relations([a_item1, a_item2]),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -23,6 +23,8 @@ def test_all_createable_props_schema(
     get_id_prefix: Callable[[str], str],
     person: uno.User,
 ) -> None:
+    notion.cache[person.id] = person
+
     class SchemaA(uno.Schema, db_title='Schema A'):
         """Only used to create relations in Schema B"""
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -27,12 +27,10 @@ def test_search_get_db(notion: uno.Session) -> None:
 @pytest.mark.vcr()
 def test_whoami_get_user(notion: uno.Session) -> None:
     me = notion.whoami()
-    assert me.name == 'Github Unittests'
     user = notion.get_user(me.id)
     assert user.id == me.id
     user = notion.get_user(me.id, use_cache=False, raise_on_unknown=False)
-    assert user.name == 'Github Unittests'
-    notion.get_user('645e79dd-3e43-40de-9d51-39357c1c427f', use_cache=False)
+    assert user == me
     with pytest.raises(UnknownUserError):
         unknown_id = '745e79dd-3e43-40de-9d51-39357c1c428f'
         notion.get_user(unknown_id, use_cache=False)


### PR DESCRIPTION
## Description

Makes the Notion test suite portable across maintainers by removing workspace-specific user and root-page assumptions, adding clear skips for unavailable named fixtures, and documenting the few objects that still require manual setup.
Adds an idempotent bootstrap command for API-creatable databases, pages, schemas, and seed rows, while preserving reusable VCR playback for user-dependent tests.
Also handles current Notion API drift around `is_archived`, nullable paragraph icons, read-only block fields, URL formats, and date-only values in Polars exports; this advances #194 and fixes #202.
Validated with the full `hatch run vcr-only` suite, Ruff formatting/lint checks, and mypy.

### Types of change

Bug fixes, test-infrastructure enhancement, and documentation.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with `hatch run vcr-only`; the full cassette suite passes.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
