### PR TITLE
Drop __str__ metaclass type: ignore by moving as_table onto SchemaType

### DIFF
--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -815,7 +815,28 @@ class SchemaType(ABCMeta):
         """Get all properties of this schema."""
         return cls._props
 
-    def __str__(cls: type[Schema]) -> str:  # type: ignore[misc]
+    def as_table(cls, tablefmt: str | None = None) -> str:
+        """Return the schema in a given string table format.
+
+        Some table formats:
+
+        - plain: no pseudographics
+        - simple: Pandoc's simple table, i.e. only dashes to separate header from content
+        - github: GitHub flavored Markdown
+        - simple_grid: uses dashes & pipes to separate cells
+        - html: standard html markup
+
+        Find more table formats under: https://github.com/astanin/python-tabulate#table-format
+        """
+        if tablefmt is None:
+            tablefmt = 'html' if is_notebook() else 'simple'
+
+        headers = ['Name', 'Property', 'Attribute']
+        rows = [(prop.name, prop, prop.attr_name) for prop in cls.get_props()]
+
+        return tabulate(rows, headers=headers, tablefmt=tablefmt)
+
+    def __str__(cls) -> str:
         # We can only overwrite __str__ for a class in a metaclass
         return cls.as_table(tablefmt='simple')
 
@@ -1053,30 +1074,6 @@ class Schema(metaclass=SchemaType):
     def to_dict(cls) -> dict[str, Property]:
         """Convert this schema to a dictionary of property names and corresponding types."""
         return {prop.name: prop for prop in cls.get_props()}
-
-    @classmethod
-    def as_table(cls, tablefmt: str | None = None) -> str:
-        """Return the schema in a given string table format.
-
-        Some table formats:
-
-        - plain: no pseudographics
-        - simple: Pandoc's simple table, i.e. only dashes to separate header from content
-        - github: GitHub flavored Markdown
-        - simple_grid: uses dashes & pipes to separate cells
-        - html: standard html markup
-
-        Find more table formats under: https://github.com/astanin/python-tabulate#table-format
-        """
-        if tablefmt is None:
-            tablefmt = 'html' if is_notebook() else 'simple'
-
-        headers = ['Name', 'Property', 'Attribute']
-        rows = []
-        for prop in cls.get_props():
-            rows.append((prop.name, prop, prop.attr_name))
-
-        return tabulate(rows, headers=headers, tablefmt=tablefmt)
 
     @classmethod
     def show(cls, *, simple: bool | None = None) -> None:


### PR DESCRIPTION
## Description

Removes the `type: ignore[misc]` from `SchemaType.__str__` by fixing the root cause instead of suppressing it. `as_table` is moved from a `Schema` classmethod onto the `SchemaType` metaclass — the same pattern as the earlier `get_props` move — so `__str__` gets a correctly-typed `cls` (the metaclass instance) rather than the misleading `cls: type[Schema]` annotation that required the suppression. No `cast`, `__mro__`, or `getattr` tricks; mypy and pyright both stay clean (pyright error count unchanged from baseline), and `str(schema)`, `schema.as_table(...)`, `schema.show()`, and `schema._repr_html_()` all verified working at runtime.

### Types of change

Internal type-hygiene change (no behavior change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)