### PR TITLE
Drop wrap_obj_ref __func__ type ignore via class identity check

### DIFF
--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -72,11 +72,11 @@ class Wrapper(Generic[GT_co], ABC):
     def wrap_obj_ref(cls: type[Self], obj_ref: GT_co, /) -> Self:  # type: ignore[misc] # breaking covariance
         """Wraps low-level `obj_ref` from Notion API into a high-level (hl) object of Ultimate Notion."""
         hl_cls = cls._obj_api_map[type(obj_ref)]
-        # To allow for `Block.wrap_obj_ref` to work call a specific 'wrap_obj_ref' if it exists,
-        # e.g. `RichText.wrap_obj_ref` we need to break a potential recursion in the MRO.
-        if cls.wrap_obj_ref.__func__ is hl_cls.wrap_obj_ref.__func__:  # type: ignore[attr-defined]
-            # ToDo: remove type ignore when https://github.com/python/mypy/issues/14123 is fixed
-            # break recursion
+        # Resolving `obj_ref` may yield a more specific high-level class than `cls`, e.g. calling
+        # `Block.wrap_obj_ref` on a paragraph object resolves `hl_cls` to `Paragraph`. In that case we
+        # hand off to that class' `wrap_obj_ref` so its specialised wrapping (e.g. children handling) runs.
+        # Once `cls` already is the resolved class we build the object directly to break the recursion.
+        if cls is hl_cls:
             hl_obj = hl_cls.__new__(hl_cls)
             hl_obj._obj_ref = obj_ref
             return cast(Self, hl_obj)


### PR DESCRIPTION
## Description

Removes the `# type: ignore[attr-defined]` in `Wrapper.wrap_obj_ref` that was only needed because of the unfixed mypy bug [#14123](https://github.com/python/mypy/issues/14123). The recursion-breaking check no longer introspects classmethod identity via `__func__`; it instead compares classes directly (`cls is hl_cls`), which is behaviorally equivalent for all real usage — when `cls` isn't yet the concrete resolved class it hands off to that class' `wrap_obj_ref`, otherwise it builds the object directly. Verified with mypy and pyright (no new errors), `hatch run vcr-only` (identical results before/after), and a direct functional check of both dispatch branches.

### Types of change

Code cleanup / type-checking improvement (no behavior change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
