### PR TITLE
Fix strict docs build broken by TEST_WORKSPACE.md link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,8 @@ Notion API or **re-record the cassettes** with `hatch run vcr-rewrite`.
 !!! note
     Three objects (`All Properties DB`, `Wiki DB` and the `Custom Emoji Page`) use
     features the API cannot create and must be built by hand. See
-    [`tests/TEST_WORKSPACE.md`](tests/TEST_WORKSPACE.md) for exact instructions.
+    [`tests/TEST_WORKSPACE.md`](https://github.com/ultimate-notion/ultimate-notion/blob/main/tests/TEST_WORKSPACE.md)
+    for exact instructions.
 
 ### Implement your changes
 


### PR DESCRIPTION
## Problem

CI on `main` is failing in the **Build documentation** job:

```
WARNING -  Doc file 'contributing.md' contains a link '../tests/TEST_WORKSPACE.md', but the target is not found among documentation files.
Aborted with 1 warnings in strict mode!
```

`docs/contributing.md` pulls in `CONTRIBUTING.md` via `include-markdown`. The relative link to `tests/TEST_WORKSPACE.md` (added in #210) points outside the docs tree, so `mkdocs build --strict` treats the unresolved link as a fatal warning.

## Fix

Point the link at the GitHub blob URL. It renders correctly when CONTRIBUTING.md is viewed on GitHub and resolves cleanly under mkdocs strict mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)