### PR TITLE
Make markdown mention test workspace-neutral

### DIFF
--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -6,6 +6,19 @@ import ultimate_notion as uno
 from ultimate_notion.blocks import TextBlock
 
 
+def _neutralize_mention(md: str) -> str:
+    """Replace a `[@<name>]()` person mention with a workspace-neutral `[@USER]()`.
+
+    Keeps the test portable across maintainers re-recording the cassette, who will have a
+    different user name in the mention (cf. `test_rich_text.py`).
+    """
+    before, mention, rest = md.partition('[@')
+    if not mention:
+        return md
+    _name, end, after = rest.partition(']()')
+    return f'{before}[@USER](){after}' if end else md
+
+
 @pytest.mark.vcr()
 def test_rich_text_md(md_text_page: uno.Page) -> None:
     """These markdowns were tested with https://stackedit.io/app#"""
@@ -17,7 +30,7 @@ def test_rich_text_md(md_text_page: uno.Page) -> None:
         'here is one more with a *strange **style*** **combination**',
         'here is one with an inline **~~equa-*tion*~~ *$E=mc^2$ and*** no block equation',
         (
-            'and here is one with ~~***person** mention [@Florian Wilhelm]()*~~ and **page mention '
+            'and here is one with ~~***person** mention [@USER]()*~~ and **page mention '
             '↗[Markdown Text Test](https://www.notion.so/0c8ea7f1c7ca4abb8890085c0fac383b)** '
         ),
         'here is one **stretching over *many\n~~many~~*\n~~lines~~**',
@@ -31,5 +44,5 @@ def test_rich_text_md(md_text_page: uno.Page) -> None:
     ]
     for idx, block in enumerate(md_text_page.children):
         assert isinstance(block, TextBlock)
-        our_md = block.to_markdown()
+        our_md = _neutralize_mention(block.to_markdown())
         assert our_md == correct_mds[idx]


### PR DESCRIPTION
## Description

`test_rich_text_md` asserted on a hard-coded user name (`[@Florian Wilhelm]()`) rendered from the recorded cassette, so it would break for any maintainer re-recording it against their own workspace. This normalizes the person mention to `[@USER]()` before comparing — via a small `_neutralize_mention` string helper — mirroring the portable approach already used in `test_rich_text.py`. Advances #194 (removing hard-coded personal/workspace references from the test suite). Verified offline with `hatch run vcr-only tests/test_markdown.py` (passes against the existing cassette) plus ruff lint/format.

### Types of change

Test-infrastructure enhancement (portability), no production code change.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)