### PR TITLE
Drop wrap_obj_ref covariance type: ignores via a _finalize_wrap hook

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -419,14 +419,12 @@ class ParentBlock(Block[B_co], ChildrenMixin[B_co], wraps=obj_blocks.Block):
     def __hash__(self) -> int:
         return hash((super().__hash__(), *self.children))
 
-    @classmethod
-    def wrap_obj_ref(cls: type[Self], obj_ref: B_co, /) -> Self:  # type: ignore[misc] # breaking covariance
-        self = super().wrap_obj_ref(obj_ref)
+    def _finalize_wrap(self) -> None:
+        super()._finalize_wrap()
         value = self.obj_ref.value
-        if obj_ref.has_children and isinstance(value, obj_blocks.WithChildren) and value.children:
+        if self.obj_ref.has_children and isinstance(value, obj_blocks.WithChildren) and value.children:
             self._children = [Block.wrap_obj_ref(child) for child in value.children]
             value.children = []  # clear children to avoid confusion during comparison
-        return self
 
 
 class CaptionMixin(Block[B_co], wraps=obj_blocks.Block):

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -79,9 +79,18 @@ class Wrapper(Generic[GT_co], ABC):
         if cls is hl_cls:
             hl_obj = hl_cls.__new__(hl_cls)
             hl_obj._obj_ref = obj_ref
+            hl_obj._finalize_wrap()
             return cast(Self, hl_obj)
         else:
             return cast(Self, hl_cls.wrap_obj_ref(obj_ref))
+
+    def _finalize_wrap(self) -> None:
+        """Run subclass-specific initialisation after `wrap_obj_ref` has set `_obj_ref`.
+
+        Subclasses override this to derive state from `obj_ref` (e.g. an attribute name or child
+        blocks). It is an instance method rather than a parameter of `wrap_obj_ref` so that it does
+        not take the covariant type variable in an input position, which would break covariance.
+        """
 
     @property
     def _obj_api_map_inv(self) -> dict[type[Wrapper], type[GT_co]]:

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Annotated, Any, TypeAlias, cast, overload
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model, field_validator
 from tabulate import tabulate
-from typing_extensions import Self, TypeVar
+from typing_extensions import TypeVar
 
 import ultimate_notion.obj_api.core as obj_core
 import ultimate_notion.obj_api.schema as obj_schema
@@ -153,12 +153,10 @@ class Property(Wrapper[GO_co], ABC, wraps=PropertyGO):
 
         schema._set_obj_refs()
 
-    @classmethod
-    def wrap_obj_ref(cls, obj_ref: GO_co) -> Self:  # type: ignore[misc] # breaking covariance
-        """Wrap the object reference for this property."""
-        obj = super().wrap_obj_ref(obj_ref)
-        obj._attr_name = rich_text.snake_case(obj.name)
-        return obj
+    def _finalize_wrap(self) -> None:
+        """Derive the attribute name from the wrapped property's name."""
+        super()._finalize_wrap()
+        self._attr_name = rich_text.snake_case(self.name)
 
     def delete(self) -> None:
         """Delete this property from the schema."""


### PR DESCRIPTION
## Description

The covariant TypeVars `GO_co`/`B_co` were used in an input position on the `Property` and `ParentBlock` overrides of `wrap_obj_ref`, each requiring a `type: ignore[misc] # breaking covariance`. Since both overrides only post-process the freshly wrapped object, the logic moves into a new param-less `_finalize_wrap` instance-method hook on the base `Wrapper`, called by `wrap_obj_ref` right after it sets `_obj_ref`. This removes both variance violations with no cast or other workaround; behaviour is unchanged and `wrap_obj_ref` remains callable on both classes (now inherited). Verified with `hatch run vcr-only` (169 passed) and `hatch run lint:typing`/`lint:style`.

### Types of change

Code quality / internal refactor (removes two `type: ignore` comments). No functional change.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)