### PR TITLE
Drop value setter covariance type: ignore by widening param to object

### DIFF
--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -524,11 +524,13 @@ class TypedObject(GenericObject, Generic[TO_co]):
         return cast(TO_co, getattr(self, self._type_name))
 
     @value.setter
-    def value(self, val: TO_co) -> None:  # type: ignore[misc]  # breaking covariance
-        """Set the nested object."""
-        # we are breaking covariance here but going down the Protocol way didn't work out
-        # either due to many limititations, e.g. @runtime_checkable not working with inheritance, etc.
-        # This is still the most programmatic way it seems without adding too much complexity.
+    def value(self, val: object) -> None:
+        """Set the nested object.
+
+        The setter accepts ``object`` rather than the covariant ``TO_co``: a covariant type
+        variable may not appear in an input position, and ``TO_co`` is unbounded so ``object``
+        is its upper bound. The getter still narrows the return type to ``TO_co``.
+        """
         setattr(self, self._type_name, val)
 
 


### PR DESCRIPTION
## Description

`TypedObject.value`'s setter took the covariant `TO_co`, which is unsound in an input position and required a `# type: ignore[misc]`. Since the setter body only does an untyped `setattr`, the parameter is now typed `object` (the upper bound of the unbounded `TO_co`), while the getter still narrows its return to `TO_co` — so reads keep their precise type and the write side is honestly typed, with no cast or other workaround and identical runtime behaviour. mypy is clean and the removed ignore is no longer reported.

### Types of change

Code quality / typing fix (no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)