### PR TITLE
Let contributors run the offline test suite without a Notion token

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,13 @@ import ultimate_notion as uno
 from ultimate_notion import Database, Option, Page, Session, User, schema
 from ultimate_notion import blocks as uno_blocks
 from ultimate_notion.adapters.google.tasks import GTasksClient
-from ultimate_notion.config import ENV_ULTIMATE_NOTION_CFG, ENV_ULTIMATE_NOTION_DEBUG, get_cfg_file, get_or_create_cfg
+from ultimate_notion.config import (
+    ENV_NOTION_TOKEN,
+    ENV_ULTIMATE_NOTION_CFG,
+    ENV_ULTIMATE_NOTION_DEBUG,
+    get_cfg_file,
+    get_or_create_cfg,
+)
 from ultimate_notion.utils import temp_attr, temp_timezone
 
 if TYPE_CHECKING:
@@ -145,6 +151,21 @@ def exec_pyfile(file_path: str) -> None:
     """Executes a Python module as a script, as if it was called from the command line."""
     code = compile(Path(file_path).read_text(encoding='utf-8'), file_path, 'exec')
     exec(code, {'__MODULE__': '__main__'})  # noqa: S102
+
+
+@pytest.fixture(scope='session', autouse=True)
+def offline_replay_token(request: SubRequest) -> None:
+    """Provide a dummy Notion token for pure offline replay (`hatch run vcr-only`).
+
+    With `--record-mode=none` the network is blocked and every interaction is
+    replayed from a cassette, so the token is never actually sent. Supplying a
+    placeholder lets contributors run the offline suite with no credentials, as
+    promised in `CONTRIBUTING.md`. Live and (re-)recording runs are untouched: a
+    real token must be provided via `NOTION_TOKEN` for those.
+    """
+    replay_only = request.config.getoption('--record-mode') == 'none'
+    if replay_only and not os.environ.get(ENV_NOTION_TOKEN):
+        os.environ[ENV_NOTION_TOKEN] = 'secret...'  # never sent; the network is blocked during replay
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
## Description

`hatch run vcr-only` replays VCR cassettes with the network blocked, so the Notion token is never sent — yet `uno.Session()` raised `No Notion token found!` whenever the token was missing, breaking the entire offline suite for fresh contributors and fork PRs (where the CI secret is unavailable) and contradicting the `CONTRIBUTING.md` promise that replay needs no credentials. This adds a replay-only autouse fixture in `tests/conftest.py` that injects a placeholder token when `--record-mode=none` and none is already set, while live runs and cassette re-recording still require a real `NOTION_TOKEN`. Verified with `env -u NOTION_TOKEN hatch run vcr-only` (full suite now passes), plus `hatch run lint:style` and `hatch run lint:typing`.

### Types of change

Bug fix (test infrastructure).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
