### PR TITLE
Narrow block types to drop attr-defined ignores in nesting test

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -739,7 +739,9 @@ def test_max_nesting_level(root_page: uno.Page, notion: uno.Session) -> None:
     # add a 1st level of nesting
     blocks[0].append([uno.BulletedItem(f'Nested Point {i}') for i in range(n_blocks)])
     # add a 2nd level of nesting
-    blocks[0].blocks[0].append([uno.BulletedItem(f'Deeply Nested Point {i}') for i in range(n_blocks)])  # type: ignore[attr-defined]
+    nested = blocks[0].blocks[0]
+    assert isinstance(nested, uno.BulletedItem)
+    nested.append([uno.BulletedItem(f'Deeply Nested Point {i}') for i in range(n_blocks)])
 
     page = notion.create_page(
         parent=root_page, title='Page for testing max nesting level', blocks=[uno.Paragraph('Intro')]
@@ -747,8 +749,12 @@ def test_max_nesting_level(root_page: uno.Page, notion: uno.Session) -> None:
     page.append(blocks)
 
     assert len(page.blocks) == n_blocks + 1
-    assert len(page.blocks[1].blocks) == n_blocks  # type: ignore[attr-defined]
-    assert len(page.blocks[1].blocks[0].blocks) == n_blocks  # type: ignore[attr-defined]
+    first_nested = page.blocks[1]
+    assert isinstance(first_nested, uno.BulletedItem)
+    assert len(first_nested.blocks) == n_blocks
+    second_nested = first_nested.blocks[0]
+    assert isinstance(second_nested, uno.BulletedItem)
+    assert len(second_nested.blocks) == n_blocks
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Description

Removes three `# type: ignore[attr-defined]` comments in `test_max_nesting_level` by fixing the root cause rather than suppressing the checker: the `.blocks` property returns `tuple[Block, ...]`, and the base `Block` has no children API, so the test now narrows those elements to `BulletedItem` via `isinstance` assertions. These assertions are always true given the test constructs `BulletedItem`s, and they also validate the expected block types at runtime. The change holds across mypy and stricter checkers (pyright/basedpyright), and the test still passes under VCR playback.

### Types of change

Test/code-quality cleanup (no behavior change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
