### PR TITLE
Generalize personal name in docs table example (#194)

### DIFF
--- a/docs/usage/page_advanced.md
+++ b/docs/usage/page_advanced.md
@@ -228,8 +228,8 @@ Creating a 4x6 table with 4 rows and 6 columns where the first row is a header r
 ```python
 table = uno.Table(4, 3, header_row=True, header_col=False)
 table[0] = ('First name', 'Last name', 'Sports')
-table[1, 0] = 'Florian'
-table[1, 1] = 'Wilhelm'
+table[1, 0] = 'Jane'
+table[1, 1] = 'Doe'
 table[1, 2] = 'Running and bicycling'
 
 page.append(table)


### PR DESCRIPTION
## What

Replaces the maintainer's real name (`Florian` / `Wilhelm`) used as sample table-cell data in `docs/usage/page_advanced.md` with the neutral `Jane` / `Doe` placeholder.

This was the last non-attribution personal reference outside the recorded cassettes, completing the de-personalization tracked in #194. (Author attributions in `pyproject.toml`/`README.md`/`AUTHORS.md` are legitimate and intentionally left as-is.)

## Safe for offline replay

The snippet is exercised by `test_page_advanced` against `test_page_advanced.yaml`. VCR here matches on method+URI (no `match_on` override), so the changed request body still replays against the existing cassette — no re-recording needed.

## Verification

- `hatch run vcr-only -k test_page_advanced` → 1 passed
- `hatch run vcr-only` → 169 passed, 14 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)