### PR TITLE
Drop obj_ref setter covariance type: ignore via a covariant self-view

### DIFF
--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -64,8 +64,15 @@ class Wrapper(Generic[GT_co], ABC):
         return self._obj_ref
 
     @obj_ref.setter
-    def obj_ref(self, value: GT_co) -> None:  # type: ignore[misc] # breaking covariance
-        """Set the low-level Notion-API object reference."""
+    def obj_ref(self: Wrapper[obj_core.GenericObject], value: obj_core.GenericObject) -> None:
+        """Set the low-level Notion-API object reference.
+
+        Both `self` and `value` are typed against `GenericObject` (the upper bound of the covariant
+        `GT_co`) rather than `GT_co` itself: a covariant type variable may not appear in an input
+        position. Viewing `self` as `Wrapper[GenericObject]` is sound precisely because `Wrapper` is
+        covariant, and it makes the assignment to `_obj_ref` type-check without breaking covariance.
+        The getter still narrows the return type to `GT_co`.
+        """
         self._obj_ref = value
 
     @classmethod

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -495,7 +495,11 @@ class Relation(Property[obj_schema.Relation], wraps=obj_schema.Relation):
         return self._obj_ref
 
     @obj_ref.setter
-    def obj_ref(self, new_obj_ref: obj_schema.Relation) -> None:
+    def obj_ref(self: Wrapper[obj_core.GenericObject], new_obj_ref: obj_core.GenericObject) -> None:
+        # Mirrors `Wrapper.obj_ref`'s setter: the parameter is widened to `GenericObject` (the upper
+        # bound of the covariant type variable) so it stays contravariant with the base, and viewing
+        # `self` as `Wrapper[GenericObject]` keeps the assignment sound. The getter above still
+        # narrows the return type to `obj_schema.Relation`.
         self._obj_ref = new_obj_ref
 
     @property


### PR DESCRIPTION
## Description

`Wrapper.obj_ref`'s setter took the covariant `GT_co`, which is unsound in an input position and required a `# type: ignore[misc]`. Both `self` and the value are now typed against `GenericObject` (the upper bound of `GT_co`); annotating `self: Wrapper[GenericObject]` is a sound upcast because `Wrapper` is genuinely covariant, so the assignment to `_obj_ref` type-checks without a `cast` while the getter still narrows reads to `GT_co`. `Relation` overrides the getter and so re-declares the setter, getting the same widening to stay contravariant with the base. This is annotation-only with no runtime change, and `hatch run lint:typing`/`lint:style` are clean.

### Types of change

Maintenance / typing improvement (removes a `type: ignore`).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.