### PR TITLE
Narrow code block annotations to drop union-attr ignores in color test

### DIFF
--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -638,14 +638,18 @@ def test_nested_bullet_items(root_page: uno.Page, notion: uno.Session) -> None:
 def test_color_code_block(root_page: uno.Page, notion: uno.Session) -> None:
     page = notion.create_page(parent=root_page, title='Page for color code block')
     code_block = uno.Code('print("Hello, world!")', language='python')
-    assert code_block.obj_ref.code.rich_text[0].annotations.color is Unset  # type: ignore[union-attr]
+    annotations = code_block.obj_ref.code.rich_text[0].annotations
+    assert isinstance(annotations, objs.Annotations)
+    assert annotations.color is Unset
     page.append(code_block)
 
     assert page.children == (code_block,)
     assert code_block.language == 'python'
     # Note that None was replaced with Color.DEFAULT by the API. Sending it directly
     # would have prevented the python code coloring from being applied in the Notion UI.
-    assert code_block.obj_ref.code.rich_text[0].annotations.color is uno.Color.DEFAULT  # type: ignore[union-attr]
+    annotations = code_block.obj_ref.code.rich_text[0].annotations
+    assert isinstance(annotations, objs.Annotations)
+    assert annotations.color is uno.Color.DEFAULT
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Description

`RichTextBaseObject.annotations` is typed `Annotations | UnsetType`, so accessing `.color` directly in `test_color_code_block` raised a mypy `union-attr` error that was silenced with two `# type: ignore[union-attr]` comments. This PR binds the value and narrows it with an `isinstance` assert instead, removing both ignores while also strengthening the test by confirming the annotations object is actually present. No production code changes; verified with `hatch run lint:typing tests/test_blocks.py` (clean) and `hatch run vcr-only tests/test_blocks.py::test_color_code_block` (passes).

### Types of change

Test cleanup / type-safety improvement.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
