### PR TITLE
Narrow ID property via isinstance to drop attr-defined ignores in tests

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -565,25 +565,30 @@ def test_update_unique_id_prop(notion: uno.Session, root_page: uno.Page, get_id_
 
     db = notion.create_db(parent=root_page, schema=Schema)
 
-    db.schema.unique_id.prefix = new_id_prefix  # type: ignore[attr-defined]
+    unique_id = db.schema.unique_id
+    assert isinstance(unique_id, uno.PropType.ID)
+
+    unique_id.prefix = new_id_prefix
     db.reload()
-    assert db.schema.unique_id.prefix.startswith(new_id_prefix)  # type: ignore[attr-defined]
+    assert unique_id.prefix.startswith(new_id_prefix)
 
     with pytest.raises(ValueError):
-        db.schema.unique_id.prefix = 'Invalid Prefix!'  # type: ignore[attr-defined]
+        unique_id.prefix = 'Invalid Prefix!'
 
-    db.schema.unique_id.prefix = None  # type: ignore[attr-defined]
-    assert db.schema.unique_id.prefix == ''  # type: ignore[attr-defined]
+    unique_id.prefix = None
+    assert unique_id.prefix == ''
 
-    db.schema.unique_id.prefix = ''  # type: ignore[attr-defined]
-    assert db.schema.unique_id.prefix == ''  # type: ignore[attr-defined]
+    unique_id.prefix = ''
+    assert unique_id.prefix == ''
 
     class NoIDPrefixSchema(uno.Schema, db_title='No Prefix ID Test'):
         name = uno.PropType.Title('Name')
         unique_id = uno.PropType.ID('ID')
 
     db = notion.create_db(parent=root_page, schema=NoIDPrefixSchema)
-    assert db.schema.unique_id.prefix == ''  # type: ignore[attr-defined]
+    unique_id = db.schema.unique_id
+    assert isinstance(unique_id, uno.PropType.ID)
+    assert unique_id.prefix == ''
 
     with pytest.raises(SchemaError):
 


### PR DESCRIPTION
## Description

Removes seven `# type: ignore[attr-defined]` comments from `test_update_unique_id_prop` in `tests/test_schema.py`. The ignores existed because `db.schema.unique_id` is typed to return the base `Property` class, whose interface lacks the `ID`-specific `.prefix` attribute. Instead of suppressing the checker, the property is now bound to a local and narrowed with `assert isinstance(unique_id, uno.PropType.ID)`, which gives mypy the concrete type for both reads and writes while adding a real runtime assertion. No casts or `__mro__`/`getattr` tricks are used.

### Types of change

Code quality / test cleanup (no behavior change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
