### PR TITLE
Remove wrap_obj_ref covariance type: ignore by widening to GenericObject

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -42,6 +42,7 @@ from ultimate_notion.errors import InvalidAPIUsageError, UnknownDatabaseError
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
 from ultimate_notion.markdown import md_comment
 from ultimate_notion.obj_api import blocks as obj_blocks
+from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.enums import BGColor, CodeLang, Color
@@ -1246,7 +1247,12 @@ class TableRow(tuple[Text | None, ...], Block[obj_blocks.TableRow], wraps=obj_bl
             self.obj_ref.table_row.cells[idx] = Text(cell).obj_ref
 
     @classmethod
-    def wrap_obj_ref(cls, obj_ref: obj_blocks.TableRow, /) -> TableRow:
+    def wrap_obj_ref(cls, obj_ref: obj_core.GenericObject, /) -> TableRow:
+        # `obj_ref` is typed against the covariant upper bound `GenericObject`; the registry guarantees
+        # that `TableRow.wrap_obj_ref` is only ever handed a `TableRow` object.
+        if not isinstance(obj_ref, obj_blocks.TableRow):
+            msg = f'Expected a `TableRow` object, got `{type(obj_ref).__name__}`'
+            raise TypeError(msg)
         row = TableRow(*[Text.wrap_obj_ref(cell) if cell else None for cell in obj_ref.table_row.cells])
         row.obj_ref = obj_ref
         return row

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -35,9 +35,9 @@ class Wrapper(Generic[GT_co], ABC):
 
     _obj_ref: GT_co
 
-    _obj_api_map: ClassVar[dict[type[GT_co], type[Wrapper]]] = {}
+    _obj_api_map: ClassVar[dict[type[obj_core.GenericObject], type[Wrapper]]] = {}
 
-    def __init_subclass__(cls, wraps: type[GT_co], **kwargs: Any):
+    def __init_subclass__(cls, wraps: type[obj_core.GenericObject], **kwargs: Any):
         super().__init_subclass__(**kwargs)
         cls._obj_api_map[wraps] = cls
 
@@ -45,9 +45,9 @@ class Wrapper(Generic[GT_co], ABC):
         # Needed for wrap_obj_ref and its call to __new__ to work!
         return super().__new__(cls)
 
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self: Wrapper[obj_core.GenericObject], *args: Any, **kwargs: Any):
         """Default constructor that also builds `obj_ref`."""
-        obj_api_type: type[GT_co] = self._obj_api_map_inv[self.__class__]
+        obj_api_type = self._obj_api_map_inv[self.__class__]
         self._obj_ref = obj_api_type.build(*args, **kwargs)
 
     def __pydantic_serializer__(self) -> SchemaSerializer:  # noqa: PLW3201
@@ -76,8 +76,13 @@ class Wrapper(Generic[GT_co], ABC):
         self._obj_ref = value
 
     @classmethod
-    def wrap_obj_ref(cls: type[Self], obj_ref: GT_co, /) -> Self:  # type: ignore[misc] # breaking covariance
-        """Wraps low-level `obj_ref` from Notion API into a high-level (hl) object of Ultimate Notion."""
+    def wrap_obj_ref(cls: type[Self], obj_ref: obj_core.GenericObject, /) -> Self:
+        """Wraps low-level `obj_ref` from Notion API into a high-level (hl) object of Ultimate Notion.
+
+        `obj_ref` is typed against `GenericObject` (the upper bound of the covariant `GT_co`) rather
+        than `GT_co` itself, since a covariant type variable may not appear in an input position. The
+        concrete high-level class is resolved at runtime from the registry keyed on `type(obj_ref)`.
+        """
         hl_cls = cls._obj_api_map[type(obj_ref)]
         # Resolving `obj_ref` may yield a more specific high-level class than `cls`, e.g. calling
         # `Block.wrap_obj_ref` on a paragraph object resolves `hl_cls` to `Paragraph`. In that case we
@@ -100,7 +105,7 @@ class Wrapper(Generic[GT_co], ABC):
         """
 
     @property
-    def _obj_api_map_inv(self) -> dict[type[Wrapper], type[GT_co]]:
+    def _obj_api_map_inv(self) -> dict[type[Wrapper], type[obj_core.GenericObject]]:
         return {v: k for k, v in self._obj_api_map.items()}
 
 

--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ultimate_notion.core import Wrapper, get_repr
 from ultimate_notion.errors import UnsetError
+from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.core import Unset, UnsetType, raise_unset
 from ultimate_notion.obj_api.enums import Color, OptionGroupType
@@ -120,7 +121,7 @@ class OptionGroup(Wrapper[objs.SelectGroup], wraps=objs.SelectGroup):
         super().__init__(name=name, color=color, option_ids=option_ids)
 
     @classmethod
-    def wrap_obj_ref(cls, obj_ref: objs.SelectGroup, /, *, options: list[Option] | None = None) -> OptionGroup:
+    def wrap_obj_ref(cls, obj_ref: obj_core.GenericObject, /, *, options: list[Option] | None = None) -> OptionGroup:
         """Convienence constructor for the group of options."""
         obj = super().wrap_obj_ref(obj_ref)
         obj._options = [] if options is None else options

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -130,11 +130,9 @@ class Page(
 
     props: PagePropertiesNS
 
-    @classmethod
-    def wrap_obj_ref(cls, obj_ref: obj_blocks.Page, /) -> Self:
-        obj = super().wrap_obj_ref(obj_ref)
-        obj.props = obj._create_page_props_ns()
-        return obj
+    def _finalize_wrap(self) -> None:
+        super()._finalize_wrap()
+        self.props = self._create_page_props_ns()
 
     def _create_page_props_ns(self) -> PagePropertiesNS:
         """Create a namespace for the properties of this page defind by the database."""

--- a/src/ultimate_notion/props.py
+++ b/src/ultimate_notion/props.py
@@ -42,10 +42,6 @@ class PropertyValue(Wrapper[PV_co], ABC, wraps=obj_props.PropertyValue):
         type_name = wraps.model_fields['type'].get_default()
         cls._type_value_map[type_name] = cls
 
-    @property
-    def _obj_api_type(self) -> type[obj_props.PropertyValue]:
-        return self._obj_api_map_inv[self.__class__]
-
     def __init__(self, values: Any | Sequence[Any]):
         if isinstance(values, Sequence) and not isinstance(values, str | bytes):
             values = [value.obj_ref if isinstance(value, Wrapper) else value for value in values]


### PR DESCRIPTION
## Description

Removes the `# type: ignore[misc]  # breaking covariance` on `Wrapper.wrap_obj_ref` — the last covariance ignore in the `Wrapper` hierarchy — by fixing the root cause rather than suppressing it: the covariant TypeVar `GT_co` no longer appears in an input position. The shared `_obj_api_map` registry is now honestly keyed by `type[GenericObject]` (keying a shared `ClassVar` by a per-subclass TypeVar was never coherent and basedpyright flagged it), `wrap_obj_ref`'s parameter is widened to `GenericObject` with the concrete class still resolved at runtime via the registry, and `__init__`'s `_obj_ref` build assignment uses a sound covariant-self upcast (`self: Wrapper[GenericObject]`). Consumers are adapted accordingly: `Page.wrap_obj_ref` is dropped in favour of the existing `_finalize_wrap` hook, the `OptionGroup`/`TableRow` overrides are widened (the latter gains a runtime type guard the registry already guarantees), and the dead, now-untypeable `_obj_api_type` property is deleted. No `cast` or `__mro__` tricks are used; mypy is clean and all 169 offline tests pass.

### Types of change

Internal refactor / type-checking improvement (no behaviour or API change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
