### PR TITLE
Narrow Formula prop via isinstance to drop attr-defined ignores in test

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -319,9 +319,13 @@ def test_add_del_update_prop(notion: uno.Session, root_page: uno.Page) -> None:
         db.schema['Number'] = uno.PropType.Formula('New Name', formula='prop("Name") + "!"')
 
     db.schema['Number'] = uno.PropType.Formula(formula='prop("Name") + "!"')
-    assert db.schema['Number'].formula.startswith('{{notion:block_property:title:')  # type: ignore[attr-defined]
+    formula = db.schema['Number']
+    assert isinstance(formula, uno.PropType.Formula)
+    assert formula.formula.startswith('{{notion:block_property:title:')
     db.reload()
-    assert db.schema['Number'].formula.startswith('{{notion:block_property:title:')  # type: ignore[attr-defined]
+    formula = db.schema['Number']
+    assert isinstance(formula, uno.PropType.Formula)
+    assert formula.formula.startswith('{{notion:block_property:title:')
 
     db.schema.number = uno.PropType.Number(format=uno.NumberFormat.PERCENT)
     assert db.schema.number.format == uno.NumberFormat.PERCENT


### PR DESCRIPTION
## Description

Removes two `# type: ignore[attr-defined]` comments in `tests/test_schema.py` (`test_add_del_update_prop`). `db.schema['Number']` returns the base `Property` type, which has no `.formula` attribute, so the ignores were suppressing the resulting mypy errors. Instead of suppressing, the result is now bound to a local and narrowed with `assert isinstance(formula, uno.PropType.Formula)`, which both satisfies mypy and adds a genuine runtime check that the property round-trips as the expected type. This follows the same pattern as commit 1bb4df8e in the same function. Verified with `hatch run lint:typing tests/test_schema.py` (clean) and `hatch run vcr-only tests/test_schema.py::test_add_del_update_prop` (passed).

### Types of change

Code quality / test cleanup (no functional change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
