### PR TITLE
Narrow Relation prop via isinstance to drop attr-defined ignores in change-target test

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -387,11 +387,15 @@ def test_update_prop_type_attrs(notion: uno.Session, root_page: uno.Page) -> Non
 
     # Change target from SchemaA to SchemaB for one-way and two-way relations
     for rel in ('Relation', 'Relation two-way'):
-        assert db_c.schema[rel].schema == db_a.schema  # type: ignore[attr-defined]
-        db_c.schema[rel].schema = db_b.schema  # type: ignore[attr-defined]
-        assert db_c.schema[rel].schema == db_b.schema  # type: ignore[attr-defined]
+        relation = db_c.schema[rel]
+        assert isinstance(relation, uno.PropType.Relation)
+        assert relation.schema == db_a.schema
+        relation.schema = db_b.schema
+        assert relation.schema == db_b.schema
         db_c.reload()
-        assert db_c.schema[rel].schema == db_b.schema  # type: ignore[attr-defined]
+        relation = db_c.schema[rel]
+        assert isinstance(relation, uno.PropType.Relation)
+        assert relation.schema == db_b.schema
 
     # change the options of the (multi-)select property
     options = [uno.Option(name='Cat1', color=uno.Color.DEFAULT), uno.Option(name='Cat2', color=uno.Color.RED)]


### PR DESCRIPTION
## Description

Removes 4 `# type: ignore[attr-defined]` comments in the relation change-target block of `test_update_prop_type_attrs`. The lookups `db_c.schema[rel]` return the base `Property` (which has no `schema` attribute) so the result is now bound to a local and narrowed with `assert isinstance(relation, uno.PropType.Relation)`, letting mypy type-check `.schema` access and assignment directly. This follows the same isinstance-narrowing approach as the recent #227–#232 PRs, with no casts or `__mro__` tricks. Verified with `hatch run lint:typing` and `hatch run vcr-only` on the affected tests.

### Types of change

Code quality / typing cleanup in tests (no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
