### PR TITLE
Drop GTaskList __iter__ override ignore via composition over BaseModel

### DIFF
--- a/src/ultimate_notion/adapters/google/tasks/client.py
+++ b/src/ultimate_notion/adapters/google/tasks/client.py
@@ -241,10 +241,60 @@ class GTask(GObject):
         return self
 
 
-class GTaskList(GObject):
-    """Representation of a Google Task List."""
+class _GTaskListData(GObject):
+    """Pydantic representation of the JSON fields of a Google Task List."""
 
     kind: Literal[Kind.TASK_LIST]
+
+
+class GTaskList:
+    """Representation of a Google Task List.
+
+    A task list is a collection of tasks. Unlike [`GTask`][], it is therefore not
+    a pydantic `BaseModel` itself but wraps its JSON fields in one. This lets
+    iterating over a task list yield its [`GTask`][]s instead of the
+    `(field, value)` pairs that pydantic's `BaseModel.__iter__` produces.
+    """
+
+    def __init__(self, resource: Resource, **data: Any) -> None:
+        self._data = _GTaskListData(resource=resource, **data)
+
+    @property
+    def _resource(self) -> Resource:
+        return self._data._resource
+
+    @property
+    def id(self) -> str:  # A003
+        """Returns the ID of this task list."""
+        return self._data.id
+
+    @property
+    def kind(self) -> Kind:
+        """Returns the kind of this Google object."""
+        return self._data.kind
+
+    @property
+    def etag(self) -> str:
+        """Returns the ETag of this task list."""
+        return self._data.etag
+
+    @property
+    def updated(self) -> datetime:
+        """Returns the time this task list was last updated."""
+        return self._data.updated
+
+    @property
+    def self_link(self) -> HttpUrl:
+        """Returns the API URL of this task list."""
+        return self._data.self_link
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, GTaskList):
+            return self._data == other._data
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._data)
 
     def all_tasks(self, *, show_deleted: bool = False) -> list[GTask]:
         """Returns a list of all tasks, completed or not, in this task list."""
@@ -270,7 +320,7 @@ class GTaskList(GObject):
 
         return tasks
 
-    def __iter__(self) -> Iterator[GTask]:  # type: ignore[override]
+    def __iter__(self) -> Iterator[GTask]:
         """Returns an iterator over all tasks in this task list."""
         yield from self.all_tasks()
 
@@ -321,20 +371,20 @@ class GTaskList(GObject):
     @property
     def title(self) -> str:
         """Returns the title of this task list."""
-        return self.title_
+        return self._data.title_
 
     @title.setter
     def title(self, new_title: str) -> None:
         """Sets the title of this task list."""
         resource = self._resource.tasklists()
         resp = resource.patch(tasklist=self.id, body={'title': new_title}).execute()
-        self._update(resp)
+        self._data._update(resp)
 
     def reload(self) -> GTaskList:
         """Reloads this task list from the API."""
         resource = self._resource.tasklists()
         resp = resource.get(tasklist=self.id).execute()
-        self._update(resp)
+        self._data._update(resp)
         return self
 
 


### PR DESCRIPTION
## Description

`GTaskList` subclassed the pydantic `GObject`/`BaseModel`, so its `__iter__ -> Iterator[GTask]` was an incompatible override of `BaseModel.__iter__` (which yields `(field, value)` pairs) and carried a `# type: ignore[override]`. This wraps the task-list JSON fields in a new `_GTaskListData(GObject)` model and makes `GTaskList` a plain class that holds one, delegating its data fields and equality, so `GTaskList.__iter__` overrides nothing and the ignore is removed at the root rather than suppressed. There is no public API change — `for task in tasklist`, the data fields, and equality all behave as before. Verified with `hatch run lint:typing` (clean aside from the pre-existing pendulum stub drift) and `hatch run vcr-only tests/adapters/google/`.

### Types of change

Code quality / type-correctness refactor (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)