### PR TITLE
Set mypy to strict mode

### DIFF
--- a/locks/lint.lock
+++ b/locks/lint.lock
@@ -6,6 +6,10 @@
 # - mypy==1.18.2
 # - ruff==0.14.5
 # - pyright~=1.1
+# - types-tabulate
+# - pandas-stubs
+# - pytest
+# - hypothesis
 # - httpx>=0.27
 # - notion-client~=2.5.0
 # - tabulate>=0.9
@@ -61,6 +65,8 @@ exceptiongroup==1.3.0
     # via
     #   -c locks/default.lock
     #   anyio
+    #   hypothesis
+    #   pytest
 google-api-core==2.28.1
     # via
     #   -c locks/default.lock
@@ -107,6 +113,10 @@ httpx==0.28.1
     #   -c locks/default.lock
     #   hatch.envs.lint
     #   notion-client
+hypothesis==6.147.0
+    # via
+    #   -c locks/default.lock
+    #   hatch.envs.lint
 idna==3.11
     # via
     #   -c locks/default.lock
@@ -114,6 +124,10 @@ idna==3.11
     #   httpx
     #   requests
     #   url-normalize
+iniconfig==2.3.0
+    # via
+    #   -c locks/default.lock
+    #   pytest
 markdown-it-py==4.0.0
     # via
     #   -c locks/default.lock
@@ -143,6 +157,7 @@ numpy==2.2.6
     #   -c locks/default.lock
     #   hatch.envs.lint
     #   pandas
+    #   pandas-stubs
 oauthlib==3.3.1
     # via
     #   -c locks/default.lock
@@ -151,16 +166,23 @@ packaging==25.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+    #   pytest
 pandas==2.3.3
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+pandas-stubs==2.3.3.260113
+    # via hatch.envs.lint
 pathspec==0.12.1
     # via mypy
 pendulum==3.1.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+pluggy==1.6.0
+    # via
+    #   -c locks/default.lock
+    #   pytest
 polars==1.35.2
     # via
     #   -c locks/default.lock
@@ -199,6 +221,7 @@ pydantic-core==2.41.5
 pygments==2.19.2
     # via
     #   -c locks/default.lock
+    #   pytest
     #   rich
 pyparsing==3.2.5
     # via
@@ -206,6 +229,10 @@ pyparsing==3.2.5
     #   httplib2
 pyright==1.1.407
     # via hatch.envs.lint
+pytest==9.0.0
+    # via
+    #   -c locks/default.lock
+    #   hatch.envs.lint
 python-dateutil==2.9.0.post0
     # via
     #   -c locks/default.lock
@@ -246,6 +273,10 @@ sniffio==1.3.1
     # via
     #   -c locks/default.lock
     #   anyio
+sortedcontainers==2.4.0
+    # via
+    #   -c locks/default.lock
+    #   hypothesis
 tabulate==0.9.0
     # via
     #   -c locks/default.lock
@@ -255,6 +286,7 @@ tomli==2.3.0
     #   -c locks/default.lock
     #   hatch.envs.lint
     #   mypy
+    #   pytest
 tomli-w==1.2.0
     # via
     #   -c locks/default.lock
@@ -263,6 +295,10 @@ typer==0.20.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+types-pytz==2026.2.0.20260518
+    # via pandas-stubs
+types-tabulate==0.10.0.20260508
+    # via hatch.envs.lint
 typing-extensions==4.15.0
     # via
     #   -c locks/default.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,22 @@ plugins = ["pydantic.mypy"]
 files = ["src/ultimate_notion", "tests", "examples"]
 show_column_numbers = true
 pretty = true
-ignore_missing_imports = true # missing stubs like pytest
 strict = true
 disallow_untyped_calls = false
 disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+# Third-party libraries shipping neither type information nor stubs on typeshed
+module = [
+    "googleapiclient.*",
+    "google_auth_oauthlib.*",
+    "IPython",
+    "IPython.*",
+    "mktestdocs",
+    "vcr",
+    "vcr.*",
+]
+ignore_missing_imports = true
 
 # Pytest configuration
 
@@ -364,6 +376,11 @@ dependencies = [
     "mypy==1.18.2",
     "ruff==0.14.5", # make sure this is consistent with .pre-commit-config.yaml, thus pinned!
     "pyright~=1.1", # no automatic testing, just additionally to mypy
+    "types-tabulate", # stubs for tabulate, otherwise mypy needs --install-types
+    "pandas-stubs", # stubs for pandas
+    # Typed test deps so mypy checks against their real types instead of ignoring them
+    "pytest",
+    "hypothesis",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,22 +110,10 @@ plugins = ["pydantic.mypy"]
 files = ["src/ultimate_notion", "tests", "examples"]
 show_column_numbers = true
 pretty = true
-follow_imports = "normal"
 ignore_missing_imports = true # missing stubs like pytest
-disallow_untyped_defs = true
-disallow_incomplete_defs = true
+strict = true
 disallow_untyped_calls = false
 disallow_untyped_decorators = false
-disallow_any_generics = true
-disallow_any_unimported = false
-disallow_any_expr = false
-disallow_any_explicit = false
-disallow_any_decorated = false
-warn_return_any = true
-warn_unused_ignores = true
-warn_no_return = true
-warn_redundant_casts = true
-warn_unused_configs = true
 
 # Pytest configuration
 

--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -46,7 +46,8 @@ from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.enums import BGColor, CodeLang, Color
-from ultimate_notion.rich_text import Text, User
+from ultimate_notion.rich_text import Text
+from ultimate_notion.user import User
 from ultimate_notion.utils import set_attr_none
 
 if TYPE_CHECKING:
@@ -1474,7 +1475,7 @@ class SyncedBlock(ParentBlock[obj_blocks.SyncedBlock], wraps=obj_blocks.SyncedBl
             raise RuntimeError(msg)
 
         obj = obj_blocks.SyncedBlock.build()
-        obj.synced_block.synced_from = obj_blocks.BlockRef.build(self.obj_ref)
+        obj.synced_block.synced_from = objs.BlockRef.build(self.obj_ref)
         return self.wrap_obj_ref(obj)
 
     def to_markdown(self, *, with_comment: bool = True) -> str:

--- a/src/ultimate_notion/emoji.py
+++ b/src/ultimate_notion/emoji.py
@@ -11,11 +11,12 @@ from emoji import demojize, emojize, is_emoji
 from ultimate_notion.core import Wrapper, get_repr
 from ultimate_notion.errors import InvalidAPIUsageError
 from ultimate_notion.obj_api import objects as objs
+from ultimate_notion.obj_api.core import TypedObject
 
-TO = TypeVar('TO', bound=objs.TypedObject)
+TO = TypeVar('TO', bound=TypedObject)
 
 
-class EmojiBase(Wrapper[TO], str, ABC, wraps=objs.TypedObject):
+class EmojiBase(Wrapper[TO], str, ABC, wraps=TypedObject):
     """Base class for emoji objects, which behave like str."""
 
     @property

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -22,7 +22,15 @@ from typing import Annotated, Any, Generic, cast
 from pydantic import AfterValidator, Field, SerializeAsAny
 from typing_extensions import TypeVar
 
-from ultimate_notion.obj_api.core import GenericObject, NotionEntity, TypedObject, Unset, UnsetType
+from ultimate_notion.obj_api.core import (
+    GenericObject,
+    NotionEntity,
+    ParentRef,
+    TypedObject,
+    Unset,
+    UnsetType,
+    UserRef,
+)
 from ultimate_notion.obj_api.enums import BGColor, CodeLang, Color
 from ultimate_notion.obj_api.objects import (
     MAX_TEXT_OBJECT_SIZE,
@@ -35,10 +43,8 @@ from ultimate_notion.obj_api.objects import (
     MentionMixin,
     MentionObject,
     MentionPage,
-    ParentRef,
     RichTextBaseObject,
     TextObject,
-    UserRef,
 )
 from ultimate_notion.obj_api.props import PropertyValue, Title
 from ultimate_notion.obj_api.schema import Property

--- a/src/ultimate_notion/obj_api/endpoints.py
+++ b/src/ultimate_notion/obj_api/endpoints.py
@@ -16,7 +16,16 @@ from uuid import UUID
 from pydantic import SerializeAsAny, TypeAdapter
 
 from ultimate_notion.obj_api.blocks import Block, Database, FileBase, Page
-from ultimate_notion.obj_api.core import Unset, UnsetType, is_unset, raise_unset
+from ultimate_notion.obj_api.core import (
+    GenericObject,
+    ObjectRef,
+    ParentRef,
+    Unset,
+    UnsetType,
+    UserRef,
+    is_unset,
+    raise_unset,
+)
 from ultimate_notion.obj_api.enums import FileUploadMode, FileUploadStatus
 from ultimate_notion.obj_api.iterator import EndpointIterator, PropertyItemList
 from ultimate_notion.obj_api.objects import (
@@ -27,13 +36,9 @@ from ultimate_notion.obj_api.objects import (
     EmojiObject,
     FileObject,
     FileUpload,
-    GenericObject,
-    ObjectRef,
     PageRef,
-    ParentRef,
     RichTextBaseObject,
     User,
-    UserRef,
 )
 from ultimate_notion.obj_api.props import PropertyItem, PropertyValue, Title
 from ultimate_notion.obj_api.query import DBQueryBuilder, SearchQueryBuilder

--- a/src/ultimate_notion/obj_api/props.py
+++ b/src/ultimate_notion/obj_api/props.py
@@ -20,17 +20,15 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 from pydantic import Field, SerializeAsAny, field_validator, model_serializer
 from typing_extensions import NotRequired, Self
 
-from ultimate_notion.obj_api.core import GenericObject, NotionObject, Unset, UnsetType
-from ultimate_notion.obj_api.enums import FormulaType, RollupType, VState
+from ultimate_notion.obj_api.core import GenericObject, NotionObject, ObjectRef, TypedObject, Unset, UnsetType
+from ultimate_notion.obj_api.enums import AggFunc, FormulaType, RollupType, VState
 from ultimate_notion.obj_api.objects import (
     DateRange,
     FileObject,
-    ObjectRef,
     RichTextBaseObject,
-    TypedObject,
+    SelectOption,
     User,
 )
-from ultimate_notion.obj_api.schema import AggFunc, SelectOption
 from ultimate_notion.utils import DateTimeOrRange
 
 if TYPE_CHECKING:

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -12,13 +12,14 @@ from ultimate_notion.comment import Discussion
 from ultimate_notion.core import NotionEntity, WorkspaceType, get_active_session, get_repr
 from ultimate_notion.emoji import CustomEmoji, Emoji
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
+from ultimate_notion.markdown import render_md
 from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api import props as obj_props
 from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.props import MAX_ITEMS_PER_PROPERTY
 from ultimate_notion.props import PropertyValue, Title
-from ultimate_notion.rich_text import Text, render_md
+from ultimate_notion.rich_text import Text
 from ultimate_notion.schema import Property
 from ultimate_notion.templates import page_html
 from ultimate_notion.utils import SList, is_notebook

--- a/src/ultimate_notion/props.py
+++ b/src/ultimate_notion/props.py
@@ -14,12 +14,14 @@ from typing_extensions import Self, TypeVar
 
 import ultimate_notion.obj_api.props as obj_props
 from ultimate_notion import rich_text as rt
-from ultimate_notion.core import Wrapper, get_active_session, get_repr, raise_unset
+from ultimate_notion.core import Wrapper, get_active_session, get_repr
 from ultimate_notion.file import AnyFile
+from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.enums import FormulaType, RollupType, VState
-from ultimate_notion.obj_api.objects import DateRange, DateTimeOrRange
+from ultimate_notion.obj_api.objects import DateRange
 from ultimate_notion.option import Option
 from ultimate_notion.user import User
+from ultimate_notion.utils import DateTimeOrRange
 
 if TYPE_CHECKING:
     from ultimate_notion.page import Page

--- a/src/ultimate_notion/rich_text.py
+++ b/src/ultimate_notion/rich_text.py
@@ -20,6 +20,7 @@ from ultimate_notion.obj_api.core import Unset
 from ultimate_notion.obj_api.enums import BGColor, Color
 from ultimate_notion.obj_api.objects import MAX_TEXT_OBJECT_SIZE
 from ultimate_notion.user import User
+from ultimate_notion.utils import DateTimeOrRange
 
 if TYPE_CHECKING:
     from ultimate_notion.database import Database
@@ -115,7 +116,7 @@ class Mention(RichTextBase[objs.MentionObject], wraps=objs.MentionObject):
 
     def __init__(
         self,
-        target: User | Page | Database | CustomEmoji | objs.DateTimeOrRange,
+        target: User | Page | Database | CustomEmoji | DateTimeOrRange,
         *,
         bold: bool = False,
         italic: bool = False,
@@ -139,7 +140,7 @@ class Mention(RichTextBase[objs.MentionObject], wraps=objs.MentionObject):
 
 
 def mention(
-    target: User | Page | Database | CustomEmoji | objs.DateTimeOrRange,
+    target: User | Page | Database | CustomEmoji | DateTimeOrRange,
     *,
     bold: bool = False,
     italic: bool = False,

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -47,8 +47,8 @@ from ultimate_notion.errors import (
     UnsetError,
 )
 from ultimate_notion.obj_api.core import Unset, UnsetType, is_unset, raise_unset
-from ultimate_notion.obj_api.enums import OptionGroupType
-from ultimate_notion.obj_api.schema import AggFunc, NumberFormat
+from ultimate_notion.obj_api.enums import AggFunc, NumberFormat, OptionGroupType
+from ultimate_notion.obj_api.objects import SelectGroup
 from ultimate_notion.option import Option, OptionGroup, OptionNS, check_for_updates
 from ultimate_notion.props import PropertyValue
 from ultimate_notion.utils import SList, dict_diff_str, is_notebook
@@ -362,7 +362,7 @@ class Status(Property[obj_schema.Status], wraps=obj_schema.Status):
         """Return the options of this status property."""
         return [Option.wrap_obj_ref(option) for option in self.obj_ref.status.options]
 
-    def _extract_groups(self) -> list[tuple[obj_schema.SelectGroup, list[Option]]]:
+    def _extract_groups(self) -> list[tuple[SelectGroup, list[Option]]]:
         """Extract options from a group."""
 
         def get_id(option: Option) -> str:

--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -21,6 +21,7 @@ import pendulum as pnd
 import tomli_w
 from numpy.typing import NDArray
 from packaging.version import Version
+from pendulum.tz import local_timezone
 from pydantic import BaseModel
 from typing_extensions import Self
 
@@ -383,7 +384,7 @@ def temp_timezone(tz: str | pnd.Timezone) -> Iterator[None]:
     if not isinstance(tz, pnd.Timezone):
         tz = pnd.timezone(tz)
 
-    current_tz = pnd.local_timezone()
+    current_tz = local_timezone()
     if not isinstance(current_tz, pnd.Timezone):
         msg = f'Expected a Timezone object but got type {type(current_tz)}.'
         raise RuntimeError(msg)

--- a/src/ultimate_notion/view.py
+++ b/src/ultimate_notion/view.py
@@ -15,8 +15,8 @@ from ultimate_notion import props, schema
 from ultimate_notion.core import Wrapper, get_repr
 from ultimate_notion.file import ExternalFile, NotionFile
 from ultimate_notion.obj_api.enums import FormulaType, RollupType
+from ultimate_notion.option import Option
 from ultimate_notion.page import Page
-from ultimate_notion.props import Option
 from ultimate_notion.rich_text import html_img
 from ultimate_notion.schema import Property
 from ultimate_notion.user import User

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
 from random import randint
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from unittest.mock import MagicMock, patch
 
 import pydantic
@@ -43,7 +43,7 @@ from vcr import VCR
 from vcr import mode as vcr_mode
 
 import ultimate_notion as uno
-from ultimate_notion import Database, Option, Page, Session, User, schema
+from ultimate_notion import Database, NumberFormat, Option, Page, Session, User, schema
 from ultimate_notion import blocks as uno_blocks
 from ultimate_notion.adapters.google.tasks import GTasksClient
 from ultimate_notion.config import (
@@ -104,8 +104,10 @@ def pytest_addoption(parser: Parser) -> None:
         )
 
 
-def pytest_exception_interact(node: pytest.Item, call: pytest.CallInfo, report: pytest.TestReport) -> None:
+def pytest_exception_interact(node: pytest.Item, call: pytest.CallInfo[Any], report: pytest.TestReport) -> None:
     """Handle exceptions raised in the tests and provide a bit more output for some exceptions."""
+    if call.excinfo is None:
+        return
     exc_value = call.excinfo.value
 
     if isinstance(exc_value, pydantic.ValidationError):
@@ -272,7 +274,9 @@ def custom_config(request: SubRequest) -> Iterator[Path]:
             yield cfg_path
 
 
-def vcr_fixture(scope: str, *, autouse: bool = False, shared: bool = False) -> Callable[..., Any]:
+def vcr_fixture(
+    scope: Literal['module', 'session'], *, autouse: bool = False, shared: bool = False
+) -> Callable[..., Any]:
     """Return a VCR fixture for module/session-level fixtures"""
     if scope not in {'module', 'session'}:
         msg = f'Use this only for module or session scope, not {scope}!'
@@ -287,7 +291,7 @@ def vcr_fixture(scope: str, *, autouse: bool = False, shared: bool = False) -> C
                 cassette_dir = str(Path(request.module.__file__).parent / 'cassettes' / 'fixtures')
                 cassette_name = f'mod_{func.__name__}.yaml'  # same cassette for all modules!
             else:
-                cassette_dir = str(request.config.rootdir / 'tests' / 'cassettes' / 'fixtures')
+                cassette_dir = str(request.config.rootpath / 'tests' / 'cassettes' / 'fixtures')
                 prefix = 'mod' if scope == 'module' else 'sess'
                 cassette_name = f'{prefix}_{func.__name__}.yaml'
 
@@ -409,7 +413,7 @@ def article_db(notion_cached: Session, root_page: Page) -> Iterator[Database]:
 
     class Article(schema.Schema, db_title='Articles'):
         name = schema.Title('Name')
-        cost = schema.Number('Cost', format=schema.NumberFormat.DOLLAR)
+        cost = schema.Number('Cost', format=NumberFormat.DOLLAR)
         desc = schema.Text('Description')
 
     db = notion_cached.create_db(parent=root_page, schema=Article)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -41,7 +41,7 @@ def test_append_blocks(root_page: uno.Page, notion: uno.Session) -> None:
     page.append([h2, h3, h4])
     page.append(h21, after=h2)
 
-    added_children = (h1, h2, h21, h3, h4)
+    added_children: tuple[uno.Block, ...] = (h1, h2, h21, h3, h4)
     assert page.children == added_children
     assert all(pchild is achild for pchild, achild in zip(page.children, added_children, strict=True))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from typer.testing import CliRunner, Result
+from click.testing import Result
+from typer.testing import CliRunner
 
 import ultimate_notion as uno
 from ultimate_notion import Session, __version__

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,10 @@ import ultimate_notion as uno
 
 
 def test_workspace_sentinel() -> None:
-    assert uno.Workspace != 'workspace_root'
+    # The sentinel must be a distinct object, not its underlying string value. Compare against an
+    # ``object``-typed value so the (intentional) cross-type check is not rejected by strict equality.
+    not_workspace: object = 'workspace_root'
+    assert uno.Workspace != not_workspace
     assert_type(uno.Workspace, uno.WorkspaceType)
 
     def func() -> str | uno.WorkspaceType:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -13,7 +13,7 @@ import pytest
 
 import ultimate_notion as uno
 from ultimate_notion.errors import SchemaError
-from ultimate_notion.obj_api.query import MAX_PAGE_SIZE
+from ultimate_notion.obj_api.iterator import MAX_PAGE_SIZE
 
 from .conftest import CONTACTS_DB
 

--- a/tests/test_latest_release.py
+++ b/tests/test_latest_release.py
@@ -52,4 +52,5 @@ def test_create_page(root_page: uno.Page, notion: uno.Session) -> None:
     page.append([h2, h3, h4])
     page.append(h21, after=h2)
 
-    assert page.children == (h1, h2, h21, h3, h4)
+    added_children: tuple[uno.Block, ...] = (h1, h2, h21, h3, h4)
+    assert page.children == added_children

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_array_equal
 from numpy.typing import NDArray
 
 from ultimate_notion import utils
+from ultimate_notion.errors import EmptyListError, MultipleItemsError
 
 
 def test_find_indices() -> None:
@@ -26,13 +27,13 @@ def test_find_indices() -> None:
 def test_slist() -> None:
     lst = utils.SList(range(3))
     assert isinstance(lst, list)
-    with pytest.raises(utils.MultipleItemsError):
+    with pytest.raises(MultipleItemsError):
         lst.item()
     lst = utils.SList([42])
     item = lst.item()
     assert item == 42
     lst = utils.SList([])
-    with pytest.raises(utils.EmptyListError):
+    with pytest.raises(EmptyListError):
         lst.item()
 
 


### PR DESCRIPTION
Fixes #222 

## Description

Switches the mypy configuration to `strict = true` (replacing the individually-listed strict-implied flags), then resolves the errors that the newly-enabled checks surface — **without blanket `# type: ignore`s**:

- **`no_implicit_reexport`**: import re-exported names from the module that actually defines them (e.g. core obj-types from `obj_api.core`, `DateTimeOrRange` from `utils`, `render_md` from `markdown`, `User` from `user`, `MAX_PAGE_SIZE` from `obj_api.iterator`, `Result` from `click.testing`).
- **`strict_equality`**: give the `page.children` and `Workspace`-sentinel comparisons types that preserve the intended runtime checks.
- **`pendulum.local_timezone`**: import it from `pendulum.tz` to dodge the submodule/function name collision that made mypy report "Module not callable".
- **Missing imports**: drop the blanket `ignore_missing_imports` in favour of per-module overrides for the few genuinely-untyped libraries (`googleapiclient`, `google_auth_oauthlib`, `IPython`, `mktestdocs`, `vcr`), and add the typed deps (`pytest`, `hypothesis`, `pandas-stubs`) to the lint env so they're checked for real — which surfaced and fixed four latent bugs in `conftest.py`.

`hatch run lint:all` (ruff + mypy strict) passes.

### Types of change

Maintenance / tooling change to the type-checking configuration, plus the code fixes required to satisfy it.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
