### PR TITLE
Fix broken GTask cross-reference breaking strict docs build

### DIFF
--- a/src/ultimate_notion/adapters/google/tasks/client.py
+++ b/src/ultimate_notion/adapters/google/tasks/client.py
@@ -250,9 +250,11 @@ class _GTaskListData(GObject):
 class GTaskList:
     """Representation of a Google Task List.
 
-    A task list is a collection of tasks. Unlike [`GTask`][], it is therefore not
+    A task list is a collection of tasks. Unlike
+    [`GTask`][ultimate_notion.adapters.google.tasks.client.GTask], it is therefore not
     a pydantic `BaseModel` itself but wraps its JSON fields in one. This lets
-    iterating over a task list yield its [`GTask`][]s instead of the
+    iterating over a task list yield its
+    [`GTask`][ultimate_notion.adapters.google.tasks.client.GTask]s instead of the
     `(field, value)` pairs that pydantic's `BaseModel.__iter__` produces.
     """
 


### PR DESCRIPTION
## Summary
CI on `main` is red because the **Dev docs** job fails in mkdocs strict mode.

Commit #234 (`Drop GTaskList __iter__ override ignore via composition over BaseModel`) added a docstring to `GTaskList` using the `[\`GTask\`][]` autoref shorthand. The empty-target form could not be resolved by `mkdocs_autorefs` (`Could not find cross-reference target 'GTask'`), and strict mode aborts on the warning:

```
Aborted with 2 warnings in strict mode!
##[error]Process completed with exit code 1.
```

This fully-qualifies the cross-reference target so it resolves.

## Test plan
- `hatch run docs:build` (strict mode) now completes: `Documentation built in 21.03 seconds`, no abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)