### PR TITLE
Type the Google Tasks adapter with google-api-python-client-stubs

### DIFF
--- a/locks/lint.lock
+++ b/locks/lint.lock
@@ -8,6 +8,7 @@
 # - pyright~=1.1
 # - types-tabulate
 # - pandas-stubs
+# - google-api-python-client-stubs
 # - pytest
 # - hypothesis
 # - httpx>=0.27
@@ -75,6 +76,9 @@ google-api-python-client==2.187.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+    #   google-api-python-client-stubs
+google-api-python-client-stubs==1.31.0
+    # via hatch.envs.lint
 google-auth==2.41.1
     # via
     #   -c locks/default.lock
@@ -295,6 +299,8 @@ typer==0.20.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+types-httplib2==0.31.2.20260408
+    # via google-api-python-client-stubs
 types-pytz==2026.2.0.20260518
     # via pandas-stubs
 types-tabulate==0.10.0.20260508
@@ -305,6 +311,7 @@ typing-extensions==4.15.0
     #   hatch.envs.lint
     #   anyio
     #   exceptiongroup
+    #   google-api-python-client-stubs
     #   mistune
     #   mypy
     #   pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,6 @@ disallow_untyped_decorators = false
 [[tool.mypy.overrides]]
 # Third-party libraries shipping neither type information nor stubs on typeshed
 module = [
-    "googleapiclient.*",
     "google_auth_oauthlib.*",
     "IPython",
     "IPython.*",
@@ -378,6 +377,7 @@ dependencies = [
     "pyright~=1.1", # no automatic testing, just additionally to mypy
     "types-tabulate", # stubs for tabulate, otherwise mypy needs --install-types
     "pandas-stubs", # stubs for pandas
+    "google-api-python-client-stubs", # stubs for the Google Tasks adapter
     # Typed test deps so mypy checks against their real types instead of ignoring them
     "pytest",
     "hypothesis",

--- a/src/ultimate_notion/adapters/google/tasks/client.py
+++ b/src/ultimate_notion/adapters/google/tasks/client.py
@@ -18,22 +18,41 @@ from collections.abc import Iterator
 from datetime import date, datetime, time, timezone
 from enum import Enum
 from types import TracebackType
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from googleapiclient.discovery import Resource, build
+from googleapiclient.discovery import build
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from ultimate_notion.config import Config, get_or_create_cfg
 from ultimate_notion.utils import SList, is_stable_release
 
+if TYPE_CHECKING:
+    # `_apis` only exists in google-api-python-client-stubs, not at runtime, so this
+    # import lives under TYPE_CHECKING. It types the dynamically-built Tasks service
+    # resource returned by `build('tasks', 'v1', ...)`, giving the chained
+    # `.tasklists()` / `.tasks()` calls real types instead of `Any`.
+    from googleapiclient._apis.tasks.v1.resources import TasksResource as TasksServiceResource
+    from googleapiclient._apis.tasks.v1.schemas import Task, TaskList
+
 DEFAULT_LIST_ID_LEN = 32
 """Length of the ID of the Google default tasklist."""
 MAX_RESULTS_PER_PAGE = 100
 """Maximum number of results per page when fetching all tasks."""
+
+
+def _drop_none(**kwargs: Any) -> dict[str, Any]:
+    """Drop keyword arguments whose value is `None`.
+
+    The Google Tasks discovery stubs type optional parameters (page tokens, parents, ...)
+    as required, while the underlying API treats an omitted parameter the same as the
+    `None` the higher-level code passes. Dropping them keeps the typed calls honest
+    without changing behaviour.
+    """
+    return {key: value for key, value in kwargs.items() if value is not None}
 
 
 class Scope(str, Enum):
@@ -77,9 +96,9 @@ class GObject(BaseModel):
     etag: str
     updated: datetime
     self_link: HttpUrl = Field(..., alias='selfLink')
-    _resource: Resource
+    _resource: TasksServiceResource
 
-    def __init__(self, resource: Resource, **data: Any) -> None:
+    def __init__(self, resource: TasksServiceResource, **data: Any) -> None:
         super().__init__(**data)
         self._resource = resource
 
@@ -92,7 +111,7 @@ class GObject(BaseModel):
     def __hash__(self) -> int:
         return hash(self.id)
 
-    def _update(self, resp: dict[str, str]) -> None:
+    def _update(self, resp: Task | TaskList) -> None:
         """Updates this object with the given response from the API."""
         new_obj_dct = dict(resp, resource=self._resource)
         new_obj = self.model_validate(new_obj_dct)
@@ -154,7 +173,9 @@ class GTask(GObject):
         due_date = assert_datetime(due_date)
         due_date_str = due_date if due_date is None else due_date.isoformat()
         resource = self._resource.tasks()
-        resp = resource.patch(tasklist=self.tasklist_id, task=self.id, body={'due': due_date_str}).execute()
+        # A `None` value clears the due date; the generated TypedDict only models `str`.
+        body = cast('Task', {'due': due_date_str})
+        resp = resource.patch(tasklist=self.tasklist_id, task=self.id, body=body).execute()
         self._update(resp)
 
     @property
@@ -166,7 +187,9 @@ class GTask(GObject):
     def notes(self, new_notes: str | None) -> None:
         """Sets the notes of this task."""
         resource = self._resource.tasks()
-        resp = resource.patch(tasklist=self.tasklist_id, task=self.id, body={'notes': new_notes}).execute()
+        # A `None` value clears the notes; the generated TypedDict only models `str`.
+        body = cast('Task', {'notes': new_notes})
+        resp = resource.patch(tasklist=self.tasklist_id, task=self.id, body=body).execute()
         self._update(resp)
 
     @property
@@ -206,7 +229,7 @@ class GTask(GObject):
         """Moves this task to the behind the given task."""
         previous_id = None if previous is None else previous.id
         resource = self._resource.tasks()
-        resp = resource.move(tasklist=self.tasklist_id, task=self.id, previous=previous_id).execute()
+        resp = resource.move(tasklist=self.tasklist_id, task=self.id, **_drop_none(previous=previous_id)).execute()
         self._update(resp)
         return self
 
@@ -225,7 +248,7 @@ class GTask(GObject):
         parent_id = None if parent is None else parent.id
 
         resource = self._resource.tasks()
-        resp = resource.move(tasklist=self.tasklist_id, task=self.id, parent=parent_id).execute()
+        resp = resource.move(tasklist=self.tasklist_id, task=self.id, **_drop_none(parent=parent_id)).execute()
         self._update(resp)
 
     @property
@@ -258,11 +281,11 @@ class GTaskList:
     `(field, value)` pairs that pydantic's `BaseModel.__iter__` produces.
     """
 
-    def __init__(self, resource: Resource, **data: Any) -> None:
+    def __init__(self, resource: TasksServiceResource, **data: Any) -> None:
         self._data = _GTaskListData(resource=resource, **data)
 
     @property
-    def _resource(self) -> Resource:
+    def _resource(self) -> TasksServiceResource:
         return self._data._resource
 
     @property
@@ -308,10 +331,10 @@ class GTaskList:
             results = resource.list(
                 tasklist=self.id,
                 maxResults=MAX_RESULTS_PER_PAGE,
-                pageToken=page_token,
                 showCompleted=True,
                 showHidden=True,
                 showDeleted=show_deleted,
+                **_drop_none(pageToken=page_token),
             ).execute()
             items = results.get('items', [])
             tasks.extend([GTask(resource=self._resource, **item) for item in items])
@@ -350,7 +373,7 @@ class GTaskList:
         """Creates a new task."""
         due = assert_datetime(due)
         resource = self._resource.tasks()
-        body = {'title': title}
+        body: Task = {'title': title}
         if due is not None:
             body['due'] = due.isoformat()
         task = resource.insert(tasklist=self.id, body=body).execute()
@@ -396,7 +419,7 @@ class GTasksClient:
     read_only: bool
     _scopes: list[str]
     _config: Config
-    resource: Resource
+    resource: TasksServiceResource
 
     def __init__(self, config: Config | None = None, *, read_only: bool = False) -> None:
         self.read_only = read_only
@@ -406,7 +429,7 @@ class GTasksClient:
         self._config = config
         self.resource = self._build_resource()
 
-    def _build_resource(self) -> Resource:
+    def _build_resource(self) -> TasksServiceResource:
         if self._config.google is None:
             msg = 'Configurtion has no `google` section!'
             raise RuntimeError(msg)
@@ -449,7 +472,9 @@ class GTasksClient:
         tasklists = []
 
         while True:
-            results = self.resource.tasklists().list(maxResults=max_results, pageToken=page_token).execute()
+            results = (
+                self.resource.tasklists().list(**_drop_none(maxResults=max_results, pageToken=page_token)).execute()
+            )
             items = results.get('items', [])
             tasklists.extend([GTaskList(resource=self.resource, **item) for item in items])
 


### PR DESCRIPTION
## Description

Adds `google-api-python-client-stubs` to the lint env and removes the `googleapiclient.*` `ignore_missing_imports` override, so the Google Tasks adapter is actually type-checked instead of being silently `Any` under strict mypy. The discovery service carrier is now typed as the stubs' `TasksResource`, and the 20 real mismatches this surfaced are fixed: `_update`'s response type is corrected, `create_task`'s body is typed, `None`-valued optional API params (page tokens, parent/previous) are omitted via a small `_drop_none` helper, and the nullable due/notes "clear" bodies the generated TypedDict doesn't model are cast. No new `type: ignore`s are added; full mypy (the CI gate) and `ruff` pass, and the Tasks adapter tests pass against their cassettes.

### Types of change

Internal type-checking improvement (no runtime behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)