### PR TITLE
Remove redundant widening casts from src/

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -133,7 +133,7 @@ class DataObject(NotionEntity[DO_co], wraps=obj_blocks.DataObject):
         Pages and databases are moved to the trash, blocks are deleted permanently.
         """
         session = get_active_session()
-        self.obj_ref = cast(DO_co, session.api.blocks.delete(self.id))
+        self.obj_ref = session.api.blocks.delete(self.id)
         self._delete_me_from_parent()
         return self
 
@@ -339,7 +339,7 @@ class Block(CommentMixin[B_co], ABC, wraps=obj_blocks.Block):
     def reload(self) -> Self:
         """Reload the block from the API."""
         session = get_active_session()
-        self.obj_ref = cast(B_co, session.api.blocks.retrieve(self.id))
+        self.obj_ref = session.api.blocks.retrieve(self.id)
         return self
 
     def _update_in_notion(self, *, exclude_attrs: Sequence[str] | None = None) -> None:

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self, TypeIs
 
@@ -94,7 +94,7 @@ class PagePropertiesNS(Mapping[str, Any]):
 
     def __getattr__(self, attr_name: str) -> Any:
         self._check_schema()
-        prop = cast(Property, getattr(self._schema, attr_name))
+        prop = getattr(self._schema, attr_name)
         return self[prop.name]
 
     def __setattr__(self, attr_name: str, value: Any) -> None:
@@ -102,7 +102,7 @@ class PagePropertiesNS(Mapping[str, Any]):
             return super().__setattr__(attr_name, value)
 
         self._check_schema()
-        prop = cast(Property, getattr(self._schema, attr_name))
+        prop = getattr(self._schema, attr_name)
         self[prop.name] = value
 
     def __iter__(self) -> Iterator[str]:

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -577,7 +577,7 @@ class Relation(Property[obj_schema.Relation], wraps=obj_schema.Relation):
             del target_schema[target_two_way_prop]
         else:
             new_rel = obj_schema.DualPropertyRelation.build_relation(db.id)
-            self.obj_ref.relation = cast(obj_schema.DualPropertyRelation, new_rel.relation)
+            self.obj_ref.relation = new_rel.relation
             self.obj_ref = self._update_prop()
             self._rename_two_way_prop(prop_name)
 
@@ -800,7 +800,7 @@ class SchemaType(ABCMeta):
 
         for b in bases:
             for prop in getattr(b, '_props', []):
-                prop = cast(Property, deepcopy(prop))
+                prop = deepcopy(prop)
                 props.append(prop)
 
         for attr, val in list(namespace.items()):

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -22,9 +22,7 @@ from ultimate_notion.database import Database
 from ultimate_notion.emoji import CustomEmoji, Emoji
 from ultimate_notion.errors import SessionError, UnknownDatabaseError, UnknownPageError, UnknownUserError
 from ultimate_notion.file import MAX_FILE_SIZE, AnyFile, UploadedFile, get_file_size, get_mime_type
-from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.obj_api import create_notion_client
-from ultimate_notion.obj_api import query as obj_query
 from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.endpoints import NotionAPI
 from ultimate_notion.obj_api.enums import FileUploadMode, FileUploadStatus
@@ -176,7 +174,7 @@ class Session:
         else:
             title = None  # Anonymous database without a title.
 
-        db_schema: type[Schema] = cast(type[Schema], DefaultSchema) if schema is None else schema
+        db_schema: type[Schema] = DefaultSchema if schema is None else schema
         _logger.info(f'Creating database `{title or "<NoTitle>"}` in page `{parent.title}` with schema:\n{db_schema}')
 
         title_obj = title.obj_ref if title is not None else None
@@ -213,7 +211,7 @@ class Session:
             deleted: include deleted databases in search
         """
         _logger.info(f'Searching for database with name `{db_name}`.')
-        query = cast(obj_query.SearchQueryBuilder[obj_blocks.Database], self.api.search(db_name).filter(db_only=True))
+        query = self.api.search(db_name).filter(db_only=True)
         if reverse:
             query.sort(ascending=True)
         dbs = [
@@ -267,7 +265,7 @@ class Session:
             reverse: search in the reverse order, i.e. the least recently edited results first
         """
         _logger.info(f'Searching for page with title `{title}`.')
-        query = cast(obj_query.SearchQueryBuilder[obj_blocks.Page], self.api.search(title).filter(page_only=True))
+        query = self.api.search(title).filter(page_only=True)
         if reverse:
             query.sort(ascending=True)
         pages = [


### PR DESCRIPTION
## Description

Removes 9 `typing.cast()` calls from `src/ultimate_notion/` that were no-ops for the type checker because the cast target was already a supertype of the expression (widening casts). Affected: `blocks.py` (endpoint return TypeVars), `page.py` (`getattr` → `Any`), `schema.py` (`deepcopy`/relation already correctly typed), and `session.py` (`DefaultSchema` and two search query-builder casts). Also drops the now-unused `cast` import in `page.py` and the `obj_blocks`/`obj_query` imports in `session.py`. The remaining casts are genuinely needed (union/`Any`/`Self` narrowing) and were left untouched. `hatch run lint:typing` (mypy --strict) and `hatch run lint:style` (ruff) both remain clean.

### Types of change

Code cleanup / typing maintenance (no behavior change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)