### PR TITLE
Use IPython's bundled py.typed instead of ignoring missing imports

### DIFF
--- a/locks/lint.lock
+++ b/locks/lint.lock
@@ -11,6 +11,7 @@
 # - google-api-python-client-stubs
 # - pytest
 # - hypothesis
+# - ipython
 # - httpx>=0.27
 # - notion-client~=2.5.0
 # - tabulate>=0.9
@@ -40,6 +41,10 @@ anyio==4.11.0
     # via
     #   -c locks/default.lock
     #   httpx
+asttokens==3.0.0
+    # via
+    #   -c locks/default.lock
+    #   stack-data
 cachetools==6.2.1
     # via
     #   -c locks/default.lock
@@ -58,6 +63,10 @@ click==8.3.0
     # via
     #   -c locks/default.lock
     #   typer
+decorator==5.2.1
+    # via
+    #   -c locks/default.lock
+    #   ipython
 emoji==2.15.0
     # via
     #   -c locks/default.lock
@@ -67,7 +76,12 @@ exceptiongroup==1.3.0
     #   -c locks/default.lock
     #   anyio
     #   hypothesis
+    #   ipython
     #   pytest
+executing==2.2.1
+    # via
+    #   -c locks/default.lock
+    #   stack-data
 google-api-core==2.28.1
     # via
     #   -c locks/default.lock
@@ -132,10 +146,22 @@ iniconfig==2.3.0
     # via
     #   -c locks/default.lock
     #   pytest
+ipython==8.37.0
+    # via
+    #   -c locks/default.lock
+    #   hatch.envs.lint
+jedi==0.19.2
+    # via
+    #   -c locks/default.lock
+    #   ipython
 markdown-it-py==4.0.0
     # via
     #   -c locks/default.lock
     #   rich
+matplotlib-inline==0.2.1
+    # via
+    #   -c locks/default.lock
+    #   ipython
 mdurl==0.1.2
     # via
     #   -c locks/default.lock
@@ -177,12 +203,20 @@ pandas==2.3.3
     #   hatch.envs.lint
 pandas-stubs==2.3.3.260113
     # via hatch.envs.lint
+parso==0.8.5
+    # via
+    #   -c locks/default.lock
+    #   jedi
 pathspec==0.12.1
     # via mypy
 pendulum==3.1.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+pexpect==4.9.0
+    # via
+    #   -c locks/default.lock
+    #   ipython
 pluggy==1.6.0
     # via
     #   -c locks/default.lock
@@ -195,6 +229,10 @@ polars-runtime-32==1.35.2
     # via
     #   -c locks/default.lock
     #   polars
+prompt-toolkit==3.0.52
+    # via
+    #   -c locks/default.lock
+    #   ipython
 proto-plus==1.26.1
     # via
     #   -c locks/default.lock
@@ -205,6 +243,14 @@ protobuf==6.33.0
     #   google-api-core
     #   googleapis-common-protos
     #   proto-plus
+ptyprocess==0.7.0
+    # via
+    #   -c locks/default.lock
+    #   pexpect
+pure-eval==0.2.3
+    # via
+    #   -c locks/default.lock
+    #   stack-data
 pyasn1==0.6.1
     # via
     #   -c locks/default.lock
@@ -225,6 +271,7 @@ pydantic-core==2.41.5
 pygments==2.19.2
     # via
     #   -c locks/default.lock
+    #   ipython
     #   pytest
     #   rich
 pyparsing==3.2.5
@@ -281,6 +328,10 @@ sortedcontainers==2.4.0
     # via
     #   -c locks/default.lock
     #   hypothesis
+stack-data==0.6.3
+    # via
+    #   -c locks/default.lock
+    #   ipython
 tabulate==0.9.0
     # via
     #   -c locks/default.lock
@@ -295,6 +346,11 @@ tomli-w==1.2.0
     # via
     #   -c locks/default.lock
     #   hatch.envs.lint
+traitlets==5.14.3
+    # via
+    #   -c locks/default.lock
+    #   ipython
+    #   matplotlib-inline
 typer==0.20.0
     # via
     #   -c locks/default.lock
@@ -312,6 +368,7 @@ typing-extensions==4.15.0
     #   anyio
     #   exceptiongroup
     #   google-api-python-client-stubs
+    #   ipython
     #   mistune
     #   mypy
     #   pydantic
@@ -340,3 +397,7 @@ urllib3==2.2.3
     # via
     #   -c locks/default.lock
     #   requests
+wcwidth==0.2.14
+    # via
+    #   -c locks/default.lock
+    #   prompt-toolkit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,6 @@ disallow_untyped_decorators = false
 # Third-party libraries shipping neither type information nor stubs on typeshed
 module = [
     "google_auth_oauthlib.*",
-    "IPython",
-    "IPython.*",
     "mktestdocs",
     "vcr",
     "vcr.*",
@@ -381,6 +379,7 @@ dependencies = [
     # Typed test deps so mypy checks against their real types instead of ignoring them
     "pytest",
     "hypothesis",
+    "ipython", # ships py.typed, so mypy checks against its real types
 ]
 [tool.hatch.envs.lint.scripts]
 typing = [

--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -62,7 +62,7 @@ def safe_list_get(lst: Sequence[T], idx: int, *, default: T | None = None) -> T 
 def is_notebook() -> bool:
     """Determine if we are running within a Jupyter notebook."""
     try:
-        from IPython import get_ipython  # noqa: PLC0415
+        from IPython.core.getipython import get_ipython  # noqa: PLC0415
     except ModuleNotFoundError:
         return False  # Probably standard Python interpreter
     else:


### PR DESCRIPTION
## Description

IPython ships `py.typed`, so this drops the `IPython`/`IPython.*` entries from the mypy `ignore_missing_imports` override and adds `ipython` to the `lint` hatch env so mypy type-checks against IPython's real types. Since IPython does not explicitly re-export `get_ipython` under strict mypy, `is_notebook()` now imports it from its defining module `IPython.core.getipython`. The `locks/lint.lock` file is regenerated to include IPython and its transitive deps. `hatch run lint:typing` passes with no issues.

### Types of change

Maintenance / typing improvement.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)