### PR TITLE
Consolidate cache-narrowing casts behind Session._cache_add

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -195,10 +195,10 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
                 except UnknownDatabaseError:
                     # linked database that cannot be retrieved via API. Check the docs:
                     # https://developers.notion.com/reference/retrieve-a-database
-                    ref_block = cast(Block, child_block)
+                    ref_block = child_block
                 child_blocks[idx] = ref_block
 
-        return [cast(Block, session.cache.setdefault(block.id, block)) for block in child_blocks]
+        return [session._cache_add(block) for block in child_blocks]
 
     @property
     def children(self) -> tuple[Block | Page | Database, ...]:

--- a/src/ultimate_notion/query.py
+++ b/src/ultimate_notion/query.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 from typing_extensions import Self
@@ -14,7 +14,6 @@ from ultimate_notion import props, schema
 from ultimate_notion.core import get_active_session
 from ultimate_notion.errors import EmptyDBError, FilterQueryError
 from ultimate_notion.obj_api import query as obj_query
-from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.enums import ArrayQuantifier, FormulaType, RollupType, SortDirection
 from ultimate_notion.option import Option
 from ultimate_notion.page import Page
@@ -213,8 +212,7 @@ class PropertyCondition(Condition, ABC):
             except StopIteration as e:
                 msg = f'The database {db} is empty.'
                 raise EmptyDBError(msg) from e
-            page_obj_id = raise_unset(page_obj.id)
-            self._probe_page = cast(Page, session.cache.setdefault(page_obj_id, Page.wrap_obj_ref(page_obj)))
+            self._probe_page = session._cache_add(Page.wrap_obj_ref(page_obj))
 
         return self._probe_page
 
@@ -831,10 +829,7 @@ class Query:
         if sort_objs := self._sorts_obj_ref():
             query_obj = query_obj.sort(sort_objs)
 
-        pages = [
-            cast(Page, session.cache.setdefault(raise_unset(page.id), Page.wrap_obj_ref(page)))
-            for page in query_obj.execute()
-        ]
+        pages = [session._cache_add(Page.wrap_obj_ref(page)) for page in query_obj.execute()]
         return View(database=self.database, pages=pages, query=self)
 
     def filter(self, expr: Condition) -> Query:

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Sequence
 from threading import RLock
 from types import TracebackType
-from typing import Any, BinaryIO, ClassVar, cast
+from typing import Any, BinaryIO, ClassVar, TypeVar, cast
 from uuid import UUID
 
 import httpx
@@ -23,7 +23,6 @@ from ultimate_notion.emoji import CustomEmoji, Emoji
 from ultimate_notion.errors import SessionError, UnknownDatabaseError, UnknownPageError, UnknownUserError
 from ultimate_notion.file import MAX_FILE_SIZE, AnyFile, UploadedFile, get_file_size, get_mime_type
 from ultimate_notion.obj_api import create_notion_client
-from ultimate_notion.obj_api.core import raise_unset
 from ultimate_notion.obj_api.endpoints import NotionAPI
 from ultimate_notion.obj_api.enums import FileUploadMode, FileUploadStatus
 from ultimate_notion.obj_api.objects import get_uuid
@@ -35,6 +34,9 @@ from ultimate_notion.user import Bot, UnknownUser, User
 from ultimate_notion.utils import SList
 
 _logger = logging.getLogger(__name__)
+
+# ToDo: Use new syntax when requires-python >= 3.12
+T_cache = TypeVar('T_cache', bound='DataObject | User')
 
 
 class Session:
@@ -142,6 +144,10 @@ class Session:
             msg = 'Invalid API reponse'
             raise SessionError(msg) from err
 
+    def _cache_add(self, obj: T_cache) -> T_cache:
+        """Cache `obj` keyed by its id, returning the already-cached instance if one exists."""
+        return cast(T_cache, self.cache.setdefault(obj.id, obj))
+
     def get_block(self, block_ref: UUID | str, *, use_cache: bool = True) -> Block:
         """Retrieve a single block by an object reference."""
         block_uuid = get_uuid(block_ref)
@@ -214,10 +220,7 @@ class Session:
         query = self.api.search(db_name).filter(db_only=True)
         if reverse:
             query.sort(ascending=True)
-        dbs = [
-            cast(Database, self.cache.setdefault(raise_unset(db.id), Database.wrap_obj_ref(db)))
-            for db in query.execute()
-        ]
+        dbs = [self._cache_add(Database.wrap_obj_ref(db)) for db in query.execute()]
         if exact and db_name is not None:
             dbs = [db for db in dbs if db.title == db_name]
         if not deleted:
@@ -268,10 +271,7 @@ class Session:
         query = self.api.search(title).filter(page_only=True)
         if reverse:
             query.sort(ascending=True)
-        pages = [
-            cast(Page, self.cache.setdefault(raise_unset(page_obj.id), Page.wrap_obj_ref(page_obj)))
-            for page_obj in query.execute()
-        ]
+        pages = [self._cache_add(Page.wrap_obj_ref(page_obj)) for page_obj in query.execute()]
         if exact and title is not None:
             pages = [page for page in pages if page.title == title]
         return SList(pages)
@@ -385,7 +385,7 @@ class Session:
     def all_users(self) -> list[User]:
         """Retrieve all users of this workspace."""
         _logger.info('Retrieving all users.')
-        return [cast(User, self.cache.setdefault(user.id, User.wrap_obj_ref(user))) for user in self.api.users.list()]
+        return [self._cache_add(User.wrap_obj_ref(user)) for user in self.api.users.list()]
 
     def whoami(self) -> Bot:
         """Return the integration as bot object."""
@@ -393,7 +393,7 @@ class Session:
         if self._own_bot_id is None:
             user = self.api.users.me()
             self._own_bot_id = user.id
-            return cast(Bot, self.cache.setdefault(user.id, Bot.wrap_obj_ref(user)))
+            return self._cache_add(Bot.wrap_obj_ref(user))
         else:
             return cast(Bot, self.cache[self._own_bot_id])
 


### PR DESCRIPTION
## Description

Reduces `cast()` usage in `src/` from 51 to 44 by consolidating the cache-narrowing casts. The session cache is typed `dict[UUID, DataObject | User]`, so every wrap-and-cache site needed a `cast` to recover the concrete type; a single generic `Session._cache_add` helper now owns that cast and replaces six call-site casts across `session.py`, `query.py`, and `blocks.py`, also dropping the now-redundant `raise_unset` keys and imports. One genuinely redundant `cast(Block, child_block)` (already narrowed by `isinstance`) is removed too. The remaining casts were each verified load-bearing by stripping every cast and re-running mypy. mypy (strict), ruff, and the session/blocks/database/query suites under `hatch run vcr-only` all pass.

### Types of change

Refactor / code cleanup (no behaviour change — the cache key under `_cache_add` is the same UUID used before).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
