### PR TITLE
Drop redundant casts from Property/PropertyValue __eq__

### DIFF
--- a/src/ultimate_notion/props.py
+++ b/src/ultimate_notion/props.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import pendulum as pnd
 from typing_extensions import Self, TypeVar
@@ -55,8 +55,7 @@ class PropertyValue(Wrapper[PV_co], ABC, wraps=obj_props.PropertyValue):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, PropertyValue):
             return NotImplemented
-        other_obj_ref = cast(PV_co, other.obj_ref)
-        return (self.obj_ref.type == other_obj_ref.type) and (self.obj_ref.value == other_obj_ref.value)
+        return bool((self.obj_ref.type == other.obj_ref.type) and (self.obj_ref.value == other.obj_ref.value))
 
     @property
     @abstractmethod

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -93,8 +93,7 @@ class Property(Wrapper[GO_co], ABC, wraps=PropertyGO):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Property):
             return NotImplemented
-        other_obj_ref = cast(GO_co, other.obj_ref)
-        return (self.obj_ref.type == other_obj_ref.type) and (self.obj_ref.value == other_obj_ref.value)
+        return bool((self.obj_ref.type == other.obj_ref.type) and (self.obj_ref.value == other.obj_ref.value))
 
     def __hash__(self) -> int:
         return hash((self.obj_ref.type, self.obj_ref.value))


### PR DESCRIPTION
## Description

Both `Property.__eq__` and `PropertyValue.__eq__` cast `other.obj_ref` to a covariant TypeVar (`GO_co` / `PV_co`) solely to suppress mypy's `no-any-return` (the obj_ref's `.value` is typed `Any`). The cast narrowed nothing real, so this replaces it with a `bool(...)` coercion that honestly matches the `-> bool` contract and drops the now-unused `cast` import in `props.py`. mypy, ruff, and the offline `test_props.py`/`test_schema.py` suites all pass.

### Types of change

Code cleanup (no behavior change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)