### PR TITLE
Replace cast with isinstance asserts in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
 from random import randint
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import MagicMock, patch
 
 import pydantic
@@ -809,7 +809,9 @@ def get_id_prefix(notion: uno.Session, root_page: uno.Page) -> Callable[[str], s
             state_page.append(state_block)
 
         state_page.reload()  # this saves actually the state in VCR.py
-        id_prefix = cast(uno.Paragraph, state_page.children[0]).rich_text
+        first_child = state_page.children[0]
+        assert isinstance(first_child, uno.Paragraph)
+        id_prefix = first_child.rich_text
         if id_prefix is None:
             msg = 'Could not retrieve ID prefix from state page!'
             raise ValueError(msg)

--- a/tests/obj_api/test_objects.py
+++ b/tests/obj_api/test_objects.py
@@ -30,8 +30,10 @@ def test_date_range(tz_berlin: str) -> None:
     assert obj.time_zone == tz_berlin
     assert obj.to_pendulum() == datetime
 
-    start = cast(pnd.DateTime, pnd.parse('2024-01-01', exact=True))
-    end = cast(pnd.DateTime, pnd.parse('2024-01-03', exact=True))
+    # `pnd.parse` of a date-only string returns a `Date`, but `pnd.interval` is typed
+    # to require `DateTime`, so cast to satisfy the (overly strict) stub.
+    start = cast('pnd.DateTime', pnd.parse('2024-01-01', exact=True))
+    end = cast('pnd.DateTime', pnd.parse('2024-01-03', exact=True))
     date_interval = pnd.interval(start=start, end=end)
     obj = objs.DateRange.build(date_interval)
     assert isinstance(obj.start, dt.date)
@@ -41,9 +43,11 @@ def test_date_range(tz_berlin: str) -> None:
     assert obj.time_zone is None
     assert obj.to_pendulum() == date_interval
 
-    start = cast(pnd.DateTime, pnd.parse('2024-01-01 10:00', exact=True))
-    end = cast(pnd.DateTime, pnd.parse('2024-01-03 12:00', exact=True))
-    datetime_interval = pnd.interval(start=start, end=end)
+    dt_start = pnd.parse('2024-01-01 10:00', exact=True)
+    dt_end = pnd.parse('2024-01-03 12:00', exact=True)
+    assert isinstance(dt_start, pnd.DateTime)
+    assert isinstance(dt_end, pnd.DateTime)
+    datetime_interval = pnd.interval(start=dt_start, end=dt_end)
     obj = objs.DateRange.build(datetime_interval)
     assert isinstance(obj.start, dt.datetime)
     assert obj.start == datetime_interval.start
@@ -57,7 +61,9 @@ def test_date_range(tz_berlin: str) -> None:
 def test_pageref(intro_page: uno.Page) -> None:
     page_ref = objs.PageRef(page_id=intro_page.id)
     obj_link_to_page = obj_blocks.LinkToPage(link_to_page=page_ref, type='link_to_page')
-    assert cast(objs.PageRef, obj_link_to_page.link_to_page).page_id == intro_page.id
+    link_to_page = obj_link_to_page.link_to_page
+    assert isinstance(link_to_page, objs.PageRef)
+    assert link_to_page.page_id == intro_page.id
 
 
 @pytest.mark.vcr()

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import cast
 from uuid import uuid4
 
 import pytest
@@ -344,8 +343,12 @@ def test_nested_blocks(root_page: uno.Page, notion: uno.Session) -> None:
     p2.append(uno.Paragraph('Nested Paragraph'))
 
     assert len(page.children) == 3
-    assert cast(ChildrenMixin, page.children[1]).children == (p1,)
-    assert len(cast(ChildrenMixin, page.children[2]).children) == 1
+    child1 = page.children[1]
+    assert isinstance(child1, ChildrenMixin)
+    assert child1.children == (p1,)
+    child2 = page.children[2]
+    assert isinstance(child2, ChildrenMixin)
+    assert len(child2.children) == 1
 
 
 @pytest.mark.vcr()
@@ -399,33 +402,41 @@ def test_modify_basic_blocks(root_page: uno.Page, notion: uno.Session) -> None:
 
     page.reload()
 
-    child_paragraph = cast(uno.Paragraph, page.children[0])
+    child_paragraph = page.children[0]
+    assert isinstance(child_paragraph, uno.Paragraph)
     assert child_paragraph.color == uno.Color.PINK
     assert child_paragraph.rich_text == 'Pink paragraph'
 
-    child_code = cast(uno.Code, page.children[1])
+    child_code = page.children[1]
+    assert isinstance(child_code, uno.Code)
     assert child_code.language == uno.CodeLang.JAVASCRIPT
     assert child_code.caption == uno.text('JavaScript Code')
     child_code.caption = None
     child_code.reload()
     assert child_code.caption is None
 
-    child_heading = cast(uno.Heading1, page.children[2])
+    child_heading = page.children[2]
+    assert isinstance(child_heading, uno.Heading1)
     assert child_heading.toggleable is False
 
-    child_callout = cast(uno.Callout, page.children[3])
+    child_callout = page.children[3]
+    assert isinstance(child_callout, uno.Callout)
     assert child_callout.icon == '👍'
 
-    child_todo = cast(uno.ToDoItem, page.children[4])
+    child_todo = page.children[4]
+    assert isinstance(child_todo, uno.ToDoItem)
     assert child_todo.checked is False
 
-    child_embed = cast(uno.Embed, page.children[5])
+    child_embed = page.children[5]
+    assert isinstance(child_embed, uno.Embed)
     assert child_embed.caption == 'Notion Homepage'
 
-    child_bookmark = cast(uno.Bookmark, page.children[6])
+    child_bookmark = page.children[6]
+    assert isinstance(child_bookmark, uno.Bookmark)
     assert child_bookmark.url == 'https://notion.so/'
 
-    child_equation = cast(uno.Equation, page.children[7])
+    child_equation = page.children[7]
+    assert isinstance(child_equation, uno.Equation)
     assert child_equation.latex == r'e = mc^2'
 
 
@@ -483,28 +494,31 @@ def test_modify_column_blocks(root_page: uno.Page, notion: uno.Session) -> None:
     cols[0].delete()
     page.reload()
 
-    cols = cast(uno.Columns, page.children[0])
-    col = cols.columns[0]
-    paragraph = cast(uno.Paragraph, col.children[0])
+    reloaded_cols = page.children[0]
+    assert isinstance(reloaded_cols, uno.Columns)
+    col = reloaded_cols.columns[0]
+    paragraph = col.children[0]
+    assert isinstance(paragraph, uno.Paragraph)
     assert paragraph == right
     assert left.reload().is_deleted
 
     with pytest.raises(IndexError):
-        cols.add_column(index=-1)
+        reloaded_cols.add_column(index=-1)
     with pytest.raises(IndexError):
-        cols.add_column(index=len(cols.children) + 1)
+        reloaded_cols.add_column(index=len(reloaded_cols.children) + 1)
 
-    cols.add_column(index=1)
-    cols[1].append(new_right := uno.Paragraph('New Column 1'))
+    reloaded_cols.add_column(index=1)
+    reloaded_cols[1].append(new_right := uno.Paragraph('New Column 1'))
     page.reload()
 
-    cols = cast(uno.Columns, page.children[0])
-    left_col, right_col = cast(list[uno.Column], cols.children)
+    reloaded_cols = page.children[0]
+    assert isinstance(reloaded_cols, uno.Columns)
+    left_col, right_col = reloaded_cols.children
     assert left_col.children == (right,)
     assert right_col.children == (new_right,)
 
     with pytest.raises(InvalidAPIUsageError):
-        cols.append(uno.Paragraph('This is a paragraph'))
+        reloaded_cols.append(uno.Paragraph('This is a paragraph'))
 
 
 @pytest.mark.vcr()
@@ -555,7 +569,8 @@ def test_modify_table(root_page: uno.Page, notion: uno.Session) -> None:
     assert table[1, 1] == 'Cell 1, 1'
     assert table[1, 2] == 'Cell 1, 2'
     page.reload()
-    reloaded_table = cast(uno.Table, page.children[0])
+    reloaded_table = page.children[0]
+    assert isinstance(reloaded_table, uno.Table)
     assert reloaded_table[0] == ('Cell 0, 0', 'Cell 0, 1', 'Cell 0, 2')
     assert reloaded_table[1, 0] == 'Cell 1, 0'
     assert reloaded_table[1, 1] == 'Cell 1, 1'
@@ -571,7 +586,8 @@ def test_modify_table(root_page: uno.Page, notion: uno.Session) -> None:
     table[2].delete()
     assert table[2] == ('New Cell 3, 0', 'New Cell 3, 1', 'New Cell 3, 2')
     page.reload()
-    reloaded_table = cast(uno.Table, page.children[0])
+    reloaded_table = page.children[0]
+    assert isinstance(reloaded_table, uno.Table)
     assert reloaded_table[2] == ('New Cell 3, 0', 'New Cell 3, 1', 'New Cell 3, 2')
 
     table.has_header_col = True

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 import pytest
 
 import ultimate_notion as uno
@@ -10,7 +8,8 @@ from ultimate_notion.schema import MultiSelect, Select, Status
 
 @pytest.mark.vcr()
 def test_status_options_groups(all_props_db: uno.Database) -> None:
-    status_prop_type = cast(Status, all_props_db.schema.get_prop('Status'))
+    status_prop_type = all_props_db.schema.get_prop('Status')
+    assert isinstance(status_prop_type, Status)
     all_options = ['Not started', 'In progress', 'Done']
     assert [option.name for option in status_prop_type.options] == all_options
 
@@ -23,13 +22,15 @@ def test_status_options_groups(all_props_db: uno.Database) -> None:
 
 @pytest.mark.vcr()
 def test_select_options(all_props_db: uno.Database) -> None:
-    select_prop_type = cast(Select, all_props_db.schema.get_prop('Select'))
+    select_prop_type = all_props_db.schema.get_prop('Select')
+    assert isinstance(select_prop_type, Select)
     all_options = ['Option1', 'Option2']
     assert [option.name for option in select_prop_type.options] == all_options
 
 
 @pytest.mark.vcr()
 def test_multi_select_options(all_props_db: uno.Database) -> None:
-    multi_select_prop_type = cast(MultiSelect, all_props_db.schema.get_prop('Multi-Select'))
+    multi_select_prop_type = all_props_db.schema.get_prop('Multi-Select')
+    assert isinstance(multi_select_prop_type, MultiSelect)
     all_options = ['MultiOption1', 'MultiOption2']
     assert [option.name for option in multi_select_prop_type.options] == all_options

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 import pendulum as pnd
 import pytest
 
@@ -441,7 +439,9 @@ def test_query_new_task_db(new_task_db: uno.Database) -> None:
 
     Task = new_task_db.schema  # noqa: N806
     status_col = 'Status'
-    status_options = {option.name: option for option in cast(schema.Select, Task[status_col]).options}
+    status_prop = Task[status_col]
+    assert isinstance(status_prop, schema.Select)
+    status_options = {option.name: option for option in status_prop.options}
 
     task1 = Task.create(task='Task 1', status=status_options['Done'], due_date='2024-01-01')
     task2 = Task.create(task='Task 2', status=status_options['Backlog'], due_date='2024-01-02')


### PR DESCRIPTION
## Description

Removes nearly all uses of `typing.cast` from the test suite, replacing them with `assert isinstance(...)` checks. This both narrows the type for the type checker and adds a real runtime assertion, which is strictly better in tests. A couple of redundant casts were dropped entirely (e.g. `Columns.children` is already typed as `tuple[Column, ...]`). One cast is intentionally kept (now documented) in `test_objects.py`, where `pnd.parse` of a date-only string returns a `Date` but `pnd.interval` is typed to require `DateTime`. Verified with `hatch run lint:typing` (mypy strict, clean), `hatch run lint:style` (ruff, clean), and the affected tests pass under `hatch run vcr-only`.

### Types of change

Code quality / test refactor (no behavior change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)