### PR TITLE
Type Session.__exit__ parameters as optional

### DIFF
--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -106,9 +106,9 @@ class Session:
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_value: BaseException,
-        traceback: TracebackType,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         self.close()
 


### PR DESCRIPTION
## Summary

`Session.__exit__` annotated its three parameters as non-optional (`type[BaseException]`, `BaseException`, `TracebackType`). When a `with` block exits without an exception, Python passes `None` for all three, so the annotation did not match runtime and would mislead a type checker or reader.

This makes the three parameters optional, matching the context manager protocol.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)