### PR TITLE
Declare query condition dispatch constants as ClassVar

### DIFF
--- a/src/ultimate_notion/query.py
+++ b/src/ultimate_notion/query.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import BaseModel, Field
 from typing_extensions import Self
@@ -439,8 +439,8 @@ class EqualsNot(Equals):
 
 
 class InEquality(PropertyCondition, ABC):
-    _num_condition_kw: str
-    _date_condition_kw: str
+    _num_condition_kw: ClassVar[str]
+    _date_condition_kw: ClassVar[str]
 
     def _create_obj_ref_kwargs(self, db: Database, prop_type: Property) -> dict[str, obj_query.Condition]:
         kwargs: dict[str, obj_query.Condition] = {}
@@ -677,7 +677,7 @@ class EndsWith(StartsWith):
 
 
 class DateCondition(PropertyCondition, ABC):
-    _condition_kw: str
+    _condition_kw: ClassVar[str]
     is_method: bool = True
 
     def _create_obj_ref_kwargs(self, db: Database, prop_type: Property) -> dict[str, obj_query.Condition]:


### PR DESCRIPTION
In `src/ultimate_notion/query.py`, the per-subclass dispatch constants on the abstract `InEquality` and `DateCondition` bases were declared as bare underscore annotations:

```python
class InEquality(PropertyCondition, ABC):
    _num_condition_kw: str
    _date_condition_kw: str

class DateCondition(PropertyCondition, ABC):
    _condition_kw: str
```

Because they are bare underscore annotations on a pydantic model, pydantic treats them as private instance attributes rather than class variables. They are class-level dispatch constants (subclasses assign string values like `_num_condition_kw = 'greater_than'`), so this declares them as `ClassVar[str]` to state the intent accurately and keep pydantic from managing them as private attributes.

No runtime behaviour change. Verified the constants still resolve on every subclass, and basedpyright errors on the file dropped (255 → 244) with mypy unchanged.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)