### PR TITLE
Replace unchecked block downcasts with isinstance guards

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -1165,7 +1165,11 @@ class Columns(ParentBlock[obj_blocks.ColumnList], wraps=obj_blocks.ColumnList):
                 raise TypeError(msg)
 
     def __getitem__(self, index: int) -> Column:
-        return cast(Column, self.blocks[index])
+        column = self.blocks[index]
+        if not isinstance(column, Column):
+            msg = f'Expected a `Column` at index {index}, got `{type(column).__name__}`.'
+            raise TypeError(msg)
+        return column
 
     @property
     def columns(self) -> tuple[Column, ...]:
@@ -1459,7 +1463,11 @@ class SyncedBlock(ParentBlock[obj_blocks.SyncedBlock], wraps=obj_blocks.SyncedBl
             return self
         elif (synced_from := self.obj_ref.synced_block.synced_from) is not None:
             session = get_active_session()
-            return cast(SyncedBlock, session.get_block(objs.get_uuid(synced_from)))
+            original = session.get_block(objs.get_uuid(synced_from))
+            if not isinstance(original, SyncedBlock):
+                msg = f'Expected original of synced block to be a `SyncedBlock`, got `{type(original).__name__}`.'
+                raise TypeError(msg)
+            return original
         else:
             msg = 'Unknown synced block, neither original nor synced!'
             raise RuntimeError(msg)


### PR DESCRIPTION
## Description

Replaces two unchecked `cast` downcasts in `blocks.py` with `isinstance` checks that raise `TypeError`, matching the codebase's existing narrowing idiom (asserts are disallowed in source by ruff `S101`). This removes the casts and adds runtime safety in `Columns.__getitem__` and `SyncedBlock.get_original`. The remaining `cast` uses in `src/` were investigated and left as-is because mypy's `strict` mode (with `warn_redundant_casts`) confirms they are load-bearing workarounds for pydantic-plugin/generics/numpy limitations.

### Types of change

Code cleanup / minor enhancement (no behavioural change for valid inputs).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.