### PR TITLE
Replace cast downcasts with isinstance guards

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -1174,7 +1174,13 @@ class Columns(ParentBlock[obj_blocks.ColumnList], wraps=obj_blocks.ColumnList):
     @property
     def columns(self) -> tuple[Column, ...]:
         """Return all columns of this multi-column block."""
-        return tuple(cast(Column, col) for col in super().children)
+        columns: list[Column] = []
+        for col in super().children:
+            if not isinstance(col, Column):
+                msg = f'Expected a `Column` child, got `{type(col).__name__}`.'
+                raise TypeError(msg)
+            columns.append(col)
+        return tuple(columns)
 
     @property
     def children(self) -> tuple[Column, ...]:
@@ -1346,7 +1352,13 @@ class Table(ParentBlock[obj_blocks.Table], wraps=obj_blocks.Table):
     @property
     def rows(self) -> tuple[TableRow, ...]:
         """Return all rows of the table."""
-        return tuple(cast(TableRow, block) for block in super().children)
+        rows: list[TableRow] = []
+        for block in super().children:
+            if not isinstance(block, TableRow):
+                msg = f'Expected a `TableRow` child, got `{type(block).__name__}`.'
+                raise TypeError(msg)
+            rows.append(block)
+        return tuple(rows)
 
     @property
     def children(self) -> tuple[TableRow, ...]:
@@ -1573,8 +1585,8 @@ def _chunk_blocks_for_api(parent: Block | Page, blocks: Sequence[Block]) -> Iter
                 case Columns() as cols:
                     col_nodes = [_Node(block=col) for col in cols.columns]
                     node.children.extend(col_nodes)
-                    for col_node in col_nodes:
-                        queue.append((col_node, [_Node(block=child) for child in cast(Column, col_node.block).blocks]))
+                    for col_node, col in zip(col_nodes, cols.columns, strict=True):
+                        queue.append((col_node, [_Node(block=child) for child in col.blocks]))
                 case Table() as table:
                     node.children.extend([_Node(block=row) for row in table.rows])
                 case ParentBlock() as parent_block if parent_block.has_children:

--- a/src/ultimate_notion/view.py
+++ b/src/ultimate_notion/view.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Callable, Iterator, Sequence
 from html import escape as htmlescape
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import numpy as np
 from pydantic import BaseModel
@@ -89,11 +89,18 @@ class View(Sequence[Page]):
         if isinstance(idx, slice):
             return tuple(pages)
         else:
-            return cast(Page, pages)
+            return self._as_page(pages)
 
     def get_page(self, idx: int, /) -> Page:
         """Retrieve a page by index of the view."""
-        return cast(Page, self._pages[self._row_indices[idx]])
+        return self._as_page(self._pages[self._row_indices[idx]])
+
+    @staticmethod
+    def _as_page(page: Any) -> Page:
+        if not isinstance(page, Page):
+            msg = f'Expected a `Page`, got `{type(page).__name__}`.'
+            raise TypeError(msg)
+        return page
 
     def search_page(self, name: str) -> SList[Page]:
         """Retrieve a page from this view by name"""


### PR DESCRIPTION
## Description

Removes five `cast` calls in `blocks.py` and `view.py`, replacing the downcasts with `isinstance` guards that raise `TypeError` on unexpected types (matching the codebase's existing narrowing idiom, since ruff S101 disallows `assert` in source). In `Columns.columns`, `Table.rows`, and `View.__getitem__`/`get_page` this adds runtime safety; in `_chunk_blocks_for_api` the cast is dropped entirely by zipping the already-typed `cols.columns` alongside the column nodes. Verified with `hatch run lint:typing` (no issues), ruff, and the `test_view.py`/`test_blocks.py` suites against the VCR cassettes.

### Types of change

Refactor / code quality (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
