### PR TITLE
Replace cast downcasts with isinstance guards

### DIFF
--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -17,7 +17,7 @@ values from default/unset values.
 from __future__ import annotations
 
 from abc import ABC
-from typing import Annotated, Any, Generic, cast
+from typing import Annotated, Any, Generic
 
 from pydantic import AfterValidator, Field, SerializeAsAny
 from typing_extensions import TypeVar
@@ -101,7 +101,10 @@ class Page(DataObject, MentionMixin, object='page'):
     def title(self) -> list[RichTextBaseObject]:
         """Retrieve the title of the page from page properties."""
         title_prop_name = self._get_title_prop_name()
-        title_prop = cast(Title, self.properties[title_prop_name])
+        title_prop = self.properties[title_prop_name]
+        if not isinstance(title_prop, Title):
+            msg = f'Expected a `Title` property, got `{type(title_prop).__name__}`.'
+            raise TypeError(msg)
         return title_prop.title
 
     def build_mention(self, style: Annotations | None = None) -> MentionObject:

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -531,7 +531,10 @@ class Relation(Property[obj_schema.Relation], wraps=obj_schema.Relation):
         This is necessary as a two-way relation is created with a default name,
         which is rather a bug in the Notion API itself.
         """
-        two_way_prop_rel = cast(obj_schema.DualPropertyRelation, self.obj_ref.relation)
+        two_way_prop_rel = self.obj_ref.relation
+        if not isinstance(two_way_prop_rel, obj_schema.DualPropertyRelation):
+            msg = f'Expected a `DualPropertyRelation`, got `{type(two_way_prop_rel).__name__}`.'
+            raise TypeError(msg)
         tmp_prop_name = raise_unset(two_way_prop_rel.dual_property.synced_property_name)
         db = self.schema.get_db()
         db.reload(rebind_schema=False)

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -161,7 +161,11 @@ class Session:
         block_uuid = get_uuid(block_ref)
         if use_cache and block_uuid in self.cache:
             _logger.info(f'Retrieving cached block with id `{block_uuid}`.')
-            block = cast(Block, self.cache[block_uuid])
+            cached_obj = self.cache[block_uuid]
+            if not isinstance(cached_obj, Block):
+                msg = f'Cached object `{block_uuid}` is a `{type(cached_obj).__name__}`, expected a `Block`.'
+                raise TypeError(msg)
+            block = cached_obj
         else:
             _logger.info(f'Retrieving block with id `{block_uuid}`.')
             block = Block.wrap_obj_ref(self.api.blocks.retrieve(block_uuid))


### PR DESCRIPTION
## Description

Removes three `cast` downcasts, replacing each with an `isinstance` guard that raises `TypeError` — matching the existing narrowing idiom in the codebase, since ruff's S101 disallows asserts in source. The casts replaced are in `Page.title` (narrowed to `Title`), `Relation._rename_two_way_prop` (narrowed to `DualPropertyRelation`), and `Session.get_block` (narrowed to `Block`). This continues the prior cleanup in #253 and #254, adding runtime safety where the type was previously asserted unchecked.

### Types of change

Code cleanup / refactor (no behavioural change on the happy path).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)