### PR TITLE
Replace overloaded raise_unset with is_unset narrowing

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -38,13 +38,13 @@ from url_normalize import url_normalize
 from ultimate_notion.comment import Comment, Discussion
 from ultimate_notion.core import NotionEntity, get_active_session, get_url, is_db, is_page
 from ultimate_notion.emoji import CustomEmoji, Emoji
-from ultimate_notion.errors import InvalidAPIUsageError, UnknownDatabaseError
+from ultimate_notion.errors import InvalidAPIUsageError, UnknownDatabaseError, UnsetError
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
 from ultimate_notion.markdown import md_comment
 from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.obj_api.core import is_unset
 from ultimate_notion.obj_api.enums import BGColor, CodeLang, Color
 from ultimate_notion.rich_text import Text
 from ultimate_notion.user import User
@@ -110,8 +110,11 @@ class DataObject(NotionEntity[DO_co], wraps=obj_blocks.DataObject):
     def last_edited_by(self) -> User:
         """Return the user who last edited the block."""
         session = get_active_session()
-        last_edit_user_ref = raise_unset(self.obj_ref.last_edited_by)
-        return session.get_user(raise_unset(last_edit_user_ref.id))
+        if is_unset(last_edit_user_ref := self.obj_ref.last_edited_by):
+            raise UnsetError()
+        if is_unset(last_edit_user_id := last_edit_user_ref.id):
+            raise UnsetError()
+        return session.get_user(last_edit_user_id)
 
     @property
     def has_children(self) -> bool:
@@ -664,7 +667,8 @@ class Callout(ColoredTextBlock[obj_blocks.Callout], ParentBlock[obj_blocks.Callo
 
     @property
     def icon(self) -> NotionFile | ExternalFile | Emoji | CustomEmoji:
-        icon = raise_unset(self.obj_ref.value.icon)
+        if is_unset(icon := self.obj_ref.value.icon):
+            raise UnsetError()
         if icon is None:
             return self.get_default_icon()
         else:
@@ -1065,9 +1069,9 @@ class ChildPage(Block[obj_blocks.ChildPage], wraps=obj_blocks.ChildPage):
     @property
     def title(self) -> str | None:
         """Return the title of the child page."""
-        if title := raise_unset(self.obj_ref.child_page.title):
-            return title
-        return None
+        if is_unset(title := self.obj_ref.child_page.title):
+            raise UnsetError()
+        return title if title else None
 
     @property
     def page(self) -> Page:
@@ -1101,9 +1105,9 @@ class ChildDatabase(Block[obj_blocks.ChildDatabase], wraps=obj_blocks.ChildDatab
     @property
     def title(self) -> str | None:
         """Return the title of the child database"""
-        if title := raise_unset(self.obj_ref.child_database.title):
-            return title
-        return None
+        if is_unset(title := self.obj_ref.child_database.title):
+            raise UnsetError()
+        return title if title else None
 
     @property
     def db(self) -> Database:

--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -11,10 +11,10 @@ from uuid import UUID
 
 from typing_extensions import Self, TypeIs, TypeVar
 
-from ultimate_notion.errors import UnknownDatabaseError, UnknownPageError
+from ultimate_notion.errors import UnknownDatabaseError, UnknownPageError, UnsetError
 from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.obj_api.core import is_unset
 
 _logger = logging.getLogger(__name__)
 
@@ -119,7 +119,9 @@ class NotionObject(Wrapper[NO_co], ABC, wraps=obj_core.NotionObject):
     @property
     def id(self) -> UUID | str:
         """Return the ID of the block."""
-        return raise_unset(self.obj_ref.id)
+        if is_unset(id_ := self.obj_ref.id):
+            raise UnsetError()
+        return id_
 
     @property
     def in_notion(self) -> bool:
@@ -157,30 +159,40 @@ class NotionEntity(NotionObject[NE_co], ABC, wraps=obj_core.NotionEntity):
     @property
     def id(self) -> UUID:
         """Return the ID of the entity."""
-        return raise_unset(self.obj_ref.id)
+        if is_unset(id_ := self.obj_ref.id):
+            raise UnsetError()
+        return id_
 
     @property
     def created_time(self) -> dt.datetime:
         """Return the time when the block was created."""
-        return raise_unset(self.obj_ref.created_time)
+        if is_unset(created_time := self.obj_ref.created_time):
+            raise UnsetError()
+        return created_time
 
     @property
     def created_by(self) -> User:
         """Return the user who created the block."""
         session = get_active_session()
-        created_by = raise_unset(self.obj_ref.created_by)
-        return session.get_user(raise_unset(created_by.id), raise_on_unknown=False)
+        if is_unset(created_by := self.obj_ref.created_by):
+            raise UnsetError()
+        if is_unset(created_by_id := created_by.id):
+            raise UnsetError()
+        return session.get_user(created_by_id, raise_on_unknown=False)
 
     @property
     def last_edited_time(self) -> dt.datetime:
         """Return the time when the block was last edited."""
-        return raise_unset(self.obj_ref.last_edited_time)
+        if is_unset(last_edited_time := self.obj_ref.last_edited_time):
+            raise UnsetError()
+        return last_edited_time
 
     @property
     def parent(self) -> NotionEntity | WorkspaceType | None:
         """Return the parent Notion entity, Workspace if the workspace is the parent, or None if not accessible."""
         session = get_active_session()
-        parent = raise_unset(self.obj_ref.parent)
+        if is_unset(parent := self.obj_ref.parent):
+            raise UnsetError()
 
         match parent:
             case objs.WorkspaceRef():

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -10,10 +10,10 @@ from typing_extensions import Self
 from ultimate_notion.blocks import ChildrenMixin, DataObject, wrap_icon
 from ultimate_notion.core import get_active_session, get_repr
 from ultimate_notion.emoji import CustomEmoji, Emoji
-from ultimate_notion.errors import ReadOnlyPropertyError, SchemaError
+from ultimate_notion.errors import ReadOnlyPropertyError, SchemaError, UnsetError
 from ultimate_notion.file import AnyFile
 from ultimate_notion.obj_api import blocks as obj_blocks
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.obj_api.core import is_unset
 from ultimate_notion.page import Page
 from ultimate_notion.query import Query
 from ultimate_notion.rich_text import Text, camel_case
@@ -47,15 +47,17 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
     @property
     def url(self) -> str:
         """Return the URL of this database."""
-        return raise_unset(self.obj_ref.url)
+        if is_unset(url := self.obj_ref.url):
+            raise UnsetError()
+        return url
 
     @property
     def title(self) -> str | Text | None:
         """Return the title of this database as rich text."""
         # `str` added as return value but always RichText returned, which inherits from str.
-        if title := raise_unset(self.obj_ref.title):
-            return Text.wrap_obj_ref(title)
-        return None
+        if is_unset(title := self.obj_ref.title):
+            raise UnsetError()
+        return Text.wrap_obj_ref(title) if title else None
 
     @title.setter
     def title(self, text: str | Text | None) -> None:
@@ -70,9 +72,9 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
     @property
     def description(self) -> Text | None:
         """Return the description of this database as rich text."""
-        if desc := raise_unset(self.obj_ref.description):
-            return Text.wrap_obj_ref(desc)
-        return None
+        if is_unset(desc := self.obj_ref.description):
+            raise UnsetError()
+        return Text.wrap_obj_ref(desc) if desc else None
 
     @description.setter
     def description(self, text: str | Text | None) -> None:

--- a/src/ultimate_notion/errors.py
+++ b/src/ultimate_notion/errors.py
@@ -15,6 +15,9 @@ class UltimateNotionError(Exception):
 class UnsetError(UltimateNotionError):
     """Raised when an unset value is accessed before being initialized by the Notion API."""
 
+    def __init__(self, msg: str = 'Parameter is unset and was not yet initialized by the Notion API.') -> None:
+        super().__init__(msg)
+
 
 class SessionError(UltimateNotionError):
     """Raised when there are issues with the Notion session."""

--- a/src/ultimate_notion/file.py
+++ b/src/ultimate_notion/file.py
@@ -17,9 +17,9 @@ from typing_extensions import Self, TypeVar
 from url_normalize import url_normalize
 
 from ultimate_notion.core import Wrapper, get_active_session, get_repr
-from ultimate_notion.errors import InvalidAPIUsageError
+from ultimate_notion.errors import InvalidAPIUsageError, UnsetError
 from ultimate_notion.obj_api import objects as objs
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.obj_api.core import is_unset
 from ultimate_notion.obj_api.enums import FileUploadStatus
 from ultimate_notion.rich_text import Text, html_img
 
@@ -149,7 +149,9 @@ class UploadedFile(AnyFile[objs.UploadedFile], wraps=objs.UploadedFile):
     @property
     def id(self) -> UUID:
         """Return the ID of the uploaded file."""
-        return raise_unset(self.obj_file_upload.id)
+        if is_unset(id_ := self.obj_file_upload.id):
+            raise UnsetError()
+        return id_
 
     @classmethod
     def from_file_upload(cls, file_upload: objs.FileUpload) -> Self:

--- a/src/ultimate_notion/markdown.py
+++ b/src/ultimate_notion/markdown.py
@@ -11,7 +11,8 @@ import numpy as np
 from mistune.directives import FencedDirective, TableOfContents
 from numpy.typing import NDArray
 
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.errors import UnsetError
+from ultimate_notion.obj_api.core import is_unset
 from ultimate_notion.utils import rank
 
 if TYPE_CHECKING:
@@ -159,8 +160,13 @@ def rich_texts_to_markdown(rich_texts: Sequence[RichTextBase]) -> str:
         if left is not None:
             yield left, len(rich_texts) - 1
 
+    def is_underlined(rt: RichTextBase) -> bool:
+        if is_unset(annotations := rt.obj_ref.annotations):
+            raise UnsetError()
+        return annotations.underline
+
     def add_underlines(md_rich_texts: list[str], rich_texts: list[RichTextBase]) -> None:
-        for left, right in find_span(rich_texts, lambda rt: raise_unset(rt.obj_ref.annotations).underline):
+        for left, right in find_span(rich_texts, is_underlined):
             md_rich_texts[left] = '<u>' + md_rich_texts[left]
             md_rich_texts[right] += '</u>'
 

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -18,7 +18,7 @@ import logging
 import re
 from abc import ABC
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, NoReturn, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, cast
 from uuid import UUID
 
 from pydantic import (
@@ -32,7 +32,6 @@ from pydantic import (
 )
 from typing_extensions import Self, TypeIs, TypeVar
 
-from ultimate_notion.errors import UnsetError
 from ultimate_notion.obj_api.enums import Color
 from ultimate_notion.utils import is_stable_release, pydantic_apply
 
@@ -114,18 +113,6 @@ def is_unset(v: Any) -> TypeIs[UnsetType]:
     elif v == Unset.model_dump(mode='python'):  # v was serialized
         return True
     return False
-
-
-@overload
-def raise_unset(obj: UnsetType) -> NoReturn: ...
-@overload
-def raise_unset(obj: T) -> T: ...
-def raise_unset(obj: T | UnsetType) -> T:
-    """Raise an error if the object is unset."""
-    if is_unset(obj):
-        msg = 'Parameter is unset and was not yet initialized by the Notion API.'
-        raise UnsetError(msg)
-    return obj
 
 
 def extract_id(text: str) -> str | None:

--- a/src/ultimate_notion/obj_api/endpoints.py
+++ b/src/ultimate_notion/obj_api/endpoints.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, BinaryIO, cast
+from typing import TYPE_CHECKING, Any, BinaryIO
 from uuid import UUID
 
 from pydantic import SerializeAsAny, TypeAdapter
 
+from ultimate_notion.errors import UnsetError
 from ultimate_notion.obj_api.blocks import Block, Database, FileBase, Page
 from ultimate_notion.obj_api.core import (
     GenericObject,
@@ -24,7 +25,6 @@ from ultimate_notion.obj_api.core import (
     UnsetType,
     UserRef,
     is_unset,
-    raise_unset,
 )
 from ultimate_notion.obj_api.enums import FileUploadMode, FileUploadStatus
 from ultimate_notion.obj_api.iterator import EndpointIterator, PropertyItemList
@@ -125,9 +125,9 @@ class BlocksEndpoint(Endpoint):
                     msg = 'Number of appended blocks does not match the number of provided blocks.'
                     raise ValueError(msg)
             else:
-                appended_blocks = list(
-                    block_iter(block_id=parent_id, children=children, after=str(raise_unset(after.id)))
-                )
+                if is_unset(after_id := after.id):
+                    raise UnsetError()
+                appended_blocks = list(block_iter(block_id=parent_id, children=children, after=str(after_id)))
 
             # the first len(blocks) of appended_blocks correspond to the blocks we passed, the rest are updated
             # blocks after the specified block, where we append the blocks.
@@ -183,7 +183,11 @@ class BlocksEndpoint(Endpoint):
 
         The block info will be updated to the latest version from the server.
         """
-        block_id = cast(UUID, raise_unset(block.id))  # don't get why mypy needs this cast
+        if is_unset(block_id := block.id):
+            raise UnsetError()
+        if not isinstance(block_id, UUID):
+            msg = f'Expected block id to be a `UUID`, got `{type(block_id).__name__}`.'
+            raise TypeError(msg)
         _logger.debug(f'Updating block with id `{block_id}`.')
         params = block.serialize_for_api()
 
@@ -433,7 +437,8 @@ class PagesEndpoint(Endpoint):
         in_trash: bool | UnsetType = Unset,
     ) -> None:
         """Update the Page object properties on the server."""
-        page_id = raise_unset(page.id)
+        if is_unset(page_id := page.id):
+            raise UnsetError()
         _logger.debug(f'Updating info on page with id `{page_id}`.')
 
         request: dict[str, Any] = {}

--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -6,7 +6,7 @@ from ultimate_notion.core import Wrapper, get_repr
 from ultimate_notion.errors import UnsetError
 from ultimate_notion.obj_api import core as obj_core
 from ultimate_notion.obj_api import objects as objs
-from ultimate_notion.obj_api.core import Unset, UnsetType, raise_unset
+from ultimate_notion.obj_api.core import Unset, UnsetType, is_unset
 from ultimate_notion.obj_api.enums import Color, OptionGroupType
 from ultimate_notion.rich_text import Text
 
@@ -43,7 +43,9 @@ class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     @property
     def id(self) -> str:
         """ID of the option."""
-        return raise_unset(self.obj_ref.id)
+        if is_unset(id_ := self.obj_ref.id):
+            raise UnsetError()
+        return id_
 
     @property
     def name(self) -> str:
@@ -53,10 +55,9 @@ class Option(Wrapper[objs.SelectOption], wraps=objs.SelectOption):
     @property
     def color(self) -> Color:
         """Color of the option."""
-        try:
-            return raise_unset(self.obj_ref.color)
-        except UnsetError:  # i.e. unset value
+        if is_unset(color := self.obj_ref.color):  # i.e. unset value
             return Color.DEFAULT
+        return color
 
     @property
     def description(self) -> str:

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -11,12 +11,13 @@ from ultimate_notion.blocks import ChildrenMixin, CommentMixin, DataObject, wrap
 from ultimate_notion.comment import Discussion
 from ultimate_notion.core import NotionEntity, WorkspaceType, get_active_session, get_repr
 from ultimate_notion.emoji import CustomEmoji, Emoji
+from ultimate_notion.errors import UnsetError
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
 from ultimate_notion.markdown import render_md
 from ultimate_notion.obj_api import blocks as obj_blocks
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api import props as obj_props
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.obj_api.core import is_unset
 from ultimate_notion.obj_api.props import MAX_ITEMS_PER_PROPERTY
 from ultimate_notion.props import PropertyValue, Title
 from ultimate_notion.rich_text import Text
@@ -158,12 +159,16 @@ class Page(
     @property
     def is_locked(self) -> bool:
         """Return whether the page is locked for editing."""
-        return raise_unset(self.obj_ref.is_locked)
+        if is_unset(is_locked := self.obj_ref.is_locked):
+            raise UnsetError()
+        return is_locked
 
     @property
     def url(self) -> str:
         """Return the URL of this page."""
-        return raise_unset(self.obj_ref.url)
+        if is_unset(url := self.obj_ref.url):
+            raise UnsetError()
+        return url
 
     @property
     def public_url(self) -> str | None:

--- a/src/ultimate_notion/props.py
+++ b/src/ultimate_notion/props.py
@@ -15,8 +15,9 @@ from typing_extensions import Self, TypeVar
 import ultimate_notion.obj_api.props as obj_props
 from ultimate_notion import rich_text as rt
 from ultimate_notion.core import Wrapper, get_active_session, get_repr
+from ultimate_notion.errors import UnsetError
 from ultimate_notion.file import AnyFile
-from ultimate_notion.obj_api.core import raise_unset
+from ultimate_notion.obj_api.core import is_unset
 from ultimate_notion.obj_api.enums import FormulaType, RollupType, VState
 from ultimate_notion.obj_api.objects import DateRange
 from ultimate_notion.option import Option
@@ -64,7 +65,9 @@ class PropertyValue(Wrapper[PV_co], ABC, wraps=obj_props.PropertyValue):
 
     @property
     def id(self) -> str:
-        return raise_unset(self.obj_ref.id)
+        if is_unset(id_ := self.obj_ref.id):
+            raise UnsetError()
+        return id_
 
     def __repr__(self) -> str:
         return get_repr(self)

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -46,7 +46,7 @@ from ultimate_notion.errors import (
     SchemaNotBoundError,
     UnsetError,
 )
-from ultimate_notion.obj_api.core import Unset, UnsetType, is_unset, raise_unset
+from ultimate_notion.obj_api.core import Unset, UnsetType, is_unset
 from ultimate_notion.obj_api.enums import AggFunc, NumberFormat, OptionGroupType
 from ultimate_notion.obj_api.objects import SelectGroup
 from ultimate_notion.option import Option, OptionGroup, OptionNS, check_for_updates
@@ -164,7 +164,9 @@ class Property(Wrapper[GO_co], ABC, wraps=PropertyGO):
     @property
     def id(self) -> str | None:
         """Return identifier of this property."""
-        return raise_unset(self.obj_ref.id)
+        if is_unset(id_ := self.obj_ref.id):
+            raise UnsetError()
+        return id_
 
     @property
     def name(self) -> str:
@@ -535,7 +537,8 @@ class Relation(Property[obj_schema.Relation], wraps=obj_schema.Relation):
         if not isinstance(two_way_prop_rel, obj_schema.DualPropertyRelation):
             msg = f'Expected a `DualPropertyRelation`, got `{type(two_way_prop_rel).__name__}`.'
             raise TypeError(msg)
-        tmp_prop_name = raise_unset(two_way_prop_rel.dual_property.synced_property_name)
+        if is_unset(tmp_prop_name := two_way_prop_rel.dual_property.synced_property_name):
+            raise UnsetError()
         db = self.schema.get_db()
         db.reload(rebind_schema=False)
         if (back_ref_prop_type := db.schema[tmp_prop_name]) is not None:
@@ -550,7 +553,8 @@ class Relation(Property[obj_schema.Relation], wraps=obj_schema.Relation):
                 self._two_way_prop = self._get_owner().get_prop(self._two_way_prop)
             return self._two_way_prop
         elif self._is_init and isinstance(self.obj_ref.relation, obj_schema.DualPropertyRelation):
-            prop_name = raise_unset(self.obj_ref.relation.dual_property.synced_property_name)
+            if is_unset(prop_name := self.obj_ref.relation.dual_property.synced_property_name):
+                raise UnsetError()
             return self.schema.get_prop(prop_name) if prop_name else None
         else:
             return None


### PR DESCRIPTION
## Description

`raise_unset` used overloads to strip the `UnsetType` sentinel, but ty does not split `X | UnsetType` unions across overloads, producing false positives at ~28 call sites. This replaces the overloaded guard with `is_unset` narrowing (`TypeIs`) at each call site, raising `UnsetError` inline; `UnsetError` now carries the message as its default so call sites are a plain `raise UnsetError()` with no duplication and the helper/overloads are gone. The one `endpoints.py` site whose result feeds `.hex` keeps an `isinstance` guard raising `TypeError`, matching the repo's existing narrowing idiom. Verified against mypy (strict), ruff, ty 0.0.51, and the offline test suite. Fixes #256.

### Types of change

Enhancement / type-checking cleanup (no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.