### PR TITLE
Widen children cache type instead of casting to Block

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -168,14 +168,14 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
     as the Notion API often doesn't send the `children` property back in the response.
     """
 
-    _children: list[Block] | None = None
+    _children: list[Block | Page | Database] | None = None
 
     @property
     def _has_children_field(self) -> bool:
         """Return whether the object has a `children` field."""
         return isinstance(self.obj_ref, obj_blocks.Block) and isinstance(self.obj_ref.value, obj_blocks.WithChildren)
 
-    def _gen_children_cache(self) -> list[Block]:
+    def _gen_children_cache(self) -> list[Block | Page | Database]:
         """Generate the children cache."""
         if self.is_deleted:
             msg = 'Cannot retrieve children of a deleted block from Notion.'
@@ -187,14 +187,15 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
         if isinstance(self.obj_ref, obj_blocks.Block) and isinstance(self.obj_ref.value, obj_blocks.WithChildren):
             self.obj_ref.value.children = child_blocks_objs  # update the children attribute
 
-        child_blocks: list[Block] = [Block.wrap_obj_ref(block) for block in child_blocks_objs]
+        child_blocks: list[Block | Page | Database] = [Block.wrap_obj_ref(block) for block in child_blocks_objs]
 
         for idx, child_block in enumerate(child_blocks):
             if isinstance(child_block, ChildPage):
-                child_blocks[idx] = cast(Block, child_block.page)
+                child_blocks[idx] = child_block.page
             elif isinstance(child_block, ChildDatabase):
+                ref_block: Block | Database
                 try:
-                    ref_block = cast(Block, child_block.db)
+                    ref_block = child_block.db
                 except UnknownDatabaseError:
                     # linked database that cannot be retrieved via API. Check the docs:
                     # https://developers.notion.com/reference/retrieve-a-database


### PR DESCRIPTION
## Description

`ChildrenMixin._children` was typed `list[Block]`, but it actually holds `Page` and `Database` objects too — exactly what the `children` property's return type (`tuple[Block | Page | Database, ...]`) already advertises. Two `cast(Block, ...)` calls over `child_block.page`/`child_block.db` papered over this narrowness, so I widened `_children` and `_gen_children_cache` to `list[Block | Page | Database]` and removed the casts. This is type-only and behaviour-preserving (`cast` is a runtime no-op); mypy and ruff both pass.

### Types of change

Code cleanup / typing improvement (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
