### PR TITLE
Type vcr_fixture's wrapped func with a __name__ Protocol

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
 from random import randint
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 from unittest.mock import MagicMock, patch
 
 import pydantic
@@ -274,6 +274,14 @@ def custom_config(request: SubRequest) -> Iterator[Path]:
             yield cfg_path
 
 
+class _NamedFunc(Protocol):
+    """A callable with a `__name__`, i.e. a plain function (which `Callable` does not model)."""
+
+    __name__: str
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
 def vcr_fixture(
     scope: Literal['module', 'session'], *, autouse: bool = False, shared: bool = False
 ) -> Callable[..., Any]:
@@ -282,7 +290,7 @@ def vcr_fixture(
         msg = f'Use this only for module or session scope, not {scope}!'
         raise ValueError(msg)
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: _NamedFunc) -> Callable[..., Any]:
         args = inspect.signature(func).parameters  # to inject the fixtures into the wrapper
         is_generator = inspect.isgeneratorfunction(func)
 


### PR DESCRIPTION
## Description

`Callable` does not model `__name__`, so `func.__name__` in the `vcr_fixture` decorator is not expressible on that type — ty reports `unresolved-attribute`. This types the decorator's parameter as a small structural `Protocol` (`_NamedFunc`) capturing what it actually requires: a callable that also has a `__name__`. There is no runtime change; the Protocol is structural and the decorated functions already satisfy it. Verified against mypy 1.18.2 (strict) and ty 0.0.51. Fixes #261.

### Types of change

Internal type-correctness fix (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.