### PR TITLE
Replace cast downcasts in blocks.py with isinstance guards

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeGuard, cast, overload
+from typing import TYPE_CHECKING, Any, TypeGuard, overload
 
 import numpy as np
 from tabulate import tabulate
@@ -252,6 +252,13 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
         if not blocks:
             return self
 
+        from ultimate_notion.page import Page  # noqa: PLC0415  # Avoid circular import.
+
+        parent_obj = self
+        if not isinstance(parent_obj, (Block, Page)):
+            msg = f'Cannot append children to a `{type(parent_obj).__name__}`.'
+            raise TypeError(msg)
+
         if sync is True and not self.in_notion:
             msg = 'Cannot append blocks synchronously to a block that is not in Notion.'
             raise InvalidAPIUsageError(msg)
@@ -268,11 +275,11 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
                 raise InvalidAPIUsageError(msg)
             self.obj_ref.has_children = True
             for block in blocks:
-                block._parent = cast(Block, self)  # set fallback parent for offline use
+                block._parent = parent_obj  # set fallback parent for offline use
             # Don't store it in the potential `children` field of the obj_ref and let the Notion API do it.
             self._children.extend(blocks)
         else:  # self.in_notion and sync is not False
-            blocks_iter = _chunk_blocks_for_api(cast(ParentBlock, self), blocks)
+            blocks_iter = _chunk_blocks_for_api(parent_obj, blocks)
             _append_block_chunks(blocks_iter, after=after)
 
         return self
@@ -330,10 +337,13 @@ class Block(CommentMixin[B_co], ABC, wraps=obj_blocks.Block):
         """Return the parent block or page, or None if not accessible."""
         from ultimate_notion.page import Page  # noqa: PLC0415  # Avoid circular import.
 
-        if self.in_notion:
-            return cast(Block | Page | None, super().parent)
-        else:
+        if not self.in_notion:
             return self._parent
+        parent = super().parent
+        if parent is not None and not isinstance(parent, (Block, Page)):
+            msg = f'Expected the parent to be a block or page, got `{type(parent).__name__}`.'
+            raise TypeError(msg)
+        return parent
 
     @property
     def discussions(self) -> tuple[Discussion, ...]:


### PR DESCRIPTION
## Description

Removes three `cast` downcasts in `blocks.py`, replacing each with an `isinstance` guard that raises `TypeError` — matching the existing narrowing idiom used elsewhere in the codebase (ruff S101 disallows asserts in source). `ChildrenMixin.append` now narrows `self` to `Block | Page` once via a local variable (replacing both `cast(Block, self)` and `cast(ParentBlock, self)`; the old `ParentBlock` cast also misrepresented the `Page` case, since `Page` subclasses `ChildrenMixin` and `_chunk_blocks_for_api` accepts `Block | Page`), and `Block.parent` narrows `super().parent` to `Block | Page | None`, letting the now-unused `cast` import be dropped. `mypy`, `ruff`, and the `test_blocks.py` / `test_page.py` suites all pass.

### Types of change

Code cleanup / typing improvement (no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)