### PR TITLE
Construct new builders via type(self) in SearchQueryBuilder.filter/sort

### DIFF
--- a/src/ultimate_notion/obj_api/query.py
+++ b/src/ultimate_notion/obj_api/query.py
@@ -322,7 +322,7 @@ class SearchQueryBuilder(QueryBuilder[T]):
         else:  # db_only
             value = 'database'
 
-        builder = SearchQueryBuilder[T](self.endpoint, text=self.params.get('query'))
+        builder = type(self)(self.endpoint, text=self.params.get('query'))
         builder.query.filter = SearchFilter(property='object', value=value)
         return builder
 
@@ -330,7 +330,7 @@ class SearchQueryBuilder(QueryBuilder[T]):
         """Add the given sort elements to the query."""
         direction = SortDirection.ASCENDING if ascending else SortDirection.DESCENDING
 
-        builder = SearchQueryBuilder[T](self.endpoint, text=self.params.get('query'))
+        builder = type(self)(self.endpoint, text=self.params.get('query'))
         builder.query.sort = SearchSort(timestamp=TimestampKind.LAST_EDITED_TIME, direction=direction)
         return builder
 


### PR DESCRIPTION
Closes #267

`SearchQueryBuilder.filter` and `SearchQueryBuilder.sort` constructed their returned builder with an explicit generic subscript, `SearchQueryBuilder[T](...)`. The `[T]` is erased at runtime so has no runtime effect, and it hardcodes the class name.

This replaces both with `type(self)(...)`:

- It is the idiomatic builder pattern — a fresh instance of the same type, which stays correct under subclassing.
- `type(self)(...)` is typed as the current instance's type, matching the declared `SearchQueryBuilder[T]` return without the erased subscript.

Runtime behaviour is unchanged: `SearchQueryBuilder` has no subclasses today, so `type(self)` is always `SearchQueryBuilder`.

mypy passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)