### PR TITLE
Use __dict__ for the deepcopy_with_sharing __deepcopy__ hack

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -210,7 +210,7 @@ def deepcopy_with_sharing(obj: T, shared_attributes: Sequence[str], memo: dict[i
     if hasattr(obj, '__deepcopy__'):
         # Do hack to prevent infinite recursion in call to deepcopy
         deepcopy_method = obj.__deepcopy__
-        obj.__deepcopy__ = None
+        obj.__dict__['__deepcopy__'] = None
 
     for attr in shared_attributes:
         del obj.__dict__[attr]
@@ -223,7 +223,7 @@ def deepcopy_with_sharing(obj: T, shared_attributes: Sequence[str], memo: dict[i
 
     if hasattr(obj, '__deepcopy__'):
         # Undo hack
-        obj.__deepcopy__ = deepcopy_method
+        obj.__dict__['__deepcopy__'] = deepcopy_method
         del clone.__dict__['__deepcopy__']
 
     return clone


### PR DESCRIPTION
Closes #269

## Change

`deepcopy_with_sharing` temporarily disables an object's `__deepcopy__` to avoid infinite recursion, then restores it. Assigning `None` (and later the saved method) to `obj.__deepcopy__` is rejected under strict attribute typing, because `__deepcopy__` is a callable method and `None` is not assignable to it.

This writes to the instance `__dict__` directly instead:

```python
obj.__dict__['__deepcopy__'] = None
...
obj.__dict__['__deepcopy__'] = deepcopy_method
```

- Consistent with the surrounding code, which already manipulates `__dict__` to add and remove the shadowing entries (`del obj.__dict__[attr]`, `del clone.__dict__['__deepcopy__']`).
- Type-safe: `__dict__` is `dict[str, Any]`, so shadowing the class method with `None` no longer trips strict attribute typing.

Runtime behaviour is unchanged: setting an instance attribute on a normal object writes to its `__dict__`. Verified that the hack still copies non-shared attributes independently, shares the listed attributes, and restores a working `__deepcopy__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)