### PR TITLE
Release v0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.9.7, 2026-06-22
+
 - Fix: Add support for `pydantic` 2.13, which previously broke parsing of Notion user objects (e.g. people properties), issue #189.
 - Fix: Accept the new `is_archived` field the Notion API sends on pages and databases, which previously broke `search_page()`/`search_db()` in development mode, issue #202.
 - Fix: Accept the nullable `icon` field returned for paragraph blocks and omit read-only archive fields when creating blocks.


### PR DESCRIPTION
## Description

Cuts release `v0.9.7` by promoting the three accumulated `## Unreleased` fixes under a dated version header in `CHANGELOG.md`. The fixes shipped are: support for `pydantic` 2.13 (issue #189), accepting the new `is_archived` field on pages/databases (issue #202), and accepting the nullable `icon` on paragraph blocks. No version string is bumped because the package version is derived from the git tag via `hatch-vcs`; the actual PyPI publish happens when the `v0.9.7` tag is pushed after this merges.

### Types of change

Documentation / release housekeeping (changelog only — no code changes).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
