### PR TITLE
Bump actions/upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/.github/workflows/build-dev-docs.yml
+++ b/.github/workflows/build-dev-docs.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Create archive
       run: git archive -o site.zip gh-pages
 
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
         name: docs
         path: site.zip
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Download archive
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: docs
 

--- a/.github/workflows/build-rel-docs.yml
+++ b/.github/workflows/build-rel-docs.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Create archive
       run: git archive -o site.zip gh-pages
 
-    - uses: actions/upload-artifact@v6
+    - uses: actions/upload-artifact@v7
       with:
         name: docs
         path: site.zip
@@ -66,7 +66,7 @@ jobs:
 
     steps:
     - name: Download archive
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: docs
 

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build distributions
         run: hatch build
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts
           path: dist/*
@@ -53,7 +53,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: artifacts
           path: dist


### PR DESCRIPTION
Combines Dependabot PRs #185 (upload-artifact 6→7) and #184 (download-artifact 7→8) onto a regular branch so the test workflow runs with repo secrets.

Both actions are bumped only in the docs/publish workflows (`build-dev-docs.yml`, `build-rel-docs.yml`, `publish-pkg.yml`). The only breaking note is download-artifact v8 defaulting digest-mismatch to `error` (security hardening), which doesn't affect normal usage.

Closes #185
Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)