### PR TITLE
Release v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.9.8, 2026-06-22
+
 - Fix: Tolerate page/database objects that omit `properties`, which the `search` endpoint returns for stripped-down records (e.g. trashed or limited-access pages) and which previously broke `search_page()`/`search_db()`, issue #273.
 
 ## Version 0.9.7, 2026-06-22


### PR DESCRIPTION
Release v0.9.8.

Adds the changelog version header for 0.9.8, covering the fix for property-less page/database objects returned by the search endpoint (#273).

After merge, tag the merge commit `v0.9.8` and push the tag to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)