### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 .vscode/.env
+.env
 tags
 
 # Package files


### PR DESCRIPTION
Closes #280

## What

Add `.env` to `.gitignore` so local environment files (e.g. `.vscode/.env` workflows) aren't accidentally committed.

## Notes

- Extracted from the large Data Source migration PR #178.
- The `issues/` ignore line from PR #178 is intentionally omitted here — it only exists to hide a committed `issues/issue188.md` file that arguably shouldn't be in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)