### PR TITLE
Add SListError base class for SList exceptions

### DIFF
--- a/src/ultimate_notion/errors.py
+++ b/src/ultimate_notion/errors.py
@@ -47,11 +47,15 @@ class FilterQueryError(ValueError, UltimateNotionError):
     """An exception that is raised when a filter query is invalid."""
 
 
-class EmptyListError(UltimateNotionError):
+class SListError(UltimateNotionError):
+    """Base class for all exceptions in SList."""
+
+
+class EmptyListError(SListError):
     """Custom exception for an empty list in SList."""
 
 
-class MultipleItemsError(UltimateNotionError):
+class MultipleItemsError(SListError):
     """Custom exception for a list with multiple items in SList."""
 
 


### PR DESCRIPTION
Extracted from PR #178.

## What

In `src/ultimate_notion/errors.py`, introduce a common base for the SList exceptions and reparent the existing ones under it:

```python
class SListError(UltimateNotionError):
    """Base class for all exceptions in SList."""
```

`EmptyListError` and `MultipleItemsError` now subclass `SListError`.

## Why

Lets callers do `except SListError` to catch both cases.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)