### PR TITLE
Add stable completion-tests job for required status checks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,3 +88,18 @@ jobs:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true
           path-to-lcov: coverage.lcov
+
+  completion-tests:
+    # Aggregate job with a stable name so it can be used as a single required
+    # status check for branch protection / auto-merge. The matrix job names
+    # vary per OS and Python version, so they cannot be required directly.
+    needs: run-github-job-matrix
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # Run even if one matrix job fails
+    steps:
+      - name: Check matrix job status
+        run: |-
+          if ! ${{ needs.run-github-job-matrix.result == 'success' }}; then
+            echo "One or more matrix jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Description

Adds an aggregate `completion-tests` job to the test workflow with a stable name, so it can be set as a single required status check for branch protection / auto-merge. The matrix job names vary per OS and Python version, so they cannot be required directly; this job depends on the whole matrix and runs with `if: always()`, failing if any matrix leg fails. This mirrors the pattern used by VWS-Python/vws-cli to enable GitHub auto-merge. Enabling auto-merge and requiring this check are admin-only repo settings that still need to be configured.

### Types of change

Enhancement to CI configuration.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.