### PR TITLE
Remove dead create_dbs NotImplementedError stub

### DIFF
--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -216,11 +216,6 @@ class Session:
         self.cache[db.id] = db
         return db
 
-    def create_dbs(self, parents: Page | list[Page], schemas: list[type[Schema]]) -> list[Database]:
-        """Create new databases in the right order in case there a relations between them."""
-        # ToDo: Implement
-        raise NotImplementedError
-
     def search_db(
         self, db_name: str | None = None, *, exact: bool = True, reverse: bool = False, deleted: bool = False
     ) -> SList[Database]:


### PR DESCRIPTION
Removes the never-implemented `create_dbs` method in `src/ultimate_notion/session.py`, which only ever raised `NotImplementedError`.

It is fully independent of the `Database`→`DataSource` rename — a pure dead-code cleanup extracted from PR #178.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)