### PR TITLE
Refactor: extract resolve_ref() helper from NotionEntity.parent

### DIFF
--- a/src/ultimate_notion/core.py
+++ b/src/ultimate_notion/core.py
@@ -144,6 +144,40 @@ Workspace: Final = _Workspace.ROOT
 WorkspaceType: TypeAlias = Literal[_Workspace.ROOT]
 """This represents the type of the root workspace in Notion for type hinting."""
 
+
+def resolve_ref(obj_ref: obj_core.NotionEntity) -> NotionEntity | WorkspaceType | None:
+    """Resolve a low-level NotionEntity reference to a high-level NotionEntity object.
+
+    Returns the parent Notion entity, Workspace if the workspace is the parent, or None if not accessible.
+    """
+    session = get_active_session()
+    if is_unset(parent := obj_ref.parent):
+        raise UnsetError()
+
+    match parent:
+        case objs.WorkspaceRef():
+            return Workspace
+        case objs.PageRef(page_id=page_id):
+            try:
+                return session.get_page(page_ref=page_id)
+            except UnknownPageError as e:
+                msg = f'No access to parent page with id `{page_id}`: {e}'
+                _logger.info(msg)
+                return None
+        case objs.DatabaseRef(database_id=database_id):
+            try:
+                return session.get_db(db_ref=database_id)
+            except UnknownDatabaseError as e:
+                msg = f'No access to parent database with id `{database_id}`: {e}'
+                _logger.info(msg)
+                return None
+        case objs.BlockRef(block_id=block_id):
+            return session.get_block(block_ref=block_id)
+        case _:
+            msg = f'Unknown parent reference {type(parent)}'
+            raise RuntimeError(msg)
+
+
 # ToDo: Use new syntax when requires-python >= 3.12
 NE_co = TypeVar('NE_co', bound=obj_core.NotionEntity, default=obj_core.NotionEntity, covariant=True)
 
@@ -195,32 +229,7 @@ class NotionEntity(NotionObject[NE_co], ABC, wraps=obj_core.NotionEntity):
     @property
     def parent(self) -> NotionEntity | WorkspaceType | None:
         """Return the parent Notion entity, Workspace if the workspace is the parent, or None if not accessible."""
-        session = get_active_session()
-        if is_unset(parent := self.obj_ref.parent):
-            raise UnsetError()
-
-        match parent:
-            case objs.WorkspaceRef():
-                return Workspace
-            case objs.PageRef(page_id=page_id):
-                try:
-                    return session.get_page(page_ref=page_id)
-                except UnknownPageError as e:
-                    msg = f'No access to parent page with id `{page_id}`: {e}'
-                    _logger.info(msg)
-                    return None
-            case objs.DatabaseRef(database_id=database_id):
-                try:
-                    return session.get_db(db_ref=database_id)
-                except UnknownDatabaseError as e:
-                    msg = f'No access to parent database with id `{database_id}`: {e}'
-                    _logger.info(msg)
-                    return None
-            case objs.BlockRef(block_id=block_id):
-                return session.get_block(block_ref=block_id)
-            case _:
-                msg = f'Unknown parent reference {type(parent)}'
-                raise RuntimeError(msg)
+        return resolve_ref(self.obj_ref)
 
     @property
     def ancestors(self) -> tuple[NotionEntity, ...]:


### PR DESCRIPTION
## Description

Lifts the `match parent: ...` block out of the `NotionEntity.parent` property in `src/ultimate_notion/core.py` into a standalone module-level `resolve_ref()` helper, with `parent` now delegating to it. This is a pure mechanical extraction with no behavior change, improving testability of the parent-resolution logic. Closes #288.

### Types of change

Refactor (no functional change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)