### PR TITLE
Fix is_archived leaking into nested block children on append (#291)

### DIFF
--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -134,9 +134,30 @@ class Block(TypedObject[GO_co], DataObject, object='block', polymorphic_base=Tru
     def serialize_for_api(self) -> dict[str, Any]:
         """Serialize the block for sending it to the Notion API."""
         data = super().serialize_for_api()
-        for key in ('has_children', 'in_trash', 'archived', 'is_archived'):
-            data.pop(key, None)
+        _strip_block_meta_fields(data)
         return data
+
+
+# Read-only meta fields the Notion API rejects on create/append payloads. `is_archived`
+# is in particular rejected outright (issue #291), so it must not leak into nested children.
+_API_EXCLUDED_BLOCK_FIELDS = ('has_children', 'in_trash', 'archived', 'is_archived')
+
+
+def _strip_block_meta_fields(data: Any) -> None:
+    """Recursively remove read-only block meta fields from a serialized block tree.
+
+    Nested children are serialized via pydantic's recursive `model_dump` rather than by
+    calling each child's `serialize_for_api`, so the top-level strip never reaches them.
+    Walking the serialized tree here ensures every nested child block is cleaned too.
+    """
+    if isinstance(data, dict):
+        for key in _API_EXCLUDED_BLOCK_FIELDS:
+            data.pop(key, None)
+        for value in data.values():
+            _strip_block_meta_fields(value)
+    elif isinstance(data, list):
+        for item in data:
+            _strip_block_meta_fields(item)
 
 
 # ToDo: Use new syntax when requires-python >= 3.12

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -701,6 +701,29 @@ def test_offline_block_assembly(root_page: uno.Page, notion: uno.Session) -> Non
     heading.append(uno.Paragraph('This is a child paragraph.'))
 
 
+def test_serialize_strips_meta_from_nested_children() -> None:
+    """Read-only block meta fields must not leak into nested children when serializing.
+
+    Regression test for https://github.com/ultimate-notion/ultimate-notion/issues/291: nested
+    children are serialized via pydantic's recursive `model_dump`, not each child's
+    `serialize_for_api`, so the meta strip has to walk the whole tree. `is_archived` in particular
+    is rejected by Notion's append-children endpoint, turning a latent leak into a hard `400`.
+    """
+    top = uno.Callout('top')
+    mid = uno.Callout('mid')
+    inner = uno.Callout('inner')
+    top.obj_ref.value.children = [mid.obj_ref]
+    mid.obj_ref.value.children = [inner.obj_ref]
+
+    data = top.obj_ref.serialize_for_api()
+    meta_fields = ('has_children', 'in_trash', 'archived', 'is_archived')
+
+    child = data['callout']['children'][0]
+    grandchild = child['callout']['children'][0]
+    for level in (data, child, grandchild):
+        assert not any(field in level for field in meta_fields)
+
+
 def test_rt_default_color() -> None:
     para_1 = uno.Paragraph(text='Hello')
     para_2 = uno.Paragraph(text='')


### PR DESCRIPTION
## Description

Fixes #291. `Block.serialize_for_api` stripped the read-only meta fields (`has_children`/`in_trash`/`archived`/`is_archived`) only from the top-level block, but nested children are serialized via pydantic's recursive `model_dump` rather than each child's `serialize_for_api`, so the strip never reached them — and since `is_archived` (added in 0.9.8) is rejected outright by Notion's append-children endpoint, any append of a block tree with children (e.g. a `Table` whose rows are nested children, or nested callouts) failed with a `400`. This strips the meta fields recursively over the whole serialized tree and adds a deterministic, no-network regression test (`test_serialize_strips_meta_from_nested_children`); verified live that `page.append(uno.Table(2, 2))` now succeeds where it previously `400`ed, and `hatch run vcr-only` is green for the full suite.

### Types of change

Bug fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)