### PR TITLE
Add VCR live test for nested-children append + portable cassettes (#292)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,38 @@ You only need this section to run the tests live or to re-record cassettes.
     [`tests/TEST_WORKSPACE.md`](https://github.com/ultimate-notion/ultimate-notion/blob/main/tests/TEST_WORKSPACE.md)
     for exact instructions.
 
+### Add a new live (VCR) test
+
+The committed cassettes are one coherent recording of a single workspace, so you
+**cannot** simply `vcr-rewrite` a new test against your own workspace and commit the
+result: `vcr-rewrite` replays the shared fixture cassettes in
+`tests/cassettes/fixtures/` (the `Tests` root page, the seeded databases, …) with
+*your* workspace's ids, which then diverge from the rest of the suite. Record a new
+test like this instead:
+
+```console
+# 1. Bootstrap your workspace (root page named `Tests`, or set UNO_TEST_ROOT_PAGE).
+# 2. Delete the shared fixture cassettes so they record fresh against your workspace
+#    (vcr-rewrite otherwise downgrades them to `new_episodes` and replays committed ids).
+rm tests/cassettes/fixtures/mod_*.yaml
+# 3. Record only your new test.
+NOTION_TOKEN=ntn_… hatch run vcr-rewrite -k your_new_test
+# 4. Keep ONLY your new test's cassette; restore the shared fixtures unchanged.
+git checkout -- tests/cassettes/fixtures
+# 5. Verify it replays offline against the committed fixtures.
+hatch run vcr-only -k your_new_test
+```
+
+This works because cassettes are matched by request path and (for `POST /v1/search`)
+by request body, while request *bodies* are otherwise ignored — so a test that creates
+content under `root_page` and asserts on that content replays cleanly regardless of the
+root page's actual id. If your test instead asserts identity against a shared fixture
+(e.g. `page.parent == root_page`) or puts a shared object's id in a request *path*,
+normalise those ids to the canonical committed ones in your new cassette, otherwise it
+will not replay against the committed fixtures. To support recording against a root page
+that cannot be named `Tests`, the non-default title configured via `UNO_TEST_ROOT_PAGE`
+is scrubbed back to `Tests` when cassettes are written (see `tests/conftest.py`).
+
 ### Implement your changes
 
 1. Create a branch to hold your changes:

--- a/tests/cassettes/test_blocks/test_append_nested_children_single_call.yaml
+++ b/tests/cassettes/test_blocks/test_append_nested_children_single_call.yaml
@@ -1,0 +1,538 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "5f505199-b292-4713-920b-61d813bf72a3"},
+      "properties": {"title": {"type": "title", "title": [{"type": "text", "plain_text":
+      "Page for appending nested children", "annotations": {"bold": false, "italic":
+      false, "strikethrough": false, "underline": false, "code": false}, "text": {"content":
+      "Page for appending nested children"}}]}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '347'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    content: '{"object":"page","id":"3889ce7b-60a4-81a2-b76c-e4460729249d","created_time":"2026-06-23T11:37:00.000Z","last_edited_time":"2026-06-23T11:37:00.000Z","created_by":{"object":"user","id":"3839ce7b-60a4-81d7-9c8f-0027e2be250c"},"last_edited_by":{"object":"user","id":"3839ce7b-60a4-81d7-9c8f-0027e2be250c"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Page
+      for appending nested children","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Page
+      for appending nested children","href":null}]}},"url":"https://app.notion.com/p/Page-for-appending-nested-children-3889ce7b60a481a2b76ce4460729249d","public_url":null,"archived":false,"request_id":"f5b18c1a-c6ea-41e1-9ed3-bfac4c26fe23"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a10333529f0d4f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f5b18c1a-c6ea-41e1-9ed3-bfac4c26fe23
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/5f505199-b292-4713-920b-61d813bf72a3
+  response:
+    content: '{"object":"page","id":"5f505199-b292-4713-920b-61d813bf72a3","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-23T11:37:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"3839ce7b-60a4-81d7-9c8f-0027e2be250c"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://app.notion.com/p/Tests-5f505199b2924713920b61d813bf72a3","public_url":null,"archived":false,"request_id":"620f08dd-2b20-4bce-a7a1-1d087eaf7bf8"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1033354edbb4f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 620f08dd-2b20-4bce-a7a1-1d087eaf7bf8
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/blocks/3889ce7b-60a4-81a2-b76c-e4460729249d/children?page_size=100
+  response:
+    content: '{"object":"list","results":[],"next_cursor":null,"has_more":false,"type":"block","block":{},"request_id":"4841f20d-acc1-4f6f-9002-11a4577745ec"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a103335659f54f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 4841f20d-acc1-4f6f-9002-11a4577745ec
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: "{\"children\":[{\"object\":\"block\",\"type\":\"callout\",\"callout\":{\"children\":[],\"rich_text\":[{\"type\":\"text\",\"plain_text\":\"top\",\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false},\"text\":{\"content\":\"top\"}}],\"color\":\"default\",\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"}}}]}"
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/3889ce7b-60a4-81a2-b76c-e4460729249d/children
+  response:
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"block\",\"id\":\"3889ce7b-60a4-81ef-939f-ec0ca840f912\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"3889ce7b-60a4-81a2-b76c-e4460729249d\"},\"created_time\":\"2026-06-23T11:37:00.000Z\",\"last_edited_time\":\"2026-06-23T11:37:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"has_children\":false,\"in_trash\":false,\"type\":\"callout\",\"callout\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"top\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"top\",\"href\":null}],\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"},\"color\":\"default\"},\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"block\",\"block\":{},\"request_id\":\"1f5096b5-ba7f-40a1-8741-f6c82a8b5750\"}"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1033357ee684f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 1f5096b5-ba7f-40a1-8741-f6c82a8b5750
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: "{\"children\":[{\"object\":\"block\",\"type\":\"callout\",\"callout\":{\"children\":[],\"rich_text\":[{\"type\":\"text\",\"plain_text\":\"mid\",\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false},\"text\":{\"content\":\"mid\"}}],\"color\":\"default\",\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"}}}]}"
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '304'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/3889ce7b-60a4-81ef-939f-ec0ca840f912/children
+  response:
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"block\",\"id\":\"3889ce7b-60a4-81f9-889f-c99b4be79663\",\"parent\":{\"type\":\"block_id\",\"block_id\":\"3889ce7b-60a4-81ef-939f-ec0ca840f912\"},\"created_time\":\"2026-06-23T11:37:00.000Z\",\"last_edited_time\":\"2026-06-23T11:37:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"has_children\":false,\"in_trash\":false,\"type\":\"callout\",\"callout\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"mid\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"mid\",\"href\":null}],\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"},\"color\":\"default\"},\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"block\",\"block\":{},\"request_id\":\"33562f0e-3015-486d-98a1-b825a2482174\"}"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a10333621ce54f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 33562f0e-3015-486d-98a1-b825a2482174
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: "{\"children\":[{\"object\":\"block\",\"type\":\"callout\",\"callout\":{\"children\":[],\"rich_text\":[{\"type\":\"text\",\"plain_text\":\"inner\",\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false},\"text\":{\"content\":\"inner\"}}],\"color\":\"default\",\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"}}}]}"
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '308'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/3889ce7b-60a4-81f9-889f-c99b4be79663/children
+  response:
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"block\",\"id\":\"3889ce7b-60a4-8109-a247-fbd0b1a69750\",\"parent\":{\"type\":\"block_id\",\"block_id\":\"3889ce7b-60a4-81f9-889f-c99b4be79663\"},\"created_time\":\"2026-06-23T11:37:00.000Z\",\"last_edited_time\":\"2026-06-23T11:37:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"has_children\":false,\"in_trash\":false,\"type\":\"callout\",\"callout\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"inner\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"inner\",\"href\":null}],\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"},\"color\":\"default\"},\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"block\",\"block\":{},\"request_id\":\"981cd807-3f3e-4352-a80f-8c4709d49fbf\"}"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a10333684fa34f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 981cd807-3f3e-4352-a80f-8c4709d49fbf
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/3889ce7b-60a4-81a2-b76c-e4460729249d
+  response:
+    content: '{"object":"page","id":"3889ce7b-60a4-81a2-b76c-e4460729249d","created_time":"2026-06-23T11:37:00.000Z","last_edited_time":"2026-06-23T11:37:00.000Z","created_by":{"object":"user","id":"3839ce7b-60a4-81d7-9c8f-0027e2be250c"},"last_edited_by":{"object":"user","id":"3839ce7b-60a4-81d7-9c8f-0027e2be250c"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"5f505199-b292-4713-920b-61d813bf72a3"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Page
+      for appending nested children","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Page
+      for appending nested children","href":null}]}},"url":"https://app.notion.com/p/Page-for-appending-nested-children-3889ce7b60a481a2b76ce4460729249d","public_url":null,"archived":false,"request_id":"aab49b88-d2c4-4038-ae71-5adc5c46af35"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a103336c8c284f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - aab49b88-d2c4-4038-ae71-5adc5c46af35
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/blocks/3889ce7b-60a4-81a2-b76c-e4460729249d/children?page_size=100
+  response:
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"block\",\"id\":\"3889ce7b-60a4-81ef-939f-ec0ca840f912\",\"parent\":{\"type\":\"page_id\",\"page_id\":\"3889ce7b-60a4-81a2-b76c-e4460729249d\"},\"created_time\":\"2026-06-23T11:37:00.000Z\",\"last_edited_time\":\"2026-06-23T11:37:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"3839ce7b-60a4-81d7-9c8f-0027e2be250c\"},\"has_children\":true,\"in_trash\":false,\"type\":\"callout\",\"callout\":{\"rich_text\":[{\"type\":\"text\",\"text\":{\"content\":\"top\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"top\",\"href\":null}],\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F4A1\"},\"color\":\"default\"},\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"block\",\"block\":{},\"request_id\":\"c3d16377-5958-4236-b33d-47dc12c35f32\"}"
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a103336e28ba4f9c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - c3d16377-5958-4236-b33d-47dc12c35f32
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,55 @@ TEST_CFG_FILE = get_cfg_file()
 # Mutually exclusive pytest markers, that are not run by default and enabled via command line flags
 PYTEST_MARKERS = ['check_latest_release', 'file_upload']
 
+# --- Workspace-portable cassettes (issue #292) --------------------------------------------------
+# The default VCR matchers ignore request bodies, so every `POST /v1/search` matches by path alone
+# and a cassette with several searches only replays them in the order they were recorded. That makes
+# the shared fixtures fragile and ties a recording to the workspace it was made in. We add a matcher
+# that *additionally* compares the JSON body of `/v1/search` requests (a no-op for every other
+# endpoint), so each search is matched by what it actually queries. We also scrub a non-default root
+# page title back to the canonical `Tests` on record, so a maintainer who cannot name their shared
+# root page `Tests` (via `UNO_TEST_ROOT_PAGE`) still produces cassettes that replay against the
+# committed set. See the "Set up a Notion test workspace" section in `CONTRIBUTING.md`.
+
+NOTION_SEARCH_PATH = '/v1/search'
+VCR_DEFAULT_MATCHERS = ['method', 'scheme', 'host', 'port', 'path', 'query']
+VCR_SEARCH_MATCHER = 'notion_search_body'
+
+
+def _request_json_body(request: Any) -> Any:
+    """Return the parsed JSON body of a VCR request, or the raw body if it is not JSON."""
+    body = request.body
+    if isinstance(body, bytes):
+        try:
+            body = body.decode('utf-8')
+        except UnicodeDecodeError:
+            return body
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return body
+
+
+def match_search_body(r1: Any, r2: Any) -> bool:
+    """Match `POST /v1/search` requests by their JSON body; match everything else unconditionally.
+
+    Combined with the default `path` matcher this adds body matching *only* for the search endpoint,
+    leaving all other endpoints matched exactly as before.
+    """
+    if not (r1.path == NOTION_SEARCH_PATH and r2.path == NOTION_SEARCH_PATH):
+        return True
+    return _request_json_body(r1) == _request_json_body(r2)
+
+
+def register_notion_matchers(vcr: VCR) -> None:
+    """Register Ultimate Notion's custom VCR matchers on a freshly built VCR instance."""
+    vcr.register_matcher(VCR_SEARCH_MATCHER, match_search_body)
+
+
+def pytest_recording_configure(config: pytest.Config, vcr: VCR) -> None:
+    """Register custom matchers on the VCR instance built by pytest-recording (`@pytest.mark.vcr`)."""
+    register_notion_matchers(vcr)
+
 
 def pytest_addoption(parser: Parser) -> None:
     """Add flag to the pytest command line so that we can overwrite fixtures but not always!"""
@@ -199,18 +248,26 @@ def vcr_config() -> dict[str, Any]:
         for secret in secret_params:
             response['headers'].pop(secret, None)
         if 'body' in response and 'string' in response['body']:
+            body = response['body']['string']
             try:
                 # remove secret tokens from body in Google API calls
-                dct = json.loads(response['body']['string'])
+                dct = json.loads(body)
                 for secret in secret_params:
                     if secret in dct:
                         dct[secret] = 'secret...'
-                response['body']['string'] = json.dumps(dct)
+                body = json.dumps(dct)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 pass
+            # Normalise a non-default root page title back to the canonical `Tests` so a recording
+            # made against a differently named root (via `UNO_TEST_ROOT_PAGE`) replays against the
+            # committed cassettes. A no-op for the default `Tests`, so existing cassettes are untouched.
+            if TESTS_PAGE != 'Tests' and isinstance(body, str):
+                body = body.replace(TESTS_PAGE, 'Tests')
+            response['body']['string'] = body
         return response
 
     return {
+        'match_on': [*VCR_DEFAULT_MATCHERS, VCR_SEARCH_MATCHER],
         'filter_headers': [(param, 'secret...') for param in secret_params],
         'filter_query_parameters': secret_params,
         'filter_post_data_parameters': secret_params,
@@ -317,6 +374,7 @@ def vcr_fixture(
                 elif mode is None:
                     mode = 'none'
                 vcr = VCR(record_mode=vcr_mode(mode), **vcr_config)
+                register_notion_matchers(vcr)
 
             return vcr, cassette_name
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -724,6 +724,40 @@ def test_serialize_strips_meta_from_nested_children() -> None:
         assert not any(field in level for field in meta_fields)
 
 
+@pytest.mark.vcr()
+def test_append_nested_children_single_call(root_page: uno.Page, notion: uno.Session) -> None:
+    """Appending a block that already carries nested children must succeed in a single API call.
+
+    Live counterpart to `test_serialize_strips_meta_from_nested_children`. Regression test for
+    https://github.com/ultimate-notion/ultimate-notion/issues/291: read-only meta fields (notably
+    `is_archived`) leaking into nested children made Notion's append-children endpoint reject the
+    whole request with a hard 400. The tree is assembled offline and appended in one
+    `page.append(top)` call, so the entire nesting goes to the append endpoint at once.
+    """
+    page = notion.create_page(parent=root_page, title='Page for appending nested children')
+    top = uno.Callout('top')
+    mid = uno.Callout('mid')
+    inner = uno.Callout('inner')
+    top.append(mid)
+    mid.append(inner)
+
+    page.append(top)
+
+    assert page.children == (top,)
+    assert top.children == (mid,)
+    assert mid.children == (inner,)
+
+    page.reload()
+
+    assert len(page.children) == 1
+    reloaded_top = page.children[0]
+    assert isinstance(reloaded_top, ChildrenMixin)
+    assert len(reloaded_top.children) == 1
+    reloaded_mid = reloaded_top.children[0]
+    assert isinstance(reloaded_mid, ChildrenMixin)
+    assert len(reloaded_mid.children) == 1
+
+
 def test_rt_default_color() -> None:
     para_1 = uno.Paragraph(text='Hello')
     para_2 = uno.Paragraph(text='')


### PR DESCRIPTION
## Description

Adds `test_append_nested_children_single_call`, the live VCR counterpart to the deterministic `test_serialize_strips_meta_from_nested_children`, which appends a block carrying nested children in a single API call and asserts it succeeds. To make future live tests easier to record, cassettes are made more workspace-portable: a custom VCR matcher compares the JSON body of `POST /v1/search` requests only (a no-op for every other endpoint, registered for both pytest-recording and the module-level `vcr_fixture` instances), and a non-default `UNO_TEST_ROOT_PAGE` title is scrubbed back to `Tests` on record. Both changes are no-ops for the existing cassettes, and the full offline suite (`hatch run vcr-only`) replays green. CONTRIBUTING.md documents the add-a-live-test workflow. Fixes #292. See also #291.

### Types of change

Enhancement (test coverage + test infrastructure) and documentation.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.