### PR TITLE
Add changelog entry for is_archived nested-append fix (#291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Omit the read-only `is_archived` field from nested block children when appending a block hierarchy, which previously leaked into the children and was rejected by the Notion API, issue #291.
 - Chg: Validate polymorphic `TypedObject` sub-types and user references on construction, and wrap any resulting Pydantic `ValidationError` with contextual information about the failing type, issue #152.
 
 ## Version 0.9.8, 2026-06-22


### PR DESCRIPTION
## Description

Adds the missing changelog entry for the `is_archived` nested-append fix (issue #291), which was merged but never documented under "Unreleased". This ensures a release accurately reflects the user-facing bug fix that stops the read-only `is_archived` field from leaking into nested block children on append. No code changes — documentation only.

### Types of change

Documentation.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
