### PR TITLE
Support Notion built-in (icon gallery) icons, issue #295

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Accept Notion's built-in (icon gallery) icons, which use the `icon` sub-type with a `name` and `color` and previously broke loading any page/database (and cascaded into `search`/list endpoints) that used one, issue #295.
 - Chg: Validate polymorphic `TypedObject` sub-types and user references on construction, and wrap any resulting Pydantic `ValidationError` with contextual information about the failing type, issue #152.
 
 ## Version 0.9.8, 2026-06-22

--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -37,7 +37,7 @@ from url_normalize import url_normalize
 
 from ultimate_notion.comment import Comment, Discussion
 from ultimate_notion.core import NotionEntity, get_active_session, get_url, is_db, is_page
-from ultimate_notion.emoji import CustomEmoji, Emoji
+from ultimate_notion.emoji import BuiltInIcon, CustomEmoji, Emoji
 from ultimate_notion.errors import InvalidAPIUsageError, UnknownDatabaseError, UnsetError
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
 from ultimate_notion.markdown import md_comment
@@ -75,8 +75,8 @@ DO_co = TypeVar('DO_co', bound=obj_blocks.DataObject, default=obj_blocks.DataObj
 
 
 def wrap_icon(
-    icon_obj: objs.FileObject | objs.EmojiObject | objs.CustomEmojiObject,
-) -> NotionFile | ExternalFile | CustomEmoji | Emoji:
+    icon_obj: objs.FileObject | objs.EmojiObject | objs.CustomEmojiObject | objs.BuiltInIconObject,
+) -> NotionFile | ExternalFile | CustomEmoji | Emoji | BuiltInIcon:
     """Wrap the icon object into the corresponding class."""
     match icon_obj:
         case objs.ExternalFile():
@@ -87,6 +87,8 @@ def wrap_icon(
             return Emoji.wrap_obj_ref(icon_obj)
         case objs.CustomEmojiObject():
             return CustomEmoji.wrap_obj_ref(icon_obj)
+        case objs.BuiltInIconObject():
+            return BuiltInIcon.wrap_obj_ref(icon_obj)
         case _:
             msg = f'unknown icon object of {type(icon_obj)}'
             raise RuntimeError(msg)
@@ -660,7 +662,7 @@ class Callout(ColoredTextBlock[obj_blocks.Callout], ParentBlock[obj_blocks.Callo
         text: str,
         *,
         color: Color | BGColor = Color.DEFAULT,
-        icon: AnyFile | str | Emoji | CustomEmoji = '💡',
+        icon: AnyFile | str | Emoji | CustomEmoji | BuiltInIcon = '💡',
     ) -> None:
         super().__init__(text, color=color)
         if isinstance(icon, str) and not isinstance(icon, Emoji | CustomEmoji):
@@ -677,7 +679,7 @@ class Callout(ColoredTextBlock[obj_blocks.Callout], ParentBlock[obj_blocks.Callo
         return Emoji('💡')
 
     @property
-    def icon(self) -> NotionFile | ExternalFile | Emoji | CustomEmoji:
+    def icon(self) -> NotionFile | ExternalFile | Emoji | CustomEmoji | BuiltInIcon:
         if is_unset(icon := self.obj_ref.value.icon):
             raise UnsetError()
         if icon is None:
@@ -686,7 +688,7 @@ class Callout(ColoredTextBlock[obj_blocks.Callout], ParentBlock[obj_blocks.Callo
             return wrap_icon(icon)
 
     @icon.setter
-    def icon(self, icon: AnyFile | Emoji | CustomEmoji) -> None:
+    def icon(self, icon: AnyFile | Emoji | CustomEmoji | BuiltInIcon) -> None:
         self.obj_ref.value.icon = icon.obj_ref
         self._update_in_notion()
 
@@ -694,7 +696,7 @@ class Callout(ColoredTextBlock[obj_blocks.Callout], ParentBlock[obj_blocks.Callo
         match self.icon:
             case Emoji():
                 return f'{self.icon} {super().to_markdown()}\n'
-            case CustomEmoji():
+            case CustomEmoji() | BuiltInIcon():
                 return f':{self.icon.name}: {super().to_markdown()}\n'
             case AnyFile():
                 return f'![icon]({self.icon.url}) {super().to_markdown()}\n'

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 
 from ultimate_notion.blocks import ChildrenMixin, DataObject, wrap_icon
 from ultimate_notion.core import get_active_session, get_repr
-from ultimate_notion.emoji import CustomEmoji, Emoji
+from ultimate_notion.emoji import BuiltInIcon, CustomEmoji, Emoji
 from ultimate_notion.errors import ReadOnlyPropertyError, SchemaError, UnsetError
 from ultimate_notion.file import AnyFile
 from ultimate_notion.obj_api import blocks as obj_blocks
@@ -87,7 +87,7 @@ class Database(DataObject[obj_blocks.Database], wraps=obj_blocks.Database):
         session.api.databases.update(self.obj_ref, description=text.obj_ref)
 
     @property
-    def icon(self) -> AnyFile | Emoji | CustomEmoji | None:
+    def icon(self) -> AnyFile | Emoji | CustomEmoji | BuiltInIcon | None:
         """Return the icon of this database as file or emoji."""
         if (icon := self.obj_ref.icon) is None:
             return None

--- a/src/ultimate_notion/emoji.py
+++ b/src/ultimate_notion/emoji.py
@@ -95,3 +95,27 @@ class CustomEmoji(EmojiBase[objs.CustomEmojiObject], wraps=objs.CustomEmojiObjec
 
     def __str__(self) -> str:
         return f':{self.name}:'
+
+
+class BuiltInIcon(EmojiBase[objs.BuiltInIconObject], wraps=objs.BuiltInIconObject):
+    """Built-in icon from Notion's icon gallery, identified by a name and color."""
+
+    def __init__(self) -> None:
+        msg = 'To use a built-in icon, pick one from the icon gallery in Notion.'
+        raise InvalidAPIUsageError(msg)
+
+    @property
+    def name(self) -> str:
+        """Return the name of this built-in icon."""
+        return self.obj_ref.icon.name
+
+    @property
+    def color(self) -> str:
+        """Return the color of this built-in icon."""
+        return self.obj_ref.icon.color
+
+    def __repr__(self) -> str:
+        return get_repr(self, desc=self.name)
+
+    def __str__(self) -> str:
+        return f':{self.name}:'

--- a/src/ultimate_notion/obj_api/blocks.py
+++ b/src/ultimate_notion/obj_api/blocks.py
@@ -36,6 +36,7 @@ from ultimate_notion.obj_api.objects import (
     MAX_TEXT_OBJECT_SIZE,
     Annotations,
     BlockRef,
+    BuiltInIconObject,
     CustomEmojiObject,
     EmojiObject,
     FileObject,
@@ -68,7 +69,7 @@ class Database(DataObject, MentionMixin, object='database'):
     title: list[SerializeAsAny[RichTextBaseObject]] | UnsetType = Unset
     url: str | UnsetType = Unset
     public_url: str | None = None
-    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | None = None
+    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | BuiltInIconObject | None = None
     cover: SerializeAsAny[FileObject] | None = None
     properties: dict[str, SerializeAsAny[Property]] = Field(default_factory=dict)
     description: list[SerializeAsAny[RichTextBaseObject]] | UnsetType = Unset
@@ -83,7 +84,7 @@ class Page(DataObject, MentionMixin, object='page'):
 
     url: str | UnsetType = Unset
     public_url: str | None = None
-    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | None = None
+    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | BuiltInIconObject | None = None
     cover: SerializeAsAny[FileObject] | None = None
     properties: dict[str, PropertyValue] = Field(default_factory=dict)
     is_locked: bool | UnsetType = Unset
@@ -239,7 +240,7 @@ class ColoredTextBlock(TextBlock[CTB_co]):
 class ParagraphTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
     """Type data for `Paragraph` block."""
 
-    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | UnsetType | None = Unset
+    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | BuiltInIconObject | UnsetType | None = Unset
 
 
 class Paragraph(ColoredTextBlock[ParagraphTypeData], type='paragraph'):
@@ -313,7 +314,7 @@ class CalloutTypeData(ColoredTextBlockTypeData, WithChildren[Block]):
 
     # `Unset` means the default icon as determined by Notion, and `None` means no icon when retrieved
     #  but is not accepted when sending to Notion.
-    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | UnsetType | None = Unset
+    icon: SerializeAsAny[FileObject] | EmojiObject | CustomEmojiObject | BuiltInIconObject | UnsetType | None = Unset
 
 
 class Callout(ColoredTextBlock[CalloutTypeData], type='callout'):

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -597,6 +597,23 @@ class CustomEmojiObject(MentionBase[CustomEmojiObjectTypeData], MentionMixin, ty
         return self.__class__.build_mention_from(self, style=style)
 
 
+class BuiltInIconTypeData(GenericObject):
+    """Type data for a `BuiltInIconObject`."""
+
+    name: str
+    color: str
+
+
+class BuiltInIconObject(TypedObject[GenericObject], type='icon'):
+    """A Notion built-in icon object.
+
+    These are icons picked from Notion's icon gallery (rather than emojis or
+    custom images) and are identified by a `name` and a `color`.
+    """
+
+    icon: BuiltInIconTypeData
+
+
 class FileObject(TypedObject[GO_co], polymorphic_base=True):
     """A Notion file object.
 

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -10,7 +10,7 @@ from typing_extensions import Self, TypeIs
 from ultimate_notion.blocks import ChildrenMixin, CommentMixin, DataObject, wrap_icon
 from ultimate_notion.comment import Discussion
 from ultimate_notion.core import NotionEntity, WorkspaceType, get_active_session, get_repr
-from ultimate_notion.emoji import CustomEmoji, Emoji
+from ultimate_notion.emoji import BuiltInIcon, CustomEmoji, Emoji
 from ultimate_notion.errors import UnsetError
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile
 from ultimate_notion.markdown import render_md
@@ -220,7 +220,7 @@ class Page(
         session.api.pages.update(self.obj_ref, properties={title_prop_name: title.obj_ref})
 
     @property
-    def icon(self) -> NotionFile | ExternalFile | Emoji | CustomEmoji | None:
+    def icon(self) -> NotionFile | ExternalFile | Emoji | CustomEmoji | BuiltInIcon | None:
         """Icon of the page, i.e. emojis, Notion's icons, or custom images."""
         if (icon := self.obj_ref.icon) is None:
             return None
@@ -228,7 +228,7 @@ class Page(
             return wrap_icon(icon)
 
     @icon.setter
-    def icon(self, icon: AnyFile | Emoji | CustomEmoji | str | None) -> None:
+    def icon(self, icon: AnyFile | Emoji | CustomEmoji | BuiltInIcon | str | None) -> None:
         """Set the icon of this page."""
         if isinstance(icon, str) and not isinstance(icon, Emoji | CustomEmoji):
             icon = Emoji(icon)

--- a/tests/obj_api/test_core.py
+++ b/tests/obj_api/test_core.py
@@ -4,9 +4,9 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from ultimate_notion.obj_api.blocks import Paragraph
+from ultimate_notion.obj_api.blocks import Page, Paragraph
 from ultimate_notion.obj_api.core import extract_id
-from ultimate_notion.obj_api.objects import Bot, Person, User
+from ultimate_notion.obj_api.objects import Bot, BuiltInIconObject, Person, User
 
 
 @pytest.fixture(autouse=True)
@@ -71,6 +71,33 @@ def test_paragraph_accepts_null_icon() -> None:
     )
 
     assert paragraph.paragraph.icon is None
+
+
+def test_page_accepts_built_in_icon() -> None:
+    """A page with a built-in (icon gallery) icon must round-trip, see issue #295.
+
+    The Notion API returns these as `{'type': 'icon', 'icon': {'name': ..., 'color': ...}}`,
+    which previously failed validation and cascaded into search/list endpoints.
+    """
+    page = Page.model_validate(
+        {
+            'object': 'page',
+            'id': '00000000-0000-0000-0000-000000000000',
+            'created_time': '2024-01-01T00:00:00.000Z',
+            'last_edited_time': '2024-01-01T00:00:00.000Z',
+            'archived': False,
+            'in_trash': False,
+            'icon': {'type': 'icon', 'icon': {'name': 'snake', 'color': 'purple'}},
+            'cover': None,
+            'parent': {'type': 'workspace', 'workspace': True},
+            'url': 'https://www.notion.so/00000000000000000000000000000000',
+            'properties': {},
+        }
+    )
+
+    assert isinstance(page.icon, BuiltInIconObject)
+    assert page.icon.icon.name == 'snake'
+    assert page.icon.icon.color == 'purple'
 
 
 def test_block_serialization_omits_read_only_archive_flags() -> None:

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -8,7 +8,8 @@ import pytest
 import ultimate_notion as uno
 from tests.conftest import URL, all_blocks
 from ultimate_notion import blocks as uno_blocks
-from ultimate_notion.blocks import ChildrenMixin
+from ultimate_notion.blocks import ChildrenMixin, wrap_icon
+from ultimate_notion.emoji import BuiltInIcon
 from ultimate_notion.errors import InvalidAPIUsageError
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.blocks import Block as ObjBlock
@@ -1028,3 +1029,30 @@ def test_local_remote_mention_block_cmp(
     assert len(page.children) == 1
     assert page.children[0] == block_child
     assert page.children[0] == another_block_child
+
+
+def test_built_in_icon_wrapper() -> None:
+    """A built-in (icon gallery) icon wraps and renders like an emoji code, see issue #295."""
+    icon_obj = objs.BuiltInIconObject.model_validate({'type': 'icon', 'icon': {'name': 'snake', 'color': 'purple'}})
+
+    icon = wrap_icon(icon_obj)
+    assert isinstance(icon, BuiltInIcon)
+    assert icon.name == 'snake'
+    assert icon.color == 'purple'
+    assert str(icon) == ':snake:'
+    assert icon.to_code == ':snake:'
+
+    # built-in icons cannot be constructed by the user, only retrieved from Notion
+    with pytest.raises(InvalidAPIUsageError):
+        BuiltInIcon()
+
+
+def test_callout_with_built_in_icon_markdown() -> None:
+    """A callout carrying a built-in icon renders its name as an emoji code, see issue #295."""
+    callout = uno_blocks.Callout('Built-in icon callout')
+    callout.obj_ref.value.icon = objs.BuiltInIconObject.model_validate(
+        {'type': 'icon', 'icon': {'name': 'snake', 'color': 'purple'}}
+    )
+
+    assert isinstance(callout.icon, BuiltInIcon)
+    assert callout.to_markdown().strip() == ':snake: Built-in icon callout'


### PR DESCRIPTION
## Description

Fixes #295. Notion's API returns built-in (icon gallery) icons as the `icon` sub-type (`{"type": "icon", "icon": {"name": ..., "color": ...}}`), which was missing from the icon union and broke loading any page/database that used one — cascading into the `search`/list endpoints. This adds a `BuiltInIconObject` model plus a `BuiltInIcon` wrapper and wires them through the icon unions, `wrap_icon()`, the page/database/callout accessors, and callout markdown rendering. New non-VCR unit tests cover parsing the exact failing payload, the wrapper API, and markdown output, so the fix is verified without a live re-record.

### Types of change

Bug fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.