### PR TITLE
Accept undocumented in_trash field on file_upload objects (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: Accept Notion's built-in (icon gallery) icons, which use the `icon` sub-type with a `name` and `color` and previously broke loading any page/database (and cascaded into `search`/list endpoints) that used one, issue #295.
 - Fix: Omit the read-only `is_archived` field from nested block children when appending a block hierarchy, which previously leaked into the children and was rejected by the Notion API, issue #291.
 - Chg: Validate polymorphic `TypedObject` sub-types and user references on construction, and wrap any resulting Pydantic `ValidationError` with contextual information about the failing type, issue #152.
+- Fix: Accept the undocumented `in_trash` field the Notion API sends on `file_upload` objects, which previously broke every file upload in development mode, issue #299.
 
 ## Version 0.9.8, 2026-06-22
 

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -743,6 +743,7 @@ class FileUpload(NotionObject, object='file_upload'):
     complete_url: str | None = None
     file_import_result: FileImportResult | None = None
     archived: bool  # undocumented but sent by the API
+    in_trash: bool  # undocumented but sent by the API
     created_by: User  # undocumented but sent by the API
 
 


### PR DESCRIPTION
## Description

The Notion `file_uploads` API returns an undocumented `in_trash` field on the `file_upload` object that `obj_api.objects.FileUpload` did not declare, which raised a `ValidationError` and broke every file upload on dev builds (where `extra='forbid'`). This adds `in_trash: bool` alongside the existing undocumented `archived`/`created_by` fields. Fixes #299.

### Types of change

Bug fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)