### PR TITLE
Release v0.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.9.9, 2026-06-23
+
 - Fix: Accept Notion's built-in (icon gallery) icons, which use the `icon` sub-type with a `name` and `color` and previously broke loading any page/database (and cascaded into `search`/list endpoints) that used one, issue #295.
 - Fix: Omit the read-only `is_archived` field from nested block children when appending a block hierarchy, which previously leaked into the children and was rejected by the Notion API, issue #291.
 - Chg: Validate polymorphic `TypedObject` sub-types and user references on construction, and wrap any resulting Pydantic `ValidationError` with contextual information about the failing type, issue #152.


### PR DESCRIPTION
Cuts release **v0.9.9**.

Moves the four `Unreleased` CHANGELOG entries under a dated `## Version 0.9.9, 2026-06-23` heading. All entries are fixes/changes (no new features or breaking changes), so this is a patch bump from 0.9.8.

After merge, tag the merge commit `v0.9.9` and push it to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)