### PR TITLE
Split deeply-nested wrap_obj_ref block trees on append, issue #305

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Split deeply-nested block trees reconstructed via `Block.wrap_obj_ref()` from serialized JSON into Notion-compliant requests on `append()`. Children carried in `obj_ref.value.children` (where `has_children` is `False`) were previously left untouched by the chunker and sent in a single over-nested request, which Notion rejected with a 400, issue #305.
+
 ## Version 0.9.9, 2026-06-23
 
 - Fix: Accept Notion's built-in (icon gallery) icons, which use the `icon` sub-type with a `name` and `color` and previously broke loading any page/database (and cascaded into `search`/list endpoints) that used one, issue #295.

--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -440,8 +440,12 @@ class ParentBlock(Block[B_co], ChildrenMixin[B_co], wraps=obj_blocks.Block):
     def _finalize_wrap(self) -> None:
         super()._finalize_wrap()
         value = self.obj_ref.value
-        if self.obj_ref.has_children and isinstance(value, obj_blocks.WithChildren) and value.children:
+        # Children may be carried in `value.children` even when `has_children` is `False`, e.g. when a block tree
+        # is reconstructed via `wrap_obj_ref` from serialized JSON. Pull them into the `_children` cache regardless
+        # so the chunking machinery (which gates on `has_children`/`blocks`) splits deeply-nested trees correctly.
+        if isinstance(value, obj_blocks.WithChildren) and value.children:
             self._children = [Block.wrap_obj_ref(child) for child in value.children]
+            self.obj_ref.has_children = True
             value.children = []  # clear children to avoid confusion during comparison
 
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -917,6 +918,59 @@ def test_deserialized_block_children(root_page: uno.Page, notion: uno.Session) -
 
     # This hits an assertion error
     assert page.children[0] == another_block_child
+
+
+def test_chunk_deeply_nested_wrapped_blocks() -> None:
+    """A tree reconstructed via `wrap_obj_ref` from JSON must still be chunked one level per request.
+
+    Regression test for https://github.com/ultimate-notion/ultimate-notion/issues/305: when a block
+    tree is built via `wrap_obj_ref` from serialized JSON, its children live in `obj_ref.value.children`
+    while `obj_ref.has_children` is `False`. The chunker gates on `has_children`, so without pulling those
+    children into the `_children` cache the whole tree was sent in a single request, and Notion rejects
+    anything nested more than `MAX_NESTING_LEVEL` deep with a 400.
+    """
+
+    def serialize(block: uno.Block) -> dict[str, Any]:
+        data = block.obj_ref.serialize_for_api()
+        block_type = block.obj_ref.type
+        assert block_type is not None
+        if isinstance(block, ChildrenMixin) and block.has_children:
+            data[block_type]['children'] = [serialize(child) for child in block.blocks]
+        return data
+
+    def depth(block_dict: dict[str, Any]) -> int:
+        type_data = block_dict.get(block_dict['type'], {})
+        children = type_data.get('children', []) if isinstance(type_data, dict) else []
+        return 1 + max((depth(child) for child in children), default=0)
+
+    # Callouts nested 4 levels deep: main > [code, output > [note > [body]]]
+    note = uno.Callout('note')
+    note.append(uno.Callout('body'))
+    output = uno.Callout('Output')
+    output.append(note)
+    main = uno.Callout('Example')
+    main.append([uno.Callout('Code'), output])
+
+    # The whole tree starts out 4 levels deep, which Notion rejects in a single request.
+    assert depth(serialize(main)) == 4
+
+    reloaded = uno.Block.wrap_obj_ref(ObjBlock.model_validate(obj=serialize(main)))
+
+    # The children are pulled into the cache and `has_children` is made consistent with them, even though
+    # the serialized JSON reports `has_children == False` on every node.
+    assert reloaded.has_children
+    assert isinstance(reloaded, ChildrenMixin)
+    assert len(reloaded.blocks) == 2
+
+    parent = uno.Callout('Parent')
+    request_depths = []
+    for batch in uno_blocks._chunk_blocks_for_api(parent, [reloaded]):
+        payload = [uno_blocks._build_obj_ref(child) for child in batch.children]
+        request_depths.append([depth(block.obj_ref.serialize_for_api()) for block in payload])
+
+    # No single request nests deeper than the Notion limit of `MAX_NESTING_LEVEL`.
+    assert all(d <= uno_blocks.MAX_NESTING_LEVEL for depths in request_depths for d in depths)
+    assert request_depths == [[1], [1, 1], [1], [1]]
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Description

`page.append()` / `Block.append()` failed to split deeply-nested block trees into Notion-compliant requests when the blocks were built via `Block.wrap_obj_ref()` from serialized JSON, because `ParentBlock._finalize_wrap` only pulled `obj_ref.value.children` into the `_children` cache when `has_children` was already `True` — whereas JSON-reconstructed blocks carry children in `value.children` while reporting `has_children == False`, so the chunker treated them as leaves and sent the whole over-nested tree in one request that Notion rejected with a 400. This PR pulls children into `_children` whenever they are present and sets `has_children` accordingly, so the existing one-level-per-request chunking handles loaded-from-JSON trees. Fixes #305. A new offline regression test (`test_chunk_deeply_nested_wrapped_blocks`) round-trips a 4-level callout tree through `wrap_obj_ref` and asserts the chunker now produces flat per-level requests.

### Types of change

Bug fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)