### PR TITLE
Bump CHANGELOG for v0.9.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.9.10, 2026-06-24
+
 - Fix: Split deeply-nested block trees reconstructed via `Block.wrap_obj_ref()` from serialized JSON into Notion-compliant requests on `append()`. Children carried in `obj_ref.value.children` (where `has_children` is `False`) were previously left untouched by the chunker and sent in a single over-nested request, which Notion rejected with a 400, issue #305.
 
 ## Version 0.9.9, 2026-06-23


### PR DESCRIPTION
## Description

Promotes the pending `Unreleased` CHANGELOG entry (the deeply-nested `wrap_obj_ref` append fix for issue #305) into a versioned `Version 0.9.10, 2026-06-24` heading, leaving a fresh empty `Unreleased` section on top for future entries. This is a documentation-only change in preparation for the next release; the package version itself is derived from git tags via hatch-vcs.

### Types of change

Documentation.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.