### PR TITLE
Use a typed local instead of reassigning the parameter in Block.replace/insert_after

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -368,20 +368,19 @@ class Block(CommentMixin[B_co], ABC, wraps=obj_blocks.Block):
 
     def replace(self, blocks: Block | Sequence[Block]) -> None:
         """Replace this block with another block or blocks."""
-        if not isinstance(blocks, Sequence):
-            blocks = [blocks]
+        block_seq: Sequence[Block] = [blocks] if isinstance(blocks, Block) else blocks
 
         if self.is_deleted:
             msg = 'Cannot replace a deleted block.'
             raise InvalidAPIUsageError(msg)
 
-        for block in blocks:  # do complete sanity check first
+        for block in block_seq:  # do complete sanity check first
             if block.in_notion:
                 msg = f'Cannot replace with a block {block} that is already in Notion.'
                 raise InvalidAPIUsageError(msg)
 
         if self.parent is not None and isinstance(self.parent, ChildrenMixin):
-            for block in reversed(blocks):
+            for block in reversed(block_seq):
                 self.parent.append(block, after=self)
         else:
             msg = 'Cannot replace a block that has no parent.'
@@ -391,20 +390,19 @@ class Block(CommentMixin[B_co], ABC, wraps=obj_blocks.Block):
 
     def insert_after(self, blocks: Block | Sequence[Block]) -> None:
         """Insert a block or several blocks after this block."""
-        if not isinstance(blocks, Sequence):
-            blocks = [blocks]
+        block_seq: Sequence[Block] = [blocks] if isinstance(blocks, Block) else blocks
 
         if self.is_deleted:
             msg = 'Cannot insert a block after a deleted block.'
             raise InvalidAPIUsageError(msg)
 
-        for block in blocks:  # do complete sanity check first
+        for block in block_seq:  # do complete sanity check first
             if block.in_notion:
                 msg = f'Cannot insert block {block} that is already in Notion.'
                 raise InvalidAPIUsageError(msg)
 
         if self.parent is not None and isinstance(self.parent, ChildrenMixin):
-            self.parent.append(blocks, after=self)
+            self.parent.append(block_seq, after=self)
         else:
             msg = 'Cannot insert a block that has no parent.'
             raise InvalidAPIUsageError(msg)


### PR DESCRIPTION
## Description

`Block.replace` and `Block.insert_after` normalized their `blocks: Block | Sequence[Block]` argument by reassigning the parameter to a `list`, which made the variable's type change mid-function. They now introduce a clearly-typed local `block_seq: Sequence[Block] = [blocks] if isinstance(blocks, Block) else blocks` and use it throughout, leaving the parameter untouched with one stable type and a more direct positive `isinstance` check. Fixes #308. There is no runtime change.

### Types of change

Code cleanup / refactor (no runtime behavior change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)