### PR TITLE
Extract mention date/range check into a TypeIs predicate

### DIFF
--- a/src/ultimate_notion/rich_text.py
+++ b/src/ultimate_notion/rich_text.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, TypeGuard
 from urllib.parse import urlparse
 
 import pendulum as pnd
-from typing_extensions import Self, TypeVar
+from typing_extensions import Self, TypeIs, TypeVar
 from url_normalize import url_normalize
 
 from ultimate_notion.core import Wrapper
@@ -106,6 +106,11 @@ def math(
     return Text.wrap_obj_ref([math.obj_ref])
 
 
+def _is_date_or_range(value: object) -> TypeIs[DateTimeOrRange]:
+    """Narrow a mention target to a date/datetime/range."""
+    return isinstance(value, dt.datetime | dt.date | pnd.Interval)
+
+
 class Mention(RichTextBase[objs.MentionObject], wraps=objs.MentionObject):
     """A Mention object.
 
@@ -128,7 +133,7 @@ class Mention(RichTextBase[objs.MentionObject], wraps=objs.MentionObject):
         annotations = objs.Annotations(
             bold=bold, italic=italic, strikethrough=strikethrough, code=code, underline=underline, color=color
         )
-        if isinstance(target, dt.datetime | dt.date | pnd.Interval):
+        if _is_date_or_range(target):
             self.obj_ref = objs.DateRange.build(target).build_mention(style=annotations)
         else:
             self.obj_ref = target.obj_ref.build_mention(style=annotations)


### PR DESCRIPTION
## Description

Extracts the date/range type test in `Mention.__init__` into a small `_is_date_or_range` predicate that returns `TypeIs[DateTimeOrRange]`. This names the intent rather than spelling out the three concrete types inline, and the `TypeIs` narrowing makes the `else` branch's `target.obj_ref` access self-documenting since the false branch is narrowed to the wrapper target types. There is no runtime change. Fixes #307.

### Types of change

Refactoring / code cleanup (no behavior change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
