### PR TITLE
Replace hasattr checks in obj_api.core with type-safe checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build` and a typed `ClassVar` sentinel for the `UnsetType` singleton).
+
 ## Version 0.9.10, 2026-06-24
 
 - Fix: Split deeply-nested block trees reconstructed via `Block.wrap_obj_ref()` from serialized JSON into Notion-compliant requests on `append()`. Children carried in `obj_ref.value.children` (where `has_children` is `False`) were previously left untouched by the chunker and sent in a single over-nested request, which Notion rejected with a 400, issue #305.

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -88,9 +88,11 @@ class UnsetType(BaseModel):
 
     __slots__ = ()
 
+    _instance: ClassVar[UnsetType | None] = None
+
     def __new__(cls, *args: Any, **kwargs: Any) -> UnsetType:
         # Ensure only one instance is created, allowing `is` to work correctly
-        if not hasattr(cls, '_instance'):
+        if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
@@ -349,9 +351,9 @@ class ObjectRef(GenericObject):
             case ParentRef() if isinstance(ref.value, UUID):
                 # ParentRefs are typed objects with a nested UUID
                 return cls.model_construct(id=ref.value)
-            case GenericObject() if hasattr(ref, 'id'):
+            case UniqueObject(id=(UUID() | str()) as obj_id):
                 # Re-compose the ObjectReference from the internal ID
-                return cls.build(ref.id)
+                return cls.build(obj_id)
             case UUID():
                 return cls.model_construct(id=ref)
             case str() if (id_str := extract_id(ref)) is not None:


### PR DESCRIPTION
## Description

Replaces two `hasattr`-based checks in `obj_api/core.py` with real type-safe alternatives. `ObjectRef.build` now uses a structural pattern match on `UniqueObject` (matching `id=(UUID() | str())`) instead of `case GenericObject() if hasattr(ref, 'id')`, so the type checker narrows `id` properly and the recursive call needs no ignore. The `UnsetType` singleton now uses a typed `ClassVar` sentinel (`if cls._instance is None`) instead of `hasattr(cls, '_instance')`. Pure refactor with no behavior change; `mypy` reports no errors in `core.py` and the offline suite passes.

### Types of change

Refactor / code-quality change (no functional change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)