### PR TITLE
Replace duck-typed hasattr with isinstance in get_mime_type

### DIFF
--- a/src/ultimate_notion/file.py
+++ b/src/ultimate_notion/file.py
@@ -267,8 +267,10 @@ def get_mime_type(file: BinaryIO | str | Path) -> str:
 
     if isinstance(file, str):
         mime_type = _get_mime_type(file)
-    elif hasattr(file, 'name') and file.name:  # BinaryIO and Path have 'name' attribute
+    elif isinstance(file, Path):
         mime_type = _get_mime_type(file.name)
+    elif file_name := getattr(file, 'name', None):  # BinaryIO has a 'name' unless it is e.g. a BytesIO
+        mime_type = _get_mime_type(file_name)
     else:
         msg = 'Cannot determine MIME type without filename or file.name attribute.'
         raise ValueError(msg)


### PR DESCRIPTION
## Description

Replaces the duck-typed `hasattr(file, 'name')` check in `get_mime_type` with an explicit `isinstance(file, Path)` check to discriminate `Path` from `BinaryIO` in a type-safe way. The nameless-stream guard (e.g. `io.BytesIO`, which has no `name`) is preserved via `getattr(file, 'name', None)`, matching the existing pattern in `session.py`. Behaviour is unchanged: `str`, `Path`, and named file handles resolve a MIME type, while a nameless stream still raises `ValueError`.

### Types of change

Code cleanup / type-safety refactor; no functional change.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.