### PR TITLE
Replace hasattr checks in test_schema with type-safe attr_name checks

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -272,35 +272,35 @@ def test_add_del_update_prop(notion: uno.Session, root_page: uno.Page) -> None:
     db = notion.create_db(parent=root_page, schema=Schema)
 
     # Delete properties from the schema
-    assert hasattr(db.schema, 'formula')
+    assert 'formula' in [prop.attr_name for prop in db.schema]
     del db.schema['Formula']
     assert 'Formula' not in [prop.name for prop in db.schema]
-    assert not hasattr(db.schema, 'formula')
+    assert 'formula' not in [prop.attr_name for prop in db.schema]
     db.reload()
     assert 'Formula' not in [prop.name for prop in db.schema]
-    assert not hasattr(db.schema, 'formula')
+    assert 'formula' not in [prop.attr_name for prop in db.schema]
 
     db.schema.tags.delete()
     assert 'Tags' not in [prop.name for prop in db.schema]
-    assert not hasattr(db.schema, 'tags')
+    assert 'tags' not in [prop.attr_name for prop in db.schema]
     db.reload()
     assert 'Tags' not in [prop.name for prop in db.schema]
-    assert not hasattr(db.schema, 'tags')
+    assert 'tags' not in [prop.attr_name for prop in db.schema]
 
     # Add properties to the schema
     db.schema['Number'] = uno.PropType.Number(format=uno.NumberFormat.DOLLAR)
     assert 'Number' in [prop.name for prop in db.schema]
-    assert hasattr(db.schema, 'number')
+    assert 'number' in [prop.attr_name for prop in db.schema]
     db.reload()
     assert 'Number' in [prop.name for prop in db.schema]
-    assert hasattr(db.schema, 'number')
+    assert 'number' in [prop.attr_name for prop in db.schema]
 
     db.schema.date = uno.PropType.Date('Date')
     assert 'Date' in [prop.name for prop in db.schema]
-    assert hasattr(db.schema, 'date')
+    assert 'date' in [prop.attr_name for prop in db.schema]
     db.reload()
     assert 'Date' in [prop.name for prop in db.schema]
-    assert hasattr(db.schema, 'date')
+    assert 'date' in [prop.attr_name for prop in db.schema]
 
     class TargetSchema(uno.Schema, db_title='Add/Del/Update Prop-Test'):
         """Target schema as self-reference relations lead to a Notion Internal Server Error 500"""
@@ -312,13 +312,13 @@ def test_add_del_update_prop(notion: uno.Session, root_page: uno.Page) -> None:
     db.schema['Relation'] = uno.PropType.Relation(schema=TargetSchema, two_way_prop='Back Relation')
     assert 'Relation' in [prop.name for prop in db.schema]
     assert 'Back Relation' in [prop.name for prop in target_db.schema]
-    assert hasattr(db.schema, 'relation')
-    assert hasattr(target_db.schema, 'back_relation')
+    assert 'relation' in [prop.attr_name for prop in db.schema]
+    assert 'back_relation' in [prop.attr_name for prop in target_db.schema]
     db.reload()
     assert 'Relation' in [prop.name for prop in db.schema]
     assert 'Back Relation' in [prop.name for prop in target_db.schema]
-    assert hasattr(db.schema, 'relation')
-    assert hasattr(target_db.schema, 'back_relation')
+    assert 'relation' in [prop.attr_name for prop in db.schema]
+    assert 'back_relation' in [prop.attr_name for prop in target_db.schema]
 
     # Update properties in the schema
     with pytest.raises(PropertyError):
@@ -522,9 +522,9 @@ def test_bind_db(notion: uno.Session, root_page: uno.Page) -> None:
     my_tags = db.schema.my_tags
     assert isinstance(my_tags, uno.PropType.MultiSelect)
     assert my_tags.options == options
-    assert not hasattr(db.schema, 'name')
-    assert not hasattr(db.schema, 'cat')
-    assert not hasattr(db.schema, 'tags')
+    assert 'name' not in [prop.attr_name for prop in db.schema]
+    assert 'cat' not in [prop.attr_name for prop in db.schema]
+    assert 'tags' not in [prop.attr_name for prop in db.schema]
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Description

Replaces all 14 `hasattr(db.schema, '<attr>')` checks in `tests/test_schema.py` with type-safe membership checks against the public `Property.attr_name` property (e.g. `'formula' in [prop.attr_name for prop in db.schema]`), mirroring the existing `[prop.name for prop in db.schema]` idiom used alongside them. The old `hasattr` relied on `SchemaType.__getattr__` raising `AttributeError` for unknown attribute names, which is invisible to the type checker; the replacements iterate the typed `Property` objects and are statically verifiable.

### Types of change

Code quality / test refactor — no behavior change.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)