### PR TITLE
Replace hasattr typemap checks with a None-defaulted ClassVar sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build` and a typed `ClassVar` sentinel for the `UnsetType` singleton).
+- Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build`, a typed `ClassVar` sentinel for the `UnsetType` singleton, and a `None`-defaulted `ClassVar` sentinel for the `TypedObject._typemap` registry).
 
 ## Version 0.9.10, 2026-06-24
 

--- a/src/ultimate_notion/obj_api/core.py
+++ b/src/ultimate_notion/obj_api/core.py
@@ -411,7 +411,7 @@ class TypedObject(GenericObject, Generic[TO_co]):
     type: str | None = Field(default=None)
     """`type` is a string that identifies the specific object type, e.g. `heading_1`, `paragraph`, `equation`, ..."""
     _polymorphic_base: ClassVar[bool] = False
-    _typemap: ClassVar[dict[str, builtins.type[TypedObject]]]
+    _typemap: ClassVar[dict[str, builtins.type[TypedObject]] | None] = None
 
     def __init_subclass__(cls, *, type: str | None = None, polymorphic_base: bool = False, **kwargs: Any) -> None:  # noqa: A002
         super().__init_subclass__(**kwargs)
@@ -440,7 +440,7 @@ class TypedObject(GenericObject, Generic[TO_co]):
         # but point to a different object (e.g. the 'date' type may have
         # different implementations depending where it is used in the API)
 
-        if not hasattr(cls, '_typemap'):
+        if cls._typemap is None:
             cls._typemap = {}
 
         if name in cls._typemap:
@@ -469,7 +469,7 @@ class TypedObject(GenericObject, Generic[TO_co]):
             msg = "Invalid 'data' object"
             raise ValueError(msg)
 
-        if not hasattr(cls, '_typemap'):
+        if cls._typemap is None:
             msg = f"Missing '_typemap' in {cls}"
             raise ValueError(msg)
 


### PR DESCRIPTION
## Description

Replaces the two remaining `hasattr(cls, '_typemap')` checks in `obj_api.core` with a type-safe `None`-defaulted `ClassVar` sentinel, continuing the type-safety cleanup begun in #314. `TypedObject._typemap` now defaults to `None` and the guards in `_register_type` and `_resolve_type` check `cls._typemap is None`; the `None` default (rather than `{}`) preserves the existing inheritance-sharing semantics where each polymorphic-base subtree lazily creates and shares one registry dict, while letting mypy narrow the attribute to `dict` after the guards. Verified with mypy `strict` (clean), ruff, and a runtime check confirming polymorphic resolution and shared-typemap inheritance still work.

### Types of change

Change (internal type-safety refactor; no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)