### PR TITLE
Name the RollupTypeData.__eq__ parameter `other` to match the base and siblings

### DIFF
--- a/src/ultimate_notion/obj_api/schema.py
+++ b/src/ultimate_notion/obj_api/schema.py
@@ -323,14 +323,14 @@ class RollupTypeData(GenericObject):
     def validate_enum_field(cls, field: str) -> AggFunc:
         return AggFunc(field)
 
-    def __eq__(self, value: object) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Compare Rollup objects by all attributes except id."""
-        if not isinstance(value, RollupTypeData):
+        if not isinstance(other, RollupTypeData):
             return NotImplemented
         return (
-            self.function == value.function
-            and self.relation_property_name == value.relation_property_name
-            and self.rollup_property_name == value.rollup_property_name
+            self.function == other.function
+            and self.relation_property_name == other.relation_property_name
+            and self.rollup_property_name == other.rollup_property_name
         )
 
 


### PR DESCRIPTION
Closes #317

Renames the `RollupTypeData.__eq__` parameter from `value` to `other`, matching `GenericObject.__eq__` and every other `__eq__` in the codebase. This makes it a clean override (a keyword call like `x.__eq__(other=y)` now works uniformly across the hierarchy).

No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)