### PR TITLE
Bind interval endpoints via a Date sub-pattern in parse_dt_str

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -362,12 +362,12 @@ def parse_dt_str(dt_str: str) -> DateTimeOrRange:
             return set_tz(dt_spec)
         case pnd.Date():
             return dt_spec
-        case pnd.Interval():
+        case pnd.Interval(start=pnd.Date() as raw_start, end=pnd.Date() as raw_end):
             # We extend the interval to the full day if only a date is given
-            start, end = set_tz(dt_spec.start), set_tz(dt_spec.end)
-            if not isinstance(dt_spec.start, pnd.DateTime):
+            start, end = set_tz(raw_start), set_tz(raw_end)
+            if not isinstance(raw_start, pnd.DateTime):
                 start = pnd.datetime(start.year, start.month, start.day, 0, 0, 0)
-            if not isinstance(dt_spec.end, pnd.DateTime):
+            if not isinstance(raw_end, pnd.DateTime):
                 end = pnd.datetime(end.year, end.month, end.day, 23, 59, 59)
             return pnd.Interval(start=start, end=end)
         case _:


### PR DESCRIPTION
## Context

Closes #321.

In `parse_dt_str` (`src/ultimate_notion/utils.py`), the interval arm matched a bare `pnd.Interval()` and then reached into its endpoints. `pnd.Interval` is generic, so a bare pattern does not pin down the element type — `dt_spec.start`/`.end` came out loosely typed and the precondition (endpoints are dates) was only implied.

## Change

Match the endpoints with a sub-pattern and bind them. Since `pnd.DateTime` is a subclass of `pnd.Date`, a single `pnd.Date()` sub-pattern captures both:

```python
case pnd.Interval(start=pnd.Date() as raw_start, end=pnd.Date() as raw_end):
```

- The `case` states its precondition (an interval whose endpoints are dates) instead of leaving it implicit, and the bound `raw_start`/`raw_end` have a concrete type.
- The `isinstance` checks read against the bound names rather than re-deriving `dt_spec.start`/`.end`.

Behaviour is unchanged. Verified: a date-only range still extends to full days (`00:00:00` .. `23:59:59`) and a datetime range is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)