### PR TITLE
Simplify find_indices to use np.asarray instead of a manual array guard

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -152,11 +152,10 @@ def find_indices(
     elements: NDArray[np.int_] | Sequence[Any], total_set: NDArray[np.int_] | Sequence[Any]
 ) -> NDArray[np.int_]:
     """Finds the indices of the elements in the total set."""
-    if not isinstance(total_set, np.ndarray):
-        total_set = np.array(total_set)
-    mask = np.isin(total_set, elements)
+    total_arr = np.asarray(total_set)
+    mask = np.isin(total_arr, elements)
     indices = np.where(mask)[0]
-    lookup = dict(zip(total_set[mask], indices, strict=True))
+    lookup = dict(zip(total_arr[mask], indices, strict=True))
     result = np.array([lookup.get(x) for x in elements])
     return result
 


### PR DESCRIPTION
Closes #323.

## Description

`find_indices` in `src/ultimate_notion/utils.py` converted its `total_set` argument to an array with a manual `isinstance`/`np.array` guard. This replaces that with the idiomatic `np.asarray`, which returns an `ndarray` input unchanged (no copy) and converts sequences otherwise, so behaviour is unchanged on `ndarray`, list, and string-sequence inputs. A fresh local `total_arr` is used instead of rebinding the `total_set` parameter, keeping its declared type intact.

### Types of change

Refactor / cleanup, no behaviour change.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.