### PR TITLE
Raise UnsetError from Bot.workspace_info when workspace name/id is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Raise a clear `UnsetError` from `Bot.workspace_info` when the workspace name or id is unavailable (i.e. for any bot other than the integration's own), instead of an opaque pydantic `ValidationError`, issue #326.
 - Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build`, a typed `ClassVar` sentinel for the `UnsetType` singleton, and a `None`-defaulted `ClassVar` sentinel for the `TypedObject._typemap` registry).
 - Chg: Replace the `hasattr`-based `Property._is_init` check with a `None`-defaulted sentinel for `Wrapper._obj_ref`, so initialization is an explicit `is not None` check that the type checker understands.
 

--- a/src/ultimate_notion/user.py
+++ b/src/ultimate_notion/user.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from typing_extensions import TypeVar
 
 from ultimate_notion.core import Wrapper, get_repr
+from ultimate_notion.errors import UnsetError
 from ultimate_notion.obj_api import objects as objs
 from ultimate_notion.obj_api.core import UserRef
 
@@ -101,8 +102,12 @@ class Bot(User[objs.Bot], wraps=objs.Bot):
     def workspace_info(self) -> WorkSpaceInfo:
         """Return the workspace info of this bot, if available."""
         workspace_id = self.obj_ref.bot.workspace_id
+        workspace_name = self.obj_ref.bot.workspace_name
+        if workspace_id is None or workspace_name is None:
+            msg = "Workspace info is only available for the integration's own bot."
+            raise UnsetError(msg)
         kwargs = self.obj_ref.bot.workspace_limits.model_dump()
-        return WorkSpaceInfo(name=self.obj_ref.bot.workspace_name, workspace_id=workspace_id, **kwargs)
+        return WorkSpaceInfo(name=workspace_name, workspace_id=workspace_id, **kwargs)
 
 
 class UnknownUser(User[objs.User], wraps=UserRef):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,42 @@
+"""Unit tests for users in Notion."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from ultimate_notion.errors import UnsetError
+from ultimate_notion.obj_api import objects as objs
+from ultimate_notion.user import Bot
+
+WORKSPACE_ID = UUID('12345678-1234-1234-1234-1234567890ab')
+BOT_ID = UUID('abcdabcd-1234-1234-1234-1234567890ab')
+
+
+def test_workspace_info_for_own_bot() -> None:
+    bot_data = objs.BotTypeData(
+        workspace_id=WORKSPACE_ID,
+        workspace_name='Test Bot Workspace',
+        workspace_limits=objs.WorkSpaceLimits(max_file_upload_size_in_bytes=42),
+    )
+    bot = Bot.wrap_obj_ref(objs.Bot(id=BOT_ID, bot=bot_data))
+
+    info = bot.workspace_info
+    assert info.name == 'Test Bot Workspace'
+    assert info.workspace_id == WORKSPACE_ID
+    assert info.max_file_upload_size_in_bytes == 42
+
+
+@pytest.mark.parametrize(
+    'bot_data',
+    [
+        objs.BotTypeData(workspace_id=None, workspace_name=None),
+        objs.BotTypeData(workspace_id=WORKSPACE_ID, workspace_name=None),
+        objs.BotTypeData(workspace_id=None, workspace_name='Test Bot Workspace'),
+    ],
+)
+def test_workspace_info_unavailable_raises_unset_error(bot_data: objs.BotTypeData) -> None:
+    bot = Bot.wrap_obj_ref(objs.Bot(id=BOT_ID, bot=bot_data))
+    with pytest.raises(UnsetError):
+        _ = bot.workspace_info


### PR DESCRIPTION
## Description

`Bot.workspace_info` could raise an opaque pydantic `ValidationError` because Notion only populates `workspace_name`/`workspace_id` for the integration's own bot, leaving them `None` for any other bot. This guards those optional fields and raises a clear, typed `UnsetError` instead, adds `tests/test_user.py` covering both the populated and unavailable cases, and notes the change in the changelog. Fixes #326.

### Types of change

Bug fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)