### PR TITLE
Rename PropertyValue.build override params to value for substitutable overrides

### DIFF
--- a/src/ultimate_notion/obj_api/props.py
+++ b/src/ultimate_notion/obj_api/props.py
@@ -55,7 +55,7 @@ class PropertyValue(TypedObject[Any], polymorphic_base=True):
     _is_retrieved: bool = False  # fetched separately as property item from the server
 
     @classmethod
-    def build(cls, value: Any, /) -> Self:
+    def build(cls, value: Any) -> Self:
         """Build the property value from given value, e.g. native Python or nested type.
 
         In practice, this is like calling __init__ with the corresponding keyword.
@@ -103,9 +103,9 @@ class Date(PropertyValue, type='date'):
     date: DateRange | None = None
 
     @classmethod
-    def build(cls, dt_spec: str | DateTimeOrRange, /) -> Self:
+    def build(cls, value: str | DateTimeOrRange) -> Self:
         """Create a new Date from the native values."""
-        obj = cls.model_construct(date=DateRange.build(dt_spec))
+        obj = cls.model_construct(date=DateRange.build(value))
         if not isinstance(obj, cls):
             msg = f'Expected {cls.__name__}, got {type(obj).__name__}'
             raise TypeError(msg)
@@ -210,9 +210,9 @@ class Relation(PropertyValue, type='relation'):
     has_more: bool = False
 
     @classmethod
-    def build(cls, pages: Sequence[Page], /) -> Self:
+    def build(cls, value: Sequence[Page]) -> Self:
         """Return a `Relation` property with the specified pages."""
-        obj = cls.model_construct(relation=[ObjectRef.build(page) for page in pages])
+        obj = cls.model_construct(relation=[ObjectRef.build(page) for page in value])
         if not isinstance(obj, cls):
             msg = f'Expected {cls.__name__}, got {type(obj).__name__}'
             raise TypeError(msg)
@@ -350,8 +350,8 @@ class Place(PropertyValue, type='place'):
     place: TypeData | None = None
 
     @classmethod
-    def build(cls, place: PlaceDict | None, /) -> Self:
-        place_obj = cls.TypeData(**place) if place is not None else None
+    def build(cls, value: PlaceDict | None) -> Self:
+        place_obj = cls.TypeData(**value) if value is not None else None
         obj = cls.model_construct(place=place_obj)
         if not isinstance(obj, cls):
             msg = f'Expected {cls.__name__}, got {type(obj).__name__}'

--- a/src/ultimate_notion/obj_api/props.py
+++ b/src/ultimate_notion/obj_api/props.py
@@ -55,7 +55,7 @@ class PropertyValue(TypedObject[Any], polymorphic_base=True):
     _is_retrieved: bool = False  # fetched separately as property item from the server
 
     @classmethod
-    def build(cls, value: Any) -> Self:
+    def build(cls, value: Any, /) -> Self:
         """Build the property value from given value, e.g. native Python or nested type.
 
         In practice, this is like calling __init__ with the corresponding keyword.
@@ -103,7 +103,7 @@ class Date(PropertyValue, type='date'):
     date: DateRange | None = None
 
     @classmethod
-    def build(cls, dt_spec: str | DateTimeOrRange) -> Self:
+    def build(cls, dt_spec: str | DateTimeOrRange, /) -> Self:
         """Create a new Date from the native values."""
         obj = cls.model_construct(date=DateRange.build(dt_spec))
         if not isinstance(obj, cls):
@@ -210,7 +210,7 @@ class Relation(PropertyValue, type='relation'):
     has_more: bool = False
 
     @classmethod
-    def build(cls, pages: Sequence[Page]) -> Self:
+    def build(cls, pages: Sequence[Page], /) -> Self:
         """Return a `Relation` property with the specified pages."""
         obj = cls.model_construct(relation=[ObjectRef.build(page) for page in pages])
         if not isinstance(obj, cls):
@@ -350,7 +350,7 @@ class Place(PropertyValue, type='place'):
     place: TypeData | None = None
 
     @classmethod
-    def build(cls, place: PlaceDict | None) -> Self:
+    def build(cls, place: PlaceDict | None, /) -> Self:
         place_obj = cls.TypeData(**place) if place is not None else None
         obj = cls.model_construct(place=place_obj)
         if not isinstance(obj, cls):


### PR DESCRIPTION
## Description

The base `PropertyValue.build` accepts its argument as `value`, while the `Date`, `Relation`, and `Place` overrides renamed it (`dt_spec`, `pages`, `place`), so a keyword call like `PropertyValue.build(value=...)` would fail on those subclasses, making the overrides non-substitutable. This renames the overrides' parameter to `value` to match the base, restoring substitutability without changing any call site (all callers pass the argument positionally). Closes #327.

### Types of change

Bug fix (type-substitutability / Liskov correctness).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
