### PR TITLE
Skip two-way relation backward rename when no backward name is defined (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Skip the two-way relation backward rename in `Relation._update_bwd_rel` when no backward name is defined, instead of attempting `RenameProp(name=None)` and raising a pydantic `ValidationError`, issue #325.
 - Fix: Raise a clear `UnsetError` from `Bot.workspace_info` when the workspace name or id is unavailable (i.e. for any bot other than the integration's own), instead of an opaque pydantic `ValidationError`, issue #326.
 - Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build`, a typed `ClassVar` sentinel for the `UnsetType` singleton, and a `None`-defaulted `ClassVar` sentinel for the `TypedObject._typemap` registry).
 - Chg: Replace the `hasattr`-based `Property._is_init` check with a `None`-defaulted sentinel for `Wrapper._obj_ref`, so initialization is an explicit `is not None` check that the type checker understands.

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -615,7 +615,7 @@ class Relation(Property[obj_schema.Relation], wraps=obj_schema.Relation):
         obj_synced_property_name = self.obj_ref.relation.dual_property.synced_property_name
         two_way_prop_name = self.two_way_prop.name if self.two_way_prop else None
 
-        if obj_synced_property_name != two_way_prop_name:
+        if two_way_prop_name is not None and obj_synced_property_name != two_way_prop_name:
             session = get_active_session()
 
             # change the old default name in the target schema to what was passed during initialization


### PR DESCRIPTION
## Description

Fixes #325. `Relation._update_bwd_rel` could attempt to rename a two-way backward-relation target to `None` (calling `RenameProp(name=None)`), which raised a pydantic `ValidationError`. When a dual relation carries no defined backward name there is nothing to rename to, so the rename is now skipped by guarding the condition on `two_way_prop_name is not None` (which also narrows the value to `str` for the `RenameProp` construction).

### Types of change

Bug fix.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
