### PR TITLE
Parametrize Heading's ParentBlock base with HT so both bases resolve to Block[HT]

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -585,7 +585,7 @@ class Paragraph(ColoredTextBlock[obj_blocks.Paragraph], ParentBlock[obj_blocks.P
 HT = TypeVar('HT', bound=obj_blocks.Heading)
 
 
-class Heading(ColoredTextBlock[HT], ParentBlock[obj_blocks.Heading], wraps=obj_blocks.Heading):
+class Heading(ColoredTextBlock[HT], ParentBlock[HT], wraps=obj_blocks.Heading):
     """Abstract Heading block.
 
     Parent class of all heading block types.


### PR DESCRIPTION
Fixes #330.

## Summary

`Heading` is generic in `HT` (the concrete heading obj type supplied by `Heading1`/`Heading2`/`Heading3`). Inheriting `ColoredTextBlock[HT]` resolved the shared `Block` base to `Block[HT]`, while `ParentBlock[obj_blocks.Heading]` resolved the same base to `Block[obj_blocks.Heading]` — the two inheritance paths disagreed on `Block`'s type argument.

This parametrizes the `ParentBlock` base with the same `HT` so both paths resolve to `Block[HT]`. `HT` is bound to `obj_blocks.Heading`, which satisfies `ParentBlock`'s own bound (`obj_blocks.Block`), so this is valid. Subscripting a generic base does not affect the runtime MRO, so this is a typing-only change with no behaviour difference.

## Testing

- `hatch run vcr-only tests/test_blocks.py` — 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)