### PR TITLE
Build to_pydantic_model fields with (type, FieldInfo) tuples instead of Annotated runtime values

### DIFF
--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -25,7 +25,7 @@ from collections import Counter
 from collections.abc import Iterator
 from copy import deepcopy
 from functools import partial
-from typing import TYPE_CHECKING, Annotated, Any, TypeAlias, cast, overload
+from typing import TYPE_CHECKING, Any, TypeAlias, cast, overload
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, create_model, field_validator
 from tabulate import tabulate
@@ -1069,8 +1069,7 @@ class Schema(metaclass=SchemaType):
             return py_type if isinstance(py_type, PropertyValue) else prop_value(py_type)
 
         kwargs: dict[str, Any] = {
-            prop.attr_name: Annotated[prop.prop_value, Field(default=None, alias=prop.name)]
-            for prop in cls.get_rw_props()
+            prop.attr_name: (prop.prop_value, Field(default=None, alias=prop.name)) for prop in cls.get_rw_props()
         }
         validators: dict[str, Any] = {
             f'{prop.attr_name}_validator': field_validator(prop.attr_name, mode='before')(
@@ -1080,9 +1079,7 @@ class Schema(metaclass=SchemaType):
         }
 
         if with_ro_props:
-            kwargs |= {
-                prop.attr_name: Annotated[prop.prop_value, Field(alias=prop.name)] for prop in cls.get_ro_props()
-            }
+            kwargs |= {prop.attr_name: (prop.prop_value, Field(alias=prop.name)) for prop in cls.get_ro_props()}
             validators |= {
                 f'{prop.attr_name}_validator': field_validator(prop.attr_name, mode='before')(
                     partial(pytype_to_prop_value, prop_value=prop.prop_value)


### PR DESCRIPTION
## Description

`Schema.to_pydantic_model` built dynamic field definitions for `create_model` using `Annotated[prop.prop_value, Field(...)]`, where `prop.prop_value` is a `type[PropertyValue]` produced at runtime — placing a plain runtime value where a type expression is expected. This switches to `create_model`'s equivalent `(annotation, FieldInfo)` tuple form, which keeps the runtime type in value position while preserving aliases and the `default=None` behaviour, and drops the now-unused `Annotated` import. Fixes #333.

### Types of change

Code cleanup / refactor (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
