### PR TITLE
Make test_to_pendulum's type: ignore specific with [arg-type]

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,7 +134,7 @@ def test_to_pendulum(tz_berlin: str) -> None:
     assert datetime == pnd.datetime(2021, 1, 1, 10, 0, 0, tz='UTC')
 
     with pytest.raises(TypeError):
-        utils.to_pendulum(pnd.duration(days=21))  # type: ignore
+        utils.to_pendulum(pnd.duration(days=21))  # type: ignore[arg-type]
 
 
 def test_flatten() -> None:


### PR DESCRIPTION
## Description

Replaces the bare `# type: ignore` in `test_to_pendulum` with the specific `# type: ignore[arg-type]`, so the suppression only silences the intended argument-type mismatch (passing a `Duration` to `to_pendulum`, whose parameter is `str | DateTimeOrRange`). Verified with the project's `hatch run lint:typing` that mypy reports no `unused-ignore`, confirming `arg-type` is the correct code.

### Types of change

Code quality / maintenance.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.