### PR TITLE
Replace hasattr with type-safe checks in utils

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -206,9 +206,9 @@ def deepcopy_with_sharing(obj: T, shared_attributes: Sequence[str], memo: dict[i
     """
     shared_attrs = {k: getattr(obj, k) for k in shared_attributes}
 
-    if hasattr(obj, '__deepcopy__'):
+    deepcopy_method = getattr(obj, '__deepcopy__', None)
+    if deepcopy_method is not None:
         # Do hack to prevent infinite recursion in call to deepcopy
-        deepcopy_method = obj.__deepcopy__
         obj.__dict__['__deepcopy__'] = None
 
     for attr in shared_attributes:
@@ -220,7 +220,7 @@ def deepcopy_with_sharing(obj: T, shared_attributes: Sequence[str], memo: dict[i
         setattr(obj, attr, val)
         setattr(clone, attr, val)
 
-    if hasattr(obj, '__deepcopy__'):
+    if deepcopy_method is not None:
         # Undo hack
         obj.__dict__['__deepcopy__'] = deepcopy_method
         del clone.__dict__['__deepcopy__']
@@ -446,7 +446,7 @@ def set_attr_none(
                 raise AttributeError(msg)
 
         last_attr = attrs[-1]
-        if hasattr(curr_obj, last_attr):
+        if isinstance(curr_obj, BaseModel) and last_attr in type(curr_obj).model_fields:
             setattr(curr_obj, last_attr, None)
         elif not missing_ok:
             msg = f'{last_attr} does not exist in {".".join(attrs[:-2]) if len(attrs) > 1 else "the object"}.'


### PR DESCRIPTION
## Description

Replaces uses of `hasattr` in `utils.py` with real type-safe checks. In `set_attr_none`, the field is now nulled only when `curr_obj` is a pydantic `BaseModel` and `last_attr` is a declared field (`last_attr in type(curr_obj).model_fields`), rather than duck-typing with `hasattr` — which also matched methods/properties and could trigger property getters as a side effect. In `deepcopy_with_sharing`, the two coupled `hasattr(obj, '__deepcopy__')` checks are consolidated into a single `getattr(obj, '__deepcopy__', None)` capture, making the recursion-guard hack rely on one source of truth instead of two separate introspections that only stayed in sync by coincidence.

### Types of change

Code cleanup / type-safety improvement (no behavior change for the intended call sites).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.