### PR TITLE
Inline deepcopy_with_sharing into View.clone

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -9,7 +9,6 @@ import textwrap
 import types
 from collections.abc import Callable, Generator, Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from copy import deepcopy
 from functools import update_wrapper
 from hashlib import sha256
 from itertools import chain
@@ -166,66 +165,6 @@ def find_index(elem: Any, lst: list[Any]) -> int | None:
         return lst.index(elem)
     except ValueError:
         return None
-
-
-def deepcopy_with_sharing(obj: T, shared_attributes: Sequence[str], memo: dict[int, Any] | None = None) -> T:
-    """Like `deepcopy` but specified attributes are shared.
-
-    Deepcopy an object, except for a given list of attributes, which should
-    be shared between the original object and its copy.
-
-    Args:
-        obj: some object to copy
-        shared_attributes: A list of strings identifying the attributes that should be shared instead of copied.
-        memo: dictionary passed into __deepcopy__. Ignore this argument if not calling from within __deepcopy__.
-
-    Example:
-        ```python
-        class A(object):
-            def __init__(self):
-                self.copy_me = []
-                self.share_me = []
-
-            def __deepcopy__(self, memo):
-                return deepcopy_with_sharing(
-                    self, shared_attribute_names=['share_me'], memo=memo
-                )
-
-
-        a = A()
-        b = deepcopy(a)
-        assert a.copy_me is not b.copy_me
-        assert a.share_me is b.share_me
-
-        c = deepcopy(b)
-        assert c.copy_me is not b.copy_me
-        assert c.share_me is b.share_me
-        ```
-
-    Original from https://stackoverflow.com/a/24621200
-    """
-    shared_attrs = {k: getattr(obj, k) for k in shared_attributes}
-
-    if hasattr(obj, '__deepcopy__'):
-        # Do hack to prevent infinite recursion in call to deepcopy
-        deepcopy_method = obj.__deepcopy__
-        obj.__dict__['__deepcopy__'] = None
-
-    for attr in shared_attributes:
-        del obj.__dict__[attr]
-
-    clone = deepcopy(obj, memo)
-
-    for attr, val in shared_attrs.items():
-        setattr(obj, attr, val)
-        setattr(clone, attr, val)
-
-    if hasattr(obj, '__deepcopy__'):
-        # Undo hack
-        obj.__dict__['__deepcopy__'] = deepcopy_method
-        del clone.__dict__['__deepcopy__']
-
-    return clone
 
 
 KT = TypeVar('KT')  # ToDo: Use new syntax when requires-python >= 3.12

--- a/src/ultimate_notion/view.py
+++ b/src/ultimate_notion/view.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Callable, Iterator, Sequence
+from copy import deepcopy
 from html import escape as htmlescape
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
@@ -22,7 +23,6 @@ from ultimate_notion.schema import Property
 from ultimate_notion.user import User
 from ultimate_notion.utils import (
     SList,
-    deepcopy_with_sharing,
     display_html,
     find_index,
     find_indices,
@@ -65,8 +65,9 @@ class View(Sequence[Page]):
         return self
 
     def clone(self) -> View:
-        """Clone the current view."""
-        return deepcopy_with_sharing(self, shared_attributes=['database', '_pages', '_query'])
+        """Clone the current view, sharing the database, pages and query with the copy."""
+        memo = {id(obj): obj for obj in (self.database, self._pages, self._query)}
+        return deepcopy(self, memo)
 
     def _get_columns(self, title_col: str) -> NDArray[Any]:
         """Make sure title column is the first columns."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,18 +37,6 @@ def test_slist() -> None:
         lst.item()
 
 
-def test_deepcopy_with_sharing() -> None:
-    class Class:
-        def __init__(self) -> None:
-            self.shared = {'a': 1}
-            self.copied = {'a': 2}
-
-    obj = Class()
-    copy = utils.deepcopy_with_sharing(obj, shared_attributes=['shared'])
-    assert obj.copied is not copy.copied
-    assert obj.shared is copy.shared
-
-
 def test_find_index() -> None:
     test_set = [2, 4, 72, 23]
     assert utils.find_index(4, test_set) == 1


### PR DESCRIPTION
## Description

`deepcopy_with_sharing` was a generic StackOverflow-derived utility called from exactly one place, `View.clone`, and carried a `__deepcopy__`-swapping hack to guard against infinite recursion that the sole caller never exercised (neither `View` nor its bases define `__deepcopy__`). This inlines a memo-seeded `deepcopy` into `View.clone` — pre-populating the memo with the shared objects yields identical sharing semantics (`database`, `_pages` and `_query` are shared with the copy while view-specific state is deep-copied) and removes the utility plus its unit test.

### Types of change

Refactor / simplification (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)