### PR TITLE
Encode the block-only-children invariant in _Node's type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Raise a clear `UnsetError` from `Bot.workspace_info` when the workspace name or id is unavailable (i.e. for any bot other than the integration's own), instead of an opaque pydantic `ValidationError`, issue #326.
 - Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build`, a typed `ClassVar` sentinel for the `UnsetType` singleton, and a `None`-defaulted `ClassVar` sentinel for the `TypedObject._typemap` registry).
 - Chg: Replace the `hasattr`-based `Property._is_init` check with a `None`-defaulted sentinel for `Wrapper._obj_ref`, so initialization is an explicit `is not None` check that the type checker understands.
+- Chg: Make `_Node` generic in its wrapped type and pin `children` to `list[_Node[Block]]`, encoding the invariant that only a root node wraps a `Page` while every child wraps a `Block`, so building child obj_refs no longer needs to launder the element type, issue #339.
 
 ## Version 0.9.10, 2026-06-24
 

--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -28,7 +28,7 @@ from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeGuard, overload
+from typing import TYPE_CHECKING, Any, Generic, TypeGuard, overload
 
 import numpy as np
 from tabulate import tabulate
@@ -1561,13 +1561,19 @@ class Unsupported(Block[obj_blocks.UnsupportedBlock], wraps=obj_blocks.Unsupport
         return '<kbd>Unsupported block</kbd>\n'
 
 
-@dataclass
-class _Node:
-    """Tree of nodes used to chunk blocks for the Notion API."""
+NB_co = TypeVar('NB_co', bound='Block | Page', default='Block | Page', covariant=True)
 
-    block: Block | Page
+
+@dataclass(frozen=True)
+class _Node(Generic[NB_co]):
+    """Tree of nodes used to chunk blocks for the Notion API.
+
+    Only a root node wraps a `Page`; every node held in `children` wraps a `Block`.
+    """
+
+    block: NB_co
     is_root: bool = False
-    children: list[_Node] = field(default_factory=list)
+    children: list[_Node[Block]] = field(default_factory=list)
 
 
 def _chunk_blocks_for_api(parent: Block | Page, blocks: Sequence[Block]) -> Iterator[_Node]:
@@ -1615,13 +1621,10 @@ def _chunk_blocks_for_api(parent: Block | Page, blocks: Sequence[Block]) -> Iter
         yield batch
 
 
-def _build_obj_ref(node: _Node) -> Block:
+def _build_obj_ref(node: _Node[Block]) -> Block:
     """Recursively build the obj_ref of a block and its children."""
     block = node.block
     children = node.children
-    if not isinstance(block, Block):
-        msg = f'Non-block type {type(block)} not allowed on this level of the hierarchy.'
-        raise TypeError(msg)
     value = block.obj_ref.value
     if isinstance(block, ParentBlock) and block.has_children and isinstance(value, obj_blocks.WithChildren):
         for child in node.children:


### PR DESCRIPTION
## Description

`_Node` typed its `block` field as `Block | Page` for every node even though only a root node ever wraps a `Page`, so `child.block` was `Block | Page` everywhere and collecting child obj_refs produced a `list[Block | Page]` that did not assign to the invariant `list[Block]` children field. This makes `_Node` generic in its wrapped type with `children` pinned to `list[_Node[Block]]`, so the invariant is expressed once: building child obj_refs is now a `list[Block]` with no element-type laundering, and the now-dead `isinstance` guard in `_build_obj_ref` is removed. Covariance of the type variable requires a read-only wrapped field, hence `@dataclass(frozen=True)` — safe because `block`, `is_root` and `children` are never reassigned (the children list is only mutated in place). Existing block and append tests continue to pass. Fixes #339.

### Types of change

Type-safety change (no runtime behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)