### PR TITLE
Remove dead code: CLIError, two unused helpers, redundant import

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -172,11 +172,6 @@ class ChildrenMixin(DataObject[DO_co], wraps=obj_blocks.DataObject):
 
     _children: list[Block | Page | Database] | None = None
 
-    @property
-    def _has_children_field(self) -> bool:
-        """Return whether the object has a `children` field."""
-        return isinstance(self.obj_ref, obj_blocks.Block) and isinstance(self.obj_ref.value, obj_blocks.WithChildren)
-
     def _gen_children_cache(self) -> list[Block | Page | Database]:
         """Generate the children cache."""
         if self.is_deleted:

--- a/src/ultimate_notion/errors.py
+++ b/src/ultimate_notion/errors.py
@@ -86,11 +86,3 @@ class ReadOnlyPropertyError(SchemaError):
 
 class PropertyError(SchemaError):
     """Raised when there is an issue with a property in the schema."""
-
-
-class CLIError(UltimateNotionError):
-    """Raised for CLI-specific errors that should show clean messages without traceback."""
-
-    def __init__(self, message: str, original_exception: Exception | None = None):
-        self.original_exception = original_exception
-        super().__init__(message)

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -55,7 +55,6 @@ from ultimate_notion.utils import SList, dict_diff_str, display_html, is_noteboo
 
 if TYPE_CHECKING:
     from ultimate_notion.database import Database
-    from ultimate_notion.obj_api.core import UnsetType
     from ultimate_notion.page import Page
 
 T = TypeVar('T')
@@ -1206,14 +1205,6 @@ class Schema(metaclass=SchemaType):
 
         db.schema = cls
         cls._bind_db(db)
-
-    @classmethod
-    def _get_fwd_rels(cls) -> list[Relation]:
-        return [
-            prop
-            for prop in cls.get_props()
-            if isinstance(prop, Relation) and not (prop._is_two_way_target or prop.is_self_ref)
-        ]
 
     @classmethod
     def _get_self_refs(cls) -> list[Relation]:


### PR DESCRIPTION
## Description

Removes dead code found following the `utils.py` cleanup (#343), this time looking beyond `vulture` (whose flags here are dominated by false positives — Pydantic validators, dynamic type-dispatch models, and the public adapter API). Removed the never-used `CLIError` exception, the unreferenced `Schema._get_fwd_rels` classmethod, and the `ChildrenMixin._has_children_field` property (its logic is already inlined in `_gen_children_cache`), plus a redundant `TYPE_CHECKING` re-import of `UnsetType` in `schema.py`. Each removed symbol had zero references across `src`, `tests`, and `docs`; the package imports and the test suite collects cleanly afterwards.

### Types of change

Code cleanup (dead code removal); no behaviour change.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)