### PR TITLE
Read runtime-added Number prop via indexing + isinstance (#336)

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -334,9 +334,13 @@ def test_add_del_update_prop(notion: uno.Session, root_page: uno.Page) -> None:
     assert formula.formula.startswith('{{notion:block_property:title:')
 
     db.schema.number = uno.PropType.Number(format=uno.NumberFormat.PERCENT)
-    assert db.schema.number.format == uno.NumberFormat.PERCENT
+    number = db.schema['Number']
+    assert isinstance(number, uno.PropType.Number)
+    assert number.format == uno.NumberFormat.PERCENT
     db.reload()
-    assert db.schema.number.format == uno.NumberFormat.PERCENT
+    number = db.schema['Number']
+    assert isinstance(number, uno.PropType.Number)
+    assert number.format == uno.NumberFormat.PERCENT
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Summary

Fixes #336.

In `tests/test_schema.py::test_add_del_update_prop`, the format assertions read a `Number` property that was added to the schema at runtime via attribute access (`db.schema.number`). Since `number` is not declared on the schema class, that path resolves only through the metaclass's dynamic attribute lookup, which returns the base `Property` type — so reading `.format` off it is not statically resolvable.

This reads the property back through `db.schema['Number']` and narrows it with `isinstance`, matching the established pattern already used a few lines above for the `Formula` property. The assertions are unchanged.

## Testing

- `test_add_del_update_prop` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)