### PR TITLE
Validate raw BotTypeData payload with model_validate (#341)

### DIFF
--- a/tests/obj_api/test_objects.py
+++ b/tests/obj_api/test_objects.py
@@ -77,12 +77,12 @@ def test_bot_type_data(person: uno.User) -> None:
     user_mention = objs.MentionUser(user=person.obj_ref).model_dump()
 
     for owner in (workspace, user_mention):
-        kwargs = {
+        raw_bot_data = {
             'workspace_id': '12345678-1234-1234-1234-1234567890ab',
             'owner': owner,
             'workspace_name': 'Test Bot Workspace',
             # no workspace_limit for this test
         }
-        bot_data = objs.BotTypeData(**kwargs)
+        bot_data = objs.BotTypeData.model_validate(raw_bot_data)
         assert bot_data.owner is not None
         assert bot_data.owner.model_dump() == owner


### PR DESCRIPTION
## Description

`test_bot_type_data` built a raw API-shaped payload and constructed the model by unpacking it as `**kwargs`, which read as if the dict entries were typed constructor parameters. This validates the payload with `BotTypeData.model_validate` and renames the variable to `raw_bot_data`, mirroring the real parse path the obj-API uses for raw Notion responses (string → `UUID`, dict → the `owner` union). The test continues to pass for both the workspace and user-mention owners. Fixes #341.

### Types of change

Refactor / test cleanup.

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.