### PR TITLE
Re-record shared fixture cassettes live on vcr-rewrite (#351)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,8 +570,11 @@ def vcr_fixture(
             else:
                 mode = request.config.getoption('--record-mode')
                 if mode == 'rewrite':
-                    # This avoids rewriting the fixture cassettes every time we rewrite for a new test!
-                    mode = 'new_episodes'
+                    # Re-record the shared fixture cassettes live (with real ids) on every rewrite.
+                    # Replaying them (e.g. via `new_episodes`) would feed back the workspace-portable
+                    # placeholder ids written by the normalisation, 404ing later modules in a full-suite
+                    # re-record. Deterministic fixtures (e.g. `search('Tests')`) re-record identically.
+                    mode = 'all'
                 elif mode is None:
                     mode = 'none'
                 vcr = VCR(record_mode=vcr_mode(mode), **vcr_config)


### PR DESCRIPTION
Fixes #351.

## Problem

`vcr_fixture` in `tests/conftest.py` downgraded record-mode `rewrite` to `new_episodes`. In a full-suite `vcr-rewrite`, the first module records the shared module-fixture cassettes (`tests/cassettes/fixtures/mod_*.yaml`), which the workspace-portable normalisation rewrites to placeholder ids. Every later module then *replays* those normalised fixture cassettes (`new_episodes` replays existing interactions), so the code receives placeholder ids and 404s on its live calls (~66 failures in an 8-module run).

## Fix

Use `all` mode on rewrite, so each module re-records the shared fixtures **live** (real ids) instead of replaying the normalised ones. Deterministic fixtures (e.g. the `search('Tests')` used by `root_page`) re-record identically, so the shared cassettes stay consistent across modules.

## Trade-off

`new_episodes` was a deliberate optimisation so a single-test rewrite (`vcr-rewrite -k foo`) skipped re-recording the shared fixtures. With `all`, every rewrite re-records them live (~30s of extra searches for a single-test rewrite). This PR takes the simplest option — unconditional `all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)