### PR TITLE
Export BuiltInIcon and CustomEmoji from the top-level package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New: Export the user-facing icon subtypes `BuiltInIcon` and `CustomEmoji` from the top-level package, alongside the already-exported `Emoji`, so icons returned by `Page.icon`/`DataSource.icon`/`Database.icon` can be narrowed with `isinstance` without reaching into `ultimate_notion.emoji`, issue #353.
 - Fix: Skip the two-way relation backward rename in `Relation._update_bwd_rel` when no backward name is defined, instead of attempting `RenameProp(name=None)` and raising a pydantic `ValidationError`, issue #325.
 - Fix: Raise a clear `UnsetError` from `Bot.workspace_info` when the workspace name or id is unavailable (i.e. for any bot other than the integration's own), instead of an opaque pydantic `ValidationError`, issue #326.
 - Chg: Replace `hasattr`-based checks in `obj_api.core` with type-safe alternatives (a structural pattern match on `UniqueObject` in `ObjectRef.build`, a typed `ClassVar` sentinel for the `UnsetType` singleton, and a `None`-defaulted `ClassVar` sentinel for the `TypedObject._typemap` registry).

--- a/src/ultimate_notion/__init__.py
+++ b/src/ultimate_notion/__init__.py
@@ -48,7 +48,7 @@ from ultimate_notion.blocks import (
 )
 from ultimate_notion.core import Workspace, WorkspaceType, get_active_session
 from ultimate_notion.database import Database
-from ultimate_notion.emoji import Emoji
+from ultimate_notion.emoji import BuiltInIcon, CustomEmoji, Emoji
 from ultimate_notion.file import AnyFile, ExternalFile, NotionFile, url
 from ultimate_notion.obj_api.enums import (
     AggFunc,
@@ -79,6 +79,7 @@ __all__ = [
     'Block',  # for type hinting only
     'Bookmark',
     'Breadcrumb',
+    'BuiltInIcon',
     'BulletedItem',
     'Callout',
     'Code',
@@ -87,6 +88,7 @@ __all__ = [
     'Column',
     'Columns',
     'Condition',  # for type hinting only
+    'CustomEmoji',
     'Database',
     'DateTimeOrRange',  # for type hinting only
     'Divider',


### PR DESCRIPTION
Closes #353.

## Problem

`Page.icon` / `DataSource.icon` / `Database.icon` return `NotionFile | ExternalFile | Emoji | CustomEmoji | BuiltInIcon | None`, but of the three `EmojiBase` subtypes only `Emoji` was exported from the top-level package. Users couldn't write `isinstance(icon, uno.BuiltInIcon)` / `uno.CustomEmoji` without reaching into `ultimate_notion.emoji` directly, even though the sibling `uno.Emoji` (and `uno.ExternalFile` / `uno.NotionFile` / `uno.AnyFile`) are all exported.

## Change

- Import `BuiltInIcon` and `CustomEmoji` alongside `Emoji` in `__init__.py`.
- Add both to `__all__`.
- Changelog entry.

Safe: both are public `EmojiBase` wrapper classes with the same base/shape as the already-exported `Emoji`; `emoji.py` was already imported by `__init__.py`, so there is no new import cycle or name collision. Independent of the data-source migration — this is a small standalone change on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)