### PR TITLE
Cut Version 0.9.11 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.9.11, 2026-06-24
+
 - New: Export the user-facing icon subtypes `BuiltInIcon` and `CustomEmoji` from the top-level package, alongside the already-exported `Emoji`, so icons returned by `Page.icon`/`DataSource.icon`/`Database.icon` can be narrowed with `isinstance` without reaching into `ultimate_notion.emoji`, issue #353.
 - Fix: Skip the two-way relation backward rename in `Relation._update_bwd_rel` when no backward name is defined, instead of attempting `RenameProp(name=None)` and raising a pydantic `ValidationError`, issue #325.
 - Fix: Raise a clear `UnsetError` from `Bot.workspace_info` when the workspace name or id is unavailable (i.e. for any bot other than the integration's own), instead of an opaque pydantic `ValidationError`, issue #326.


### PR DESCRIPTION
## Description

Cuts the accumulated `## Unreleased` changelog entries into a dated `## Version 0.9.11, 2026-06-24` release section and leaves a fresh empty `## Unreleased` header for future work. No content was reworded — only the headers were restructured. The release covers the icon-subtype export (#353) plus the two-way relation rename and `Bot.workspace_info` fixes (#325, #326); the remaining entries are internal refactors. This is a changelog-only change requiring no test or documentation updates.

### Types of change

Documentation / release housekeeping.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
