### PR TITLE
Trust the Coveralls Homebrew tap on macOS to fix CI (#358)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,11 +82,17 @@ jobs:
     - name: Run tests and track code coverage
       run: hatch run ci
 
+    # The macOS runner's Homebrew refuses to load the coveralls formula from
+    # the untrusted coverallsapp/coveralls tap, which the Coveralls action
+    # installs from. Trust the tap up front so the install succeeds. See #358.
+    - name: Trust Coveralls Homebrew tap (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew tap coverallsapp/coveralls
+        brew trust coverallsapp/coveralls
+
     - name: Coveralls Parallel
-      # Coverage reporting must never fail the build. In particular, the
-      # macOS runner's Homebrew refuses to load the coveralls formula from an
-      # untrusted tap, which would otherwise cancel the whole matrix. See #358.
-      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -83,6 +83,10 @@ jobs:
       run: hatch run ci
 
     - name: Coveralls Parallel
+      # Coverage reporting must never fail the build. In particular, the
+      # macOS runner's Homebrew refuses to load the coveralls formula from an
+      # untrusted tap, which would otherwise cancel the whole matrix. See #358.
+      continue-on-error: true
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
Fixes #358.

## Problem

GitHub's hosted macOS runner picked up a new Homebrew that refuses to load formulae from untrusted third-party taps. `coverallsapp/github-action@v2` installs its reporter on macOS via `brew install coveralls`, which now fails:

```
Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap coverallsapp/coveralls.
Run `brew trust --formula coverallsapp/coveralls/coveralls` or `brew trust coverallsapp/coveralls` to trust it.
```

The tests themselves pass; only the `Coveralls Parallel` upload step fails. Because the matrix uses `fail-fast: true`, that one failure cancelled the rest of the matrix, turning every PR's CI red and blocking the `completion-tests` gate.

## Fix

Add a macOS-only step before `Coveralls Parallel` that taps and `brew trust`s the `coverallsapp/coveralls` tap, exactly as the Homebrew error recommends. The Coveralls action's subsequent `brew install coveralls` then loads the now-trusted formula and the upload succeeds — so macOS coverage is still reported rather than suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)