### PR TITLE
Test-infra for re-recording on app.notion.com workspaces (toward #361)

### DIFF
--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -15,6 +15,9 @@ from notion_client import Client
 from notion_client.errors import HTTPResponseError
 
 import ultimate_notion as uno
+from ultimate_notion.rich_text import math as rt_math
+from ultimate_notion.rich_text import mention as rt_mention
+from ultimate_notion.rich_text import text as rt_text
 
 DEFAULT_ROOT_TITLE = 'Tests'
 MAX_REQUEST_ATTEMPTS = 5
@@ -83,6 +86,99 @@ def json_object(value: Any) -> dict[str, Any]:
 
 def rich_text(text: str) -> list[dict[str, Any]]:
     return [{'type': 'text', 'text': {'content': text}}]
+
+
+# The 12 intricately-styled paragraphs that `tests/test_markdown.py::test_rich_text_md`
+# expects on the `Markdown Text Test` page. Contrary to earlier belief, this rich text *is*
+# reproducible through the API (nested bold/italic/strikethrough/underline, inline code and
+# equations, a person and a self page-mention, mid-word links), so the bootstrap builds it
+# rather than leaving it as a manual UI step. The target markdown is the `correct_mds` list
+# in that test; `markdown_text_paragraphs` reproduces it segment by segment.
+_G = 'https://google.de/'
+_A = 'https://amazon.com/'
+
+# The first paragraph rendered to markdown -- used to detect an already-built page so the
+# bootstrap stays idempotent (a placeholder page renders to plain, unstyled text).
+MARKDOWN_TEXT_FIRST_MD = 'here is something **very** *simpel* and <u>underlined</u> as well as `code`'
+
+
+def markdown_text_paragraphs(notion: uno.Session, page: uno.Page) -> list[uno.Paragraph]:
+    """Return the 12 styled paragraphs for the `Markdown Text Test` page.
+
+    `page` is the page itself, needed for the self page-mention in paragraph 7; a workspace
+    member is used for that paragraph's person mention (the test neutralises the name).
+    """
+    t, m = rt_text, rt_math
+    users = notion.all_users()
+    person = next((u for u in users if getattr(u, 'is_person', False)), users[0])
+    parts = [
+        t('here is something ')
+        + t('very', bold=True)
+        + t(' ')
+        + t('simpel', italic=True)
+        + t(' and ')
+        + t('underlined', underline=True)
+        + t(' as well as ')
+        + t('code', code=True),
+        t('here is a sentence that was bolded ', bold=True)
+        + t('then', bold=True, italic=True)
+        + t(' typed.', bold=True),
+        t('here is a test sentence with ')
+        + t('many ', strikethrough=True)
+        + t('different ', strikethrough=True, bold=True)
+        + t('styles', strikethrough=True, bold=True, italic=True)
+        + t('.', strikethrough=True, bold=True),
+        t('here is another test with ')
+        + t('many ', strikethrough=True)
+        + t('different ', strikethrough=True, italic=True)
+        + t('styles', strikethrough=True, italic=True, bold=True)
+        + t('.', strikethrough=True, italic=True),
+        t('here is one more with a ')
+        + t('strange ', italic=True)
+        + t('style', italic=True, bold=True)
+        + t(' ')
+        + t('combination', bold=True),
+        t('here is one with an inline ')
+        + t('equa-', bold=True, strikethrough=True)
+        + t('tion', bold=True, strikethrough=True, italic=True)
+        + t(' ', bold=True)
+        + m('E=mc^2', bold=True, italic=True)
+        + t(' and', bold=True, italic=True)
+        + t(' no block equation'),
+        t('and here is one with ')
+        + t('person', bold=True, italic=True, strikethrough=True)
+        + t(' mention ', italic=True, strikethrough=True)
+        + rt_mention(person, italic=True, strikethrough=True)
+        + t(' and ')
+        + t('page mention ', bold=True)
+        + rt_mention(page, bold=True)
+        + t(' '),
+        t('here is one ')
+        + t('stretching over ', bold=True)
+        + t('many\n', bold=True, italic=True)
+        + t('many', bold=True, italic=True, strikethrough=True)
+        + t('\n', bold=True)
+        + t('lines', bold=True, strikethrough=True),
+        t('This is code, e.g. ')
+        + t('python', bold=True, code=True)
+        + t(' code\nnow stretching ', bold=True)
+        + t('over\nmany lines', bold=True, code=True),
+        t('This is a ')
+        + t('li', href=_G)
+        + t('n', bold=True, href=_G)
+        + t('k', href=_G)
+        + t(' and a ')
+        + t('first', strikethrough=True)
+        + t(' an')
+        + t('d ', strikethrough=True)
+        + t('second', strikethrough=True, underline=True)
+        + t(' stroke', strikethrough=True)
+        + t(' through')
+        + t(' word.', underline=True),
+        t('Half a ') + t('lin', href=_G) + t('k', href=_A) + t(' for two destinations'),
+        t('✨Magic ✨'),
+    ]
+    return [uno.Paragraph(part) for part in parts]
 
 
 class ContactRole(uno.OptionNS):
@@ -320,10 +416,7 @@ class Bootstrap:
                 uno.Paragraph('Welcome to the Ultimate Notion test workspace.'),
             ],
         )
-        self.create_page(
-            'Markdown Text Test',
-            blocks=[uno.Paragraph('Markdown rich-text fixture.')],
-        )
+        self.ensure_markdown_text_page()
         markdown_page = self.create_page(
             'Markdown Test',
             blocks=[uno.Heading1('Headline 1')],
@@ -346,6 +439,22 @@ class Bootstrap:
             'Comments',
             blocks=[uno.Heading1('Comments')],
         )
+
+    def ensure_markdown_text_page(self) -> None:
+        """Create the `Markdown Text Test` page and build its 12 styled rich-text paragraphs.
+
+        Idempotent: if the page already renders the expected first paragraph it is left
+        unchanged; otherwise its body is rebuilt (a freshly-created or placeholder page).
+        """
+        page = self.create_page('Markdown Text Test')
+        children = list(page.children)
+        if children and children[0].to_markdown() == MARKDOWN_TEXT_FIRST_MD:
+            typer.echo('Markdown Text Test: rich text already built')
+            return
+        for child in children:
+            child.delete()
+        page.append(markdown_text_paragraphs(self.notion, page))
+        typer.echo('Markdown Text Test: built 12 rich-text paragraphs')
 
     def audit_manual_objects(self) -> None:
         for title, kind in (

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -150,9 +150,14 @@ root page. Create any missing API-creatable objects with:
 NOTION_TOKEN=ntn_... UNO_TEST_ROOT_PAGE='My Test Root' hatch run bootstrap-test-workspace
 ```
 
-The script is idempotent and leaves existing objects unchanged. Some content-sensitive
-tests still require the richer recorded fixture content; the bootstrap creates the
-minimum useful structure and seed rows needed to inspect and extend a fresh workspace.
+The script is idempotent and leaves existing objects unchanged. It also builds the
+intricately-styled rich text on the `Markdown Text Test` page that
+`tests/test_markdown.py::test_rich_text_md` expects (nested bold/italic/strikethrough/
+underline, inline code and equations, a person and a self page-mention, mid-word links).
+This rich text *is* reproducible through the API, so it is no longer a manual step. A few
+content-sensitive tests still require manual workspace content the API cannot create —
+notably the `Comments` page's **inline discussions** (the API cannot start an inline
+discussion) and the `Formula DB` formula columns (§4).
 
 After creating objects, the script runs an **audit**: it lists every page and database
 the integration can see, reports any **missing** expected object, and lists **stray**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -440,6 +440,12 @@ def _normalize_ids_in_body(body: Any) -> Any:
     # cassettes. A no-op for the default `Tests`, so existing cassettes are untouched.
     if TESTS_PAGE != 'Tests':
         body = body.replace(TESTS_PAGE, 'Tests')
+    # Notion returns object URLs under either `www.notion.so/<id>` or `app.notion.com/p/<id>` depending
+    # on the workspace/account. Canonicalise to `www.notion.so/` so a cassette recorded against an
+    # app.notion.com workspace replays against the placeholder-based, notion.so expectations. The two
+    # forms differ in length, but `Content-Length` is not stored in the cassettes, and on replay the body
+    # already carries `www.notion.so`, so the replacement is then a no-op.
+    body = body.replace('app.notion.com/p/', 'www.notion.so/')
     return _shared_ids.scrub(body)
 
 


### PR DESCRIPTION
Extracted from the work on #361 (re-recording the VCR cassette suite). These two **test-infrastructure** changes are independently valuable, green today, and don't touch the cassettes — so they land separately from the large cassette re-record.

## What's here

**1. Host canonicalisation in `conftest.py`** (cherry-picked from `datasource-api` `9826778f`)
Notion returns object URLs under either `www.notion.so/<id>` or `app.notion.com/p/<id>` depending on the workspace/account. Tests and recorded fixtures assume `www.notion.so`, so a cassette recorded against an `app.notion.com` workspace fails on the host even with ids normalised. We rewrite `app.notion.com/p/` → `www.notion.so/` in recorded response bodies — a no-op on replay (the body already carries `www.notion.so`), so existing cassettes are untouched.

**2. Bootstrap builds the `Markdown Text Test` rich-text fixture** (`scripts/bootstrap_test_workspace.py`)
`test_rich_text_md` expects 12 intricately-styled paragraphs (nested bold/italic/strikethrough/underline, inline `code` and equations, a person + self page-mention, mid-word links). This was previously believed to require a manual UI step — but it **is** reproducible through the API. The bootstrap now builds it (`markdown_text_paragraphs` / `ensure_markdown_text_page`, idempotent), and `TEST_WORKSPACE.md` is updated to match and to call out the content that genuinely stays manual (Comments inline discussions; Formula DB formula columns per #297).

## Verification

- `hatch run vcr-only` over the live-test modules: **131 passed, 2 skipped** (Windows), 1 deselected (Google adapter) — unchanged from `main`; the host-fix is a no-op on the committed `notion.so` cassettes.
- Bootstrap re-verified live against the real test workspace: the §8 builder is idempotent (reports `rich text already built`, no destructive rewrite).

## Not included
The full cassette re-record (issue #361) is staged separately — it's blocked on `test_query_formula` (Formula DB manual setup + #297) and is mostly churn, so it doesn't belong with these reviewable infra changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)