### PR TITLE
test(query): make test_query_formula independent of Notion row order (#364)

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -470,7 +470,9 @@ def test_query_new_task_db(new_task_db: uno.Database) -> None:
 
 @pytest.mark.vcr()
 def test_query_formula(root_page: uno.Page, notion: uno.Session, formula_db: uno.Database) -> None:
-    item_1, item_2 = formula_db.get_all_pages()
+    # Sort by title so the test does not depend on Notion's (workspace-specific) default row
+    # order, which `get_all_pages()` returns unsorted -- see issue #364.
+    item_1, item_2 = sorted(formula_db.get_all_pages(), key=lambda page: str(page.title))
     query = formula_db.query.filter(uno.prop('String') == 'Item 1')
     assert set(query.execute()) == {item_1}
 


### PR DESCRIPTION
Fixes #364.

`test_query_formula` unpacked `formula_db.get_all_pages()` positionally:

```python
item_1, item_2 = formula_db.get_all_pages()
```

`get_all_pages()` applies no sort, so it returns Notion's **default view order**, which varies by workspace and the public API can't set. On a workspace returning `[Item 2, Item 1]` the bindings flip and the assertions fail even though the formula filters are correct. Sorting by title removes the dependence without changing what the test verifies:

```python
item_1, item_2 = sorted(formula_db.get_all_pages(), key=lambda page: str(page.title))
```

Surfaced while re-recording the cassette suite (#361) on a workspace whose Formula DB returns the rows in the opposite order.

**Verification:** `hatch run vcr-only tests/test_query.py::test_query_formula` → passes (no-op against the committed cassette, which already has `Item 1` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)