### PR TITLE
Coerce plain-string SelectOption description into rich-text list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Coerce the plain-string `description` Notion returns on select/multi-select/status options into the rich-text list the `SelectOption.description` field is typed as (mapping the empty string to `None`), instead of raising a pydantic `ValidationError`. The error previously cascaded through `search_db()`/`db` listings and made every database containing an option with a description inaccessible.
 - Fix: Capture the read-only `block_type` field Notion sends on unsupported blocks (e.g. button or AI blocks), which previously raised a pydantic `ValidationError` on dev/CI installs (`extra='forbid'`) and made the whole children list — including sibling blocks after the unsupported one — inaccessible, issue #356.
 
 ## Version 0.9.11, 2026-06-24

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import pendulum as pnd
-from pydantic import Field, SerializeAsAny
+from pydantic import Field, SerializeAsAny, field_validator
 from typing_extensions import TypeVar
 
 from ultimate_notion.obj_api.core import (
@@ -58,6 +58,23 @@ class SelectOption(GenericObject):
     id: str | UnsetType = Unset  # According to docs: "These are sometimes, but not always, UUIDs."
     color: Color | UnsetType = Unset  # Leave this as Unset when overwriting an option as colors can't be changed
     description: list[RichTextBaseObject] | None = None  # ToDo: Undocumented in the Notion API
+
+    @field_validator('description', mode='before')
+    @classmethod
+    def _coerce_str_description(cls, value: object) -> object:
+        """Coerce a plain-string description into the expected rich-text list.
+
+        The Notion API returns the select-option description as a plain string
+        (or an empty string when unset), not the rich-text list this field is
+        typed as, so deserialising a real option raised a `ValidationError`.
+        Map the empty string to `None` and wrap a non-empty string in a single
+        text rich-text object. Existing list values pass through unchanged.
+        """
+        if value == '':
+            return None
+        if isinstance(value, str):
+            return [{'type': 'text', 'text': {'content': value}, 'plain_text': value}]
+        return value
 
     @classmethod
     def build(cls, name: str, color: Color = Color.DEFAULT) -> SelectOption:

--- a/tests/obj_api/test_objects.py
+++ b/tests/obj_api/test_objects.py
@@ -100,3 +100,21 @@ def test_unsupported_block() -> None:
     }
     block = obj_blocks.UnsupportedBlock.model_validate(raw_block)
     assert block.unsupported.block_type == 'button'
+
+
+def test_select_option_string_description() -> None:
+    # Notion returns the select-option description as a plain string (or an
+    # empty string when unset), not the rich-text list the field is typed as.
+    # Both must validate instead of raising a ValidationError.
+    unset = objs.SelectOption.model_validate({'name': 'A', 'description': ''})
+    assert unset.description is None
+
+    described = objs.SelectOption.model_validate({'name': 'B', 'description': 'A short summary.'})
+    assert described.description is not None
+    assert described.description[0].plain_text == 'A short summary.'
+
+    # An already-correct rich-text list still passes through unchanged.
+    rich = {'type': 'text', 'text': {'content': 'hi'}, 'plain_text': 'hi'}
+    passthrough = objs.SelectOption.model_validate({'name': 'C', 'description': [rich]})
+    assert passthrough.description is not None
+    assert passthrough.description[0].plain_text == 'hi'


### PR DESCRIPTION
## Problem

`SelectOption.description` is typed as `list[RichTextBaseObject] | None`, but the Notion API actually returns the select/multi-select/status option description as a **plain string** — and an **empty string** (`''`) when it is unset.

As a result, deserialising any option that has a description raises a pydantic `ValidationError`:

```
1 validation error for Select
select.options.0.description
  Input should be a valid list [type=list_type, input_value='<some description text>', input_type=str]
```

Because the error is re-raised as a `RuntimeError` while constructing the polymorphic `Select` property, it cascades through `search_db()` and any `db` listing, making **every database that contains an option with a description inaccessible** — not just the offending option.

## Fix

Add a `mode='before'` field validator on `SelectOption.description` that:

- maps the empty string `''` to `None` (Notion's meaning of "unset" for text-like fields, consistent with issue #59),
- wraps a non-empty string into a single `text` rich-text object so it satisfies the declared type while preserving the text,
- passes already-correct list values through unchanged.

## Test

Adds `test_select_option_string_description` in `tests/obj_api/test_objects.py` covering all three cases (empty string → `None`, plain string → preserved, existing list → unchanged), following the existing `test_unsupported_block` pattern.

Changelog updated under **Unreleased**.
