### PR TITLE
test(vcr): add /query JSON-body matcher (#367)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,14 +91,22 @@ PYTEST_MARKERS = ['check_latest_release', 'file_upload']
 # and a cassette with several searches only replays them in the order they were recorded. That makes
 # the shared fixtures fragile and ties a recording to the workspace it was made in. We add a matcher
 # that *additionally* compares the JSON body of `/v1/search` requests (a no-op for every other
-# endpoint), so each search is matched by what it actually queries. We also scrub a non-default root
+# endpoint), so each search is matched by what it actually queries. The same problem affects
+# database/datasource `/query` requests, whose filter/sort criteria also live in the body (issue
+# #367); a parallel matcher compares those by body too. We also scrub a non-default root
 # page title back to the canonical `Tests` on record, so a maintainer who cannot name their shared
 # root page `Tests` (via `UNO_TEST_ROOT_PAGE`) still produces cassettes that replay against the
 # committed set. See the "Set up a Notion test workspace" section in `CONTRIBUTING.md`.
 
 NOTION_SEARCH_PATH = '/v1/search'
+# Database/datasource queries (`POST /v1/databases/{id}/query`, `POST /v1/data_sources/{id}/query`)
+# carry their filter and sort criteria in the request body, which the default matchers ignore. We
+# recognise them by the `/query` path suffix (the id in the path is already distinguished by the
+# default `path` matcher). See issue #367.
+NOTION_QUERY_PATH_SUFFIX = '/query'
 VCR_DEFAULT_MATCHERS = ['method', 'scheme', 'host', 'port', 'path', 'query']
 VCR_SEARCH_MATCHER = 'notion_search_body'
+VCR_QUERY_MATCHER = 'notion_query_body'
 
 
 def _request_json_body(request: Any) -> Any:
@@ -126,9 +134,21 @@ def match_search_body(r1: Any, r2: Any) -> bool:
     return bool(_request_json_body(r1) == _request_json_body(r2))
 
 
+def match_query_body(r1: Any, r2: Any) -> bool:
+    """Match `POST .../query` requests by their JSON body; match everything else unconditionally.
+
+    Combined with the default `path` matcher this adds body matching *only* for the database/datasource
+    query endpoint, leaving all other endpoints matched exactly as before.
+    """
+    if not (r1.path.endswith(NOTION_QUERY_PATH_SUFFIX) and r2.path.endswith(NOTION_QUERY_PATH_SUFFIX)):
+        return True
+    return bool(_request_json_body(r1) == _request_json_body(r2))
+
+
 def register_notion_matchers(vcr: VCR) -> None:
     """Register Ultimate Notion's custom VCR matchers on a freshly built VCR instance."""
     vcr.register_matcher(VCR_SEARCH_MATCHER, match_search_body)
+    vcr.register_matcher(VCR_QUERY_MATCHER, match_query_body)
 
 
 def pytest_recording_configure(config: pytest.Config, vcr: VCR) -> None:
@@ -467,7 +487,7 @@ def normalize_response(response: dict[str, Any]) -> dict[str, Any]:
 def build_vcr_config() -> dict[str, Any]:
     """Build the pytest-recording config (also reused when recording from module-level fixtures)."""
     return {
-        'match_on': [*VCR_DEFAULT_MATCHERS, VCR_SEARCH_MATCHER],
+        'match_on': [*VCR_DEFAULT_MATCHERS, VCR_SEARCH_MATCHER, VCR_QUERY_MATCHER],
         'filter_headers': [(param, 'secret...') for param in SECRET_PARAMS],
         'filter_query_parameters': SECRET_PARAMS,
         'filter_post_data_parameters': SECRET_PARAMS,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,6 +4,7 @@ import pendulum as pnd
 import pytest
 
 import ultimate_notion as uno
+from tests.conftest import VCR_DEFAULT_MATCHERS, VCR_SEARCH_MATCHER
 from ultimate_notion import schema
 from ultimate_notion.errors import FilterQueryError
 from ultimate_notion.utils import parse_dt_str
@@ -104,7 +105,13 @@ def test_property() -> None:
     assert str(prop.every != 'John') == "prop('Name').every != 'John'"
 
 
-@pytest.mark.vcr()
+# This test filters on `pnd.now()`, which must stay a real timestamp: the relative-window conditions
+# (`this_week`, `past_week`, ...) are evaluated by Notion against its own clock at *record* time, so the
+# created page dates have to be relative to the real now. That makes the absolute-comparison query bodies
+# (`== now`, `< now`, ...) record-time-specific, so they cannot be matched by body on replay. We therefore
+# opt this one test out of the `/query` body matcher (issue #367) and fall back to ordered path matching --
+# exactly how every query test matched before that matcher existed.
+@pytest.mark.vcr(match_on=[*VCR_DEFAULT_MATCHERS, VCR_SEARCH_MATCHER])
 def test_date_query(root_page: uno.Page, notion: uno.Session) -> None:
     class DB(uno.Schema, db_title='Date Query DB Test'):
         name = uno.PropType.Title('Name')

--- a/tests/test_vcr_normalization.py
+++ b/tests/test_vcr_normalization.py
@@ -22,6 +22,7 @@ from tests.conftest import (
     TESTS_PAGE,
     _SharedIdRegistry,
     _undash,
+    match_query_body,
     match_search_body,
     normalize_response,
     normalize_shared_ids_request,
@@ -170,6 +171,20 @@ def test_matcher_passes_non_search_requests() -> None:
     a = _FakeRequest('https://api.notion.com/v1/pages', json.dumps({'query': 'A'}), path='/v1/pages')
     b = _FakeRequest('https://api.notion.com/v1/pages', json.dumps({'query': 'B'}), path='/v1/pages')
     assert match_search_body(a, b)
+
+
+def test_matcher_compares_query_requests_by_body() -> None:
+    path = f'/v1/databases/{ROOT_ID}/query'
+    a = _FakeRequest('https://api.notion.com' + path, json.dumps({'filter': 'A'}), path=path)
+    b = _FakeRequest('https://api.notion.com' + path, json.dumps({'filter': 'B'}), path=path)
+    assert match_query_body(a, a)
+    assert not match_query_body(a, b)
+
+
+def test_query_matcher_passes_non_query_requests() -> None:
+    a = _FakeRequest('https://api.notion.com/v1/pages', json.dumps({'filter': 'A'}), path='/v1/pages')
+    b = _FakeRequest('https://api.notion.com/v1/pages', json.dumps({'filter': 'B'}), path='/v1/pages')
+    assert match_query_body(a, b)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

Database/datasource `POST .../query` requests carry their filter and sort criteria in the request body, which the default VCR matchers ignore — so queries to the same endpoint only replay in recorded order, leaving query cassettes fragile and non-portable. This adds `match_query_body` as a clean parallel to `match_search_body` (#292), gated on the `/query` path suffix and registered in `match_on`, plus unit tests mirroring the search-matcher ones. Fixes #367. `test_date_query` is opted back out to ordered path matching because it filters on a real `pnd.now()` that is baked into the cassette at record time (required so the relative-window conditions evaluate against Notion's clock during live recording), making its absolute-comparison bodies impossible to body-match on replay. No re-record was needed: the full suite (`hatch run vcr-only`) replays green against the committed cassettes — **204 passed, 14 skipped**.

### Types of change

Test infrastructure / enhancement (no production code or user-facing behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)