### PR TITLE
test(vcr): reload formula_db from authoritative retrieve to avoid stale /search schema (#369)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -746,8 +746,17 @@ def wiki_db(notion_cached: Session) -> Database:
 
 @vcr_fixture(scope='module')
 def formula_db(notion_cached: Session) -> Database:
-    """Return manually created formula db."""
-    return require_db(notion_cached, FORMULA_DB)
+    """Return manually created formula db.
+
+    Notion's eventually-consistent `/search` index intermittently reports the formula
+    columns by their underlying storage type (e.g. `String` as `rich_text`), so reload
+    from the authoritative database-retrieve endpoint to bind the true formula schema
+    regardless of `/search` lag. `reload()`'s default `rebind_schema=True` would raise a
+    `SchemaError` here, so `rebind_schema=False` is required.
+    """
+    db = require_db(notion_cached, FORMULA_DB)
+    db.reload(rebind_schema=False)
+    return db
 
 
 @vcr_fixture(scope='module')


### PR DESCRIPTION
## Description

Fixes #369. Notion's `POST /v1/search` index is eventually consistent and intermittently reports the `Formula DB`'s formula columns by their underlying storage type (e.g. `String` comes back as `rich_text` rather than `formula`), so an early static-db fixture search can cache the stale-schema `Formula DB` (first-writer-wins `_cache_add`) before the `formula_db` fixture resolves — causing `test_query_formula` to build `rich_text` conditions that misalign against the recorded `formula.string` query bodies on replay (#368). This reloads the fixture from the authoritative database-retrieve endpoint with `db.reload(rebind_schema=False)` so it binds the true formula schema regardless of `/search` lag, making re-records deterministic (`reload()`'s default `rebind_schema=True` raises `SchemaError` here). This lands with the full re-record (#363) since the fix records an extra GET the existing cassettes don't contain. See also #297, #364.

### Types of change

Bug fix (test infrastructure).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
