### PR TITLE
test(vcr): bind test_bind_db_auto by real Task DB id so it records live (#373)

### DIFF
--- a/tests/adapters/google/tasks/cassettes/fixtures/mod_formula_db.yaml
+++ b/tests/adapters/google/tasks/cassettes/fixtures/mod_formula_db.yaml
@@ -289,4 +289,73 @@ interactions:
       - '0'
     http_version: HTTP/1.1
     status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/00000000-0000-4000-8000-00000000000d
+  response:
+    content: '{"object":"database","id":"00000000-0000-4000-8000-00000000000d","cover":null,"icon":null,"created_time":"2024-11-18T14:08:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_time":"2025-06-10T17:41:00.000Z","title":[{"type":"text","text":{"content":"Formula
+      DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Formula
+      DB","href":null}],"description":[],"is_inline":false,"properties":{"String":{"id":"PbR%3B","name":"String","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.style(\"u\",
+      \"pink\")"}},"Date":{"id":"aK_F","name":"Date","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:created_time}}.dateAdd(1,
+      \"weeks\")"}},"Checkbox":{"id":"f%3EhC","name":"Checkbox","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:fjsB:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.includes(\"Done\")"}},"Tags":{"id":"fjsB","name":"Tags","description":null,"type":"multi_select","multi_select":{"options":[{"id":"73212b86-d2fb-47f6-8c57-e9791c3a6a09","name":"In
+      Progress","color":"pink","description":null},{"id":"427db6b8-1ec9-4374-b721-6ab4572b185b","name":"Done","color":"gray","description":null}]}},"Number":{"id":"voBT","name":"Number","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:fjsB:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.length()"}},"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/0000000000004000800000000000000d","public_url":null,"archived":false,"in_trash":false,"request_id":"f5cc7f83-69db-41b3-abf7-fedc071e9c01"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 996c0da239e071d6-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f5cc7f83-69db-41b3-abf7-fedc071e9c01
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
 version: 1

--- a/tests/cassettes/fixtures/mod_formula_db.yaml
+++ b/tests/cassettes/fixtures/mod_formula_db.yaml
@@ -207,4 +207,73 @@ interactions:
       - '0'
     http_version: HTTP/1.1
     status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/00000000-0000-4000-8000-00000000000d
+  response:
+    content: '{"object":"database","id":"00000000-0000-4000-8000-00000000000d","cover":null,"icon":null,"created_time":"2024-11-18T14:08:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_time":"2025-06-10T17:41:00.000Z","title":[{"type":"text","text":{"content":"Formula
+      DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Formula
+      DB","href":null}],"description":[],"is_inline":false,"properties":{"String":{"id":"PbR%3B","name":"String","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.style(\"u\",
+      \"pink\")"}},"Date":{"id":"aK_F","name":"Date","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:created_time}}.dateAdd(1,
+      \"weeks\")"}},"Checkbox":{"id":"f%3EhC","name":"Checkbox","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:fjsB:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.includes(\"Done\")"}},"Tags":{"id":"fjsB","name":"Tags","description":null,"type":"multi_select","multi_select":{"options":[{"id":"73212b86-d2fb-47f6-8c57-e9791c3a6a09","name":"In
+      Progress","color":"pink","description":null},{"id":"427db6b8-1ec9-4374-b721-6ab4572b185b","name":"Done","color":"gray","description":null}]}},"Number":{"id":"voBT","name":"Number","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:fjsB:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.length()"}},"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/0000000000004000800000000000000d","public_url":null,"archived":false,"in_trash":false,"request_id":"f5cc7f83-69db-41b3-abf7-fedc071e9c01"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 996c0da239e071d6-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f5cc7f83-69db-41b3-abf7-fedc071e9c01
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
 version: 1

--- a/tests/obj_api/cassettes/fixtures/mod_formula_db.yaml
+++ b/tests/obj_api/cassettes/fixtures/mod_formula_db.yaml
@@ -205,4 +205,73 @@ interactions:
       - '0'
     http_version: HTTP/1.1
     status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2022-06-28'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/00000000-0000-4000-8000-00000000000d
+  response:
+    content: '{"object":"database","id":"00000000-0000-4000-8000-00000000000d","cover":null,"icon":null,"created_time":"2024-11-18T14:08:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_time":"2025-06-10T17:41:00.000Z","title":[{"type":"text","text":{"content":"Formula
+      DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Formula
+      DB","href":null}],"description":[],"is_inline":false,"properties":{"String":{"id":"PbR%3B","name":"String","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:title:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.style(\"u\",
+      \"pink\")"}},"Date":{"id":"aK_F","name":"Date","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:created_time}}.dateAdd(1,
+      \"weeks\")"}},"Checkbox":{"id":"f%3EhC","name":"Checkbox","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:fjsB:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.includes(\"Done\")"}},"Tags":{"id":"fjsB","name":"Tags","description":null,"type":"multi_select","multi_select":{"options":[{"id":"73212b86-d2fb-47f6-8c57-e9791c3a6a09","name":"In
+      Progress","color":"pink","description":null},{"id":"427db6b8-1ec9-4374-b721-6ab4572b185b","name":"Done","color":"gray","description":null}]}},"Number":{"id":"voBT","name":"Number","description":null,"type":"formula","formula":{"expression":"{{notion:block_property:fjsB:00000000-0000-0000-0000-000000000000:00000000-0000-4000-8000-0000000000f0}}.length()"}},"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/0000000000004000800000000000000d","public_url":null,"archived":false,"in_trash":false,"request_id":"f5cc7f83-69db-41b3-abf7-fedc071e9c01"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 996c0da239e071d6-FRA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f5cc7f83-69db-41b3-abf7-fedc071e9c01
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
 version: 1

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -536,7 +536,14 @@ def test_bind_db(notion: uno.Session, root_page: uno.Page) -> None:
 
 
 @pytest.mark.vcr()
-def test_bind_db_auto(notion: uno.Session) -> None:
+def test_bind_db_auto(notion: uno.Session, task_db: uno.Database) -> None:
+    """Bind a schema to a database by id and by title.
+
+    The by-id case binds to the real `Task DB` (via the `task_db` fixture) rather than a hardcoded
+    placeholder id, so it records live and replays portably: the shared-id normalization maps the real
+    Task DB id to its `…000c` placeholder in both the request URI and the response. See issue #373.
+    """
+
     class StatusOption(uno.OptionNS):
         backlog = uno.Option('Backlog', color=uno.Color.GRAY)
         in_progress = uno.Option('In Progress', color=uno.Color.BLUE)
@@ -593,7 +600,7 @@ def test_bind_db_auto(notion: uno.Session) -> None:
         TaskBase.bind_db()
     assert not TaskBase.is_bound()
 
-    class TaskWithDbId(TaskBase, db_id='0000000000004000800000000000000c'):
+    class TaskWithDbId(TaskBase, db_id=str(task_db.id)):
         """Schema with a reference to a database by ID"""
 
     TaskWithDbId.bind_db()


### PR DESCRIPTION
Closes #373. Part of #361.

## 1. Issue #373 — `test_bind_db_auto` records live (`tests/test_schema.py`)

`test_bind_db_auto` hardcoded the placeholder database id `…000c` as its `db_id`, so a **live** `bind_db()` → database-retrieve sent an id that exists in no real workspace → `404`, making the test replay-only.

It now binds the by-id case to the **real `Task DB`** via the existing `task_db` fixture (`db_id=str(task_db.id)`). The suite's shared-id normalization already maps the real Task DB id ↔ its `…000c` placeholder in both the request URI and response bodies, so the test records live and replays portably like every other test. No replay-only marker / re-record carve-out needed.

## 2. Unblock CI — restore missing `formula_db` retrieve (`mod_formula_db.yaml` ×3)

CI was red on `main` and every branch cut from it (`8 passed, 196 errors`). Cause: #370 changed the `formula_db` fixture to call `db.reload()` → `GET /v1/databases/…000d`, but the committed `mod_formula_db.yaml` cassettes were never re-recorded to include that retrieve (they hold only the `POST /v1/search`). On replay the retrieve has no match, so every test using the widely-shared `formula_db` fixture errors with `CannotOverwriteExistingCassetteException`.

Fix: splice the already-normalized `GET /databases/…000d` retrieve interaction (reused verbatim from `tests/cassettes/test_query/test_query_formula.yaml`) into all three `mod_formula_db.yaml` copies. Hand-patched rather than live re-recorded because the response already exists normalized in a committed cassette, avoiding a full-suite re-record.

> Note: this second commit repairs a `main` regression from #370 that is independent of #373; it's bundled here to get this PR green. It can be cherry-picked to `main` on its own to unblock other branches.

## Verification

`hatch run vcr-only` (full suite, as CI runs):
- **Before:** 8 passed, 196 errors (exit ≠ 0)
- **After:** exit 0, **0 FAILED / 0 ERROR / 0 CannotOverwrite** (only the expected `--file-upload` / `--check-latest-release` opt-in skips)
- `test_bind_db_auto` passes, including in isolation.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)