### PR TITLE
test(vcr): pin test_icon_attr to replay-only to preserve its cassette across re-records

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -76,7 +76,7 @@ def test_parent_children(intro_page: uno.Page) -> None:
 # re-recorded live. `record_mode='none'` makes pytest-recording always replay the committed cassette
 # (recorded before Notion changed this) -- it overrides the CLI record mode and, crucially, is applied
 # before the `rewrite` branch that would delete the cassette -- so a full `vcr-rewrite` preserves it.
-# Remove once built-in-icon-type support lands (it models the new shape). See #372 (part of #361).
+# Remove once built-in-icon-type support lands (it models the new shape); see #376. See #372 (part of #361).
 @pytest.mark.vcr(record_mode='none')
 def test_icon_attr(notion: uno.Session, root_page: uno.Page) -> None:
     new_page = notion.create_page(parent=root_page, title='My new page with icon')

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -70,7 +70,14 @@ def test_parent_children(intro_page: uno.Page) -> None:
     assert all(isinstance(block, Block) for block in intro_page.blocks)
 
 
-@pytest.mark.vcr()
+# Pin to replay-only: Notion no longer echoes `/icons/*.svg` back as an external file -- it now stores
+# such URLs as a built-in-icon type (`{'type': 'icon', 'icon': {'name': 'snake', 'color': 'purple'}}`)
+# which the pre-migration library does not model, so the `ExternalFile` round-trip below cannot be
+# re-recorded live. `record_mode='none'` makes pytest-recording always replay the committed cassette
+# (recorded before Notion changed this) -- it overrides the CLI record mode and, crucially, is applied
+# before the `rewrite` branch that would delete the cassette -- so a full `vcr-rewrite` preserves it.
+# Remove once built-in-icon-type support lands (it models the new shape). See #372 (part of #361).
+@pytest.mark.vcr(record_mode='none')
 def test_icon_attr(notion: uno.Session, root_page: uno.Page) -> None:
     new_page = notion.create_page(parent=root_page, title='My new page with icon')
 


### PR DESCRIPTION
## Description

`tests/test_page.py::test_icon_attr` sets a page icon to a Notion built-in icon URL and asserts it round-trips as an `ExternalFile`, but Notion now stores `/icons/*.svg` as a built-in-icon type (`{'type': 'icon', 'icon': {'name': 'snake', 'color': 'purple'}}`) that the pre-migration library does not model, so the cassette can no longer be re-recorded live. This pins the test to `@pytest.mark.vcr(record_mode='none')` so pytest-recording always replays the committed cassette — the marker overrides the CLI record mode and is applied before the `rewrite` branch that deletes the cassette, so a full `vcr-rewrite` preserves it. Fixes #372 (part of #361); removal once built-in-icon-type support lands is tracked in #376.

### Types of change

Test infrastructure fix.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)