### PR TITLE
Retry transient httpx connection failures (#378)

### DIFF
--- a/src/ultimate_notion/obj_api/__init__.py
+++ b/src/ultimate_notion/obj_api/__init__.py
@@ -78,7 +78,10 @@ def create_notion_client(cfg: Config, **kwargs: Any) -> notion_client.Client:
         _logger.debug(msg)
 
     user_agent = kwargs.pop('user_agent', _get_default_user_agent())
-    httpx_client = httpx.Client(event_hooks={'request': [log_request], 'response': [log_response]})
+    # Retry transient connection failures (e.g. ephemeral-port exhaustion under heavy use). This applies only to
+    # establishing the connection, not to requests that already reached the server, so it cannot cause duplicate writes.
+    transport = httpx.HTTPTransport(retries=3)
+    httpx_client = httpx.Client(transport=transport, event_hooks={'request': [log_request], 'response': [log_response]})
     client = notion_client.Client(auth=auth, client=httpx_client, **kwargs)
     # we need to set the user agent manually, because notion_client ovewrites it during initialization
     httpx_client.headers['User-Agent'] = user_agent


### PR DESCRIPTION
Closes #378.

## Problem

`create_notion_client` built the underlying `httpx.Client` with the default transport, which has `retries=0`. Under heavy use — notably long full-suite live VCR re-records that open many short-lived `Session`/`httpx.Client` connections — the machine can exhaust ephemeral ports (sockets piling up in `TIME_WAIT`), and the next connection attempt fails with `httpx.ConnectError: [Errno 49] Can't assign requested address`. With no connection retries this transient failure aborts the in-flight operation and can leave a corrupted/incomplete cassette during a re-record.

## Fix

Give the client an `HTTPTransport(retries=3)`. `retries` applies **only to establishing the connection**, not to requests that already reached the server, so it cannot cause duplicate writes. It is **transparent on cassette replay** (VCR serves recorded responses, so no real connection is made) — no cassette changes, suite stays green. This is a general robustness improvement that also benefits real users on flaky networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)