### PR TITLE
test(vcr): seed All Properties DB rows so test_retrieve_property can re-record (#371)

### DIFF
--- a/scripts/bootstrap_test_workspace.py
+++ b/scripts/bootstrap_test_workspace.py
@@ -387,6 +387,32 @@ class Bootstrap:
             typer.echo('Formula DB already has rows')
         self.check_formula_filterable(database)
 
+    def ensure_all_props_db_rows(self) -> None:
+        """Seed rows into the manually-created `All Properties DB`.
+
+        The database itself cannot be created through the API (it has AI Autofill and
+        Button properties, see `tests/TEST_WORKSPACE.md`) so it must be built by hand,
+        but its *rows* can be created through the API. `test_retrieve_property` reads the
+        first row, so the database must be non-empty for a live re-record (see issue #371).
+        Only writable properties are set; read-only ones (formula, rollup, AI, button,
+        timestamps, ...) are populated by Notion.
+        """
+        database = self.find_database('All Properties DB')
+        if database is None:
+            typer.echo('All Properties DB: not found; build it by hand first (see tests/TEST_WORKSPACE.md)')
+            return
+        if not database.is_empty:
+            typer.echo('All Properties DB already has rows')
+            return
+        for idx in (1, 2):
+            database.create_page(
+                title=f'Item {idx}',
+                text=f'Text {idx}',
+                number=idx,
+                checkbox=idx % 2 == 0,
+            )
+        typer.echo('seeded All Properties DB: 2 rows')
+
     @staticmethod
     def check_formula_filterable(database: uno.Database) -> None:
         """Report whether the Formula DB's formulas can be filtered on.
@@ -584,6 +610,7 @@ class Bootstrap:
         self.ensure_contacts_db()
         self.ensure_task_db()
         self.ensure_formula_db()
+        self.ensure_all_props_db_rows()
         self.ensure_static_pages()
         self.audit_manual_objects()
         self.audit_workspace_objects()

--- a/tests/TEST_WORKSPACE.md
+++ b/tests/TEST_WORKSPACE.md
@@ -57,6 +57,10 @@ recorded cassette `tests/cassettes/fixtures/mod_all_props_db.yaml`).
 | `AI key info` | AI Autofill (Text output) | **API cannot create.** |
 | `AI custom` | AI Autofill (Text output) | **API cannot create.** |
 
+Once the database exists, the bootstrap script seeds a couple of rows into it through
+the API (only the writable properties are set). `test_retrieve_property` reads the first
+row, so the database must be non-empty for a live re-record (see issue #371).
+
 Notes:
 - **Names are matched exactly (and are case-sensitive).** Notion gives new properties
   default names that differ from the table. For example, the title is `Name`, and you get


### PR DESCRIPTION
## Description

`tests/obj_api/test_endpoints.py::test_retrieve_property` reads the first row of `All Properties DB`, which raised `IndexError` during a live re-record because the database had no rows (offline replay stayed green off the committed cassette). The database must be built by hand — it has AI Autofill and Button properties the API cannot create — but its *rows* can be created through the API, so this seeds a couple of them in `scripts/bootstrap_test_workspace.py` alongside the existing static-DB seeding (writable properties only; read-only ones are filled by Notion), and documents it in `tests/TEST_WORKSPACE.md`. Verified live against a real workspace: the rows were created and retrieving every property of the first row succeeded. Fixes #371 (part of #361).

### Types of change

Test infrastructure / bug fix (lets a previously un-recordable VCR test re-record).

## Checklist

- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)