### PR TITLE
fix(vcr): force-overwrite shared fixture cassettes on vcr-rewrite (#383)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,21 +169,19 @@ You only need this section to run the tests live or to re-record cassettes.
 
 The committed cassettes are one coherent recording of a single workspace, so you
 **cannot** simply `vcr-rewrite` a new test against your own workspace and commit the
-result: `vcr-rewrite` replays the shared fixture cassettes in
-`tests/cassettes/fixtures/` (the `Tests` root page, the seeded databases, …) with
-*your* workspace's ids, which then diverge from the rest of the suite. Record a new
+result: `vcr-rewrite` re-records the shared fixture cassettes in
+`tests/cassettes/fixtures/` (the `Tests` root page, the seeded databases, …) against
+*your* workspace, whose ids then diverge from the rest of the suite. Record a new
 test like this instead:
 
 ```console
 # 1. Bootstrap your workspace (root page named `Tests`, or set UNO_TEST_ROOT_PAGE).
-# 2. Delete the shared fixture cassettes so they record fresh against your workspace
-#    (vcr-rewrite otherwise downgrades them to `new_episodes` and replays committed ids).
-rm tests/cassettes/fixtures/mod_*.yaml
-# 3. Record only your new test.
+# 2. Record only your new test. vcr-rewrite re-records the shared fixtures it touches
+#    against your workspace too (it deletes and re-fetches them live, see #383).
 NOTION_TOKEN=ntn_… hatch run vcr-rewrite -k your_new_test
-# 4. Keep ONLY your new test's cassette; restore the shared fixtures unchanged.
+# 3. Keep ONLY your new test's cassette; restore the shared fixtures unchanged.
 git checkout -- tests/cassettes/fixtures
-# 5. Verify it replays offline against the committed fixtures.
+# 4. Verify it replays offline against the committed fixtures.
 hatch run vcr-only -k your_new_test
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -600,6 +600,12 @@ def vcr_fixture(
                     # Replaying them (e.g. via `new_episodes`) would feed back the workspace-portable
                     # placeholder ids written by the normalisation, 404ing later modules in a full-suite
                     # re-record. Deterministic fixtures (e.g. `search('Tests')`) re-record identically.
+                    #
+                    # `all` mode never replays, but vcrpy *loads* an existing cassette and *appends*
+                    # live interactions to it rather than replacing them; the stale entries survive and
+                    # win on later replay (first match wins). Delete the file first so the rewrite is a
+                    # true overwrite and the fixture cannot carry old schema/data forward (see #383).
+                    Path(cassette_dir, cassette_name).unlink(missing_ok=True)
                     mode = 'all'
                 elif mode is None:
                     mode = 'none'


### PR DESCRIPTION
Closes #383.

## Problem

A full `hatch run vcr-rewrite tests …` did **not** actually re-record the shared module/session fixture cassettes (`tests/cassettes/fixtures/mod_*.yaml`, `tests/obj_api/cassettes/fixtures/mod_*.yaml`, `sess_*.yaml`) when they already existed on disk. It replayed the stale committed content for them while correctly re-recording the per-test cassettes live — an exit-0, git-modified, but internally inconsistent recording.

## Root cause

`vcr_fixture.setup_vcr` already upgrades the record mode to `all` on `rewrite` so the shared fixtures record live. But vcrpy's `all` mode never *replays* yet still `_load()`s the existing cassette into `self.data` and **appends** the freshly-fetched live interactions rather than replacing them. The file is saved as `[stale_old, fresh_new]` for the same request, and on later replay (`none` mode) `play_response` returns the *first* match — the stale entry. The only way an existing fixture recorded fresh was to delete it first.

## Fix

Delete the fixture cassette in the `rewrite` branch of `setup_vcr` (`Path(cassette_dir, cassette_name).unlink(missing_ok=True)`) before constructing the `all`-mode VCR, making the rewrite a true overwrite (proposed option 1/2 in the issue). This removes the manual `rm tests/cassettes/fixtures/mod_*.yaml` workaround, so the CONTRIBUTING add-a-new-test flow is updated to drop that step.

## Verification

- `hatch run vcr-only tests/test_page.py` → 19 passed offline, including the replay-only `test_icon_attr` (unaffected — it's a per-test cassette pinned via `@pytest.mark.vcr(record_mode='none')`, not a shared fixture).
- Full live re-record requires a Notion token; the change only alters the rewrite (recording) path, never the offline replay path CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)