### PR TITLE
test(vcr): skip test_sync_google_tasks on live re-record when Google creds absent (#385)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ from ultimate_notion.config import (
     ENV_NOTION_TOKEN,
     ENV_ULTIMATE_NOTION_CFG,
     ENV_ULTIMATE_NOTION_DEBUG,
+    get_cfg,
     get_cfg_file,
     get_or_create_cfg,
 )
@@ -555,6 +556,17 @@ def custom_config(request: SubRequest) -> Iterator[Path]:
     else:  # vcr-off and vcr-rewrite
         cfg_path = get_cfg_file()
         with patch.dict(os.environ, {ENV_ULTIMATE_NOTION_CFG: str(cfg_path)}):
+            # Skip (rather than poison real state and the cassette) when the optional Google
+            # OAuth creds are absent during a live re-record. The test body below would otherwise
+            # `rmtree` the sync state, `delete_all_taskslists()` and make live Notion calls before
+            # failing deep inside the Google client. See CONTRIBUTING.md for setting up creds.
+            google = get_cfg().google
+            creds = (google.client_secret_json, google.token_json) if google is not None else (None, None)
+            if any(path is None or not path.exists() for path in creds):
+                pytest.skip(
+                    'Google OAuth credentials (client_secret.json + token.json from the [google] '
+                    'config section) are required to record this test live; see CONTRIBUTING.md.'
+                )
             yield cfg_path
 
 


### PR DESCRIPTION
Fixes #385.

## Problem

During a live `hatch run vcr-rewrite` (or `vcr-off`) without Google OAuth creds, `tests/test_examples.py::test_sync_google_tasks` fails *deep inside the test body* — only when the Google client is built. By then it has already `rmtree`'d the sync state, `delete_all_taskslists()` against the live workspace, made live Notion calls, and pytest-recording has deleted the old cassette to rewrite it, leaving it empty. The cassette then has to be manually restored with `git checkout HEAD -- ...`, even though the test wasn't the target of the re-record.

## Fix

`custom_config`'s live-record branch now reads the `[google]` config and `pytest.skip`s **before** yielding when `client_secret.json` / `token.json` don't exist on disk, with a message pointing at `CONTRIBUTING.md`. Skip rather than hard-error so a whole-suite re-record isn't aborted just because optional Google creds are absent — the other ~200 tests still record. Only `test_sync_google_tasks` requests `custom_config`, so the session-scoped skip is effectively per-test.

## Verification

- `vcr-rewrite` with no creds: `test_sync_google_tasks` skipped with a clear reason, no workspace mutation, committed cassette untouched (verified locally — config has `[google]` but the cred files are absent).
- `vcr-only`: still passes (faked-creds path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)