### PR TITLE
Replace hasattr with type-safe field check in set_attr_none (#338)

### DIFF
--- a/src/ultimate_notion/utils.py
+++ b/src/ultimate_notion/utils.py
@@ -268,7 +268,7 @@ def set_attr_none(
                 raise AttributeError(msg)
 
         last_attr = attrs[-1]
-        if hasattr(curr_obj, last_attr):
+        if isinstance(curr_obj, BaseModel) and last_attr in type(curr_obj).model_fields:
             setattr(curr_obj, last_attr, None)
         elif not missing_ok:
             msg = f'{last_attr} does not exist in {".".join(attrs[:-2]) if len(attrs) > 1 else "the object"}.'


### PR DESCRIPTION
## Description

Replaces the `hasattr` check in `set_attr_none` (`utils.py`) with a type-safe one: the field is nulled only when `curr_obj` is a pydantic `BaseModel` and `last_attr` is a declared field (`last_attr in type(curr_obj).model_fields`), rather than duck-typing with `hasattr` — which also matched methods/properties and could trigger property getters as a side effect. This implements the still-applicable part of issue #338; the original PR's `deepcopy_with_sharing` change is obsolete since that function was inlined in #340 and removed in #343.

### Types of change

Code cleanup / type-safety improvement (no behavior change for the intended call sites).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
