### PR TITLE
docs: document Google Tasks credentials for re-recording test_sync_google_tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,40 @@ You only need this section to run the tests live or to re-record cassettes.
     [`tests/TEST_WORKSPACE.md`](https://github.com/ultimate-notion/ultimate-notion/blob/main/tests/TEST_WORKSPACE.md)
     for exact instructions.
 
+### Set up Google Tasks credentials (optional)
+
+One live test, `test_sync_google_tasks`, exercises the Google Tasks sync adapter and
+therefore needs Google OAuth credentials in addition to your Notion workspace. You only
+need this to **record that one test live**; it **auto-skips when the credentials are
+absent**, so a full `hatch run vcr-rewrite` of the rest of the suite needs no Google
+setup.
+
+**Where the files go.** The `[google]` paths (`client_secret_json` and `token_json`) are
+relative to the directory holding your `config.toml`. The suite uses
+`~/.ultimate-notion/config.toml` by default, so place the files at:
+
+- `~/.ultimate-notion/client_secret.json`
+- `~/.ultimate-notion/token.json`
+
+**How to get `client_secret.json`.** In the [Google Cloud Console]:
+
+1. Create or select a project.
+2. Enable the **Google Tasks API** for it.
+3. Go to **Credentials** → **Create credentials** → **OAuth 2.0 Client ID** and choose
+   application type **Desktop app**.
+4. Download the client JSON and save it as `~/.ultimate-notion/client_secret.json`.
+
+**How `token.json` is produced.** You do not create it by hand. On the first live run the
+adapter's `InstalledAppFlow` opens a browser; sign in with the Google account that holds
+the test task lists and grant the `tasks` scope. The adapter then writes `token.json` next
+to your config. Subsequent runs reuse (and refresh) it.
+
+!!! warning
+    `client_secret.json` and `token.json` are **real secrets**. Keep them only in
+    `~/.ultimate-notion/` and never commit them. The cassette scrubber already redacts the
+    Google `client_secret`, `token` and `refresh_token` values from recordings, but the
+    files themselves must stay out of the repo.
+
 ### Add a new live (VCR) test
 
 The committed cassettes are one coherent recording of a single workspace, so you
@@ -282,3 +316,4 @@ workspace-specific and are **not** normalised, so a brand-new test that asserts 
 [mkdocs]: https://www.mkdocs.org/
 [VCR.py]: https://vcrpy.readthedocs.io/
 [My integrations]: https://www.notion.so/my-integrations
+[Google Cloud Console]: https://console.cloud.google.com/


### PR DESCRIPTION
## Description

Adds a "Set up Google Tasks credentials (optional)" subsection to `CONTRIBUTING.md` so contributors doing a full cassette re-record have a signpost for the Google OAuth credentials `test_sync_google_tasks` needs. It documents where `client_secret.json` / `token.json` live (relative to `config.toml`, default `~/.ultimate-notion/`), how to obtain `client_secret.json` from the Google Cloud Console (enable Tasks API → Desktop-app OAuth client), how `token.json` is produced by the adapter's `InstalledAppFlow` on first run, that the test auto-skips when creds are absent, and that the files are real secrets to keep out of the repo. Closes #386.

### Types of change

Documentation.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded. (Docs-only change; no tests affected.)
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.