### PR TITLE
refactor: replace dynamic getattr with type-safe attribute access

### DIFF
--- a/src/ultimate_notion/option.py
+++ b/src/ultimate_notion/option.py
@@ -168,7 +168,12 @@ def check_for_updates(old: list[Option], new: list[Option]) -> dict[str, list[st
         old_opt = old_by_name[name]
         new_opt = new_by_name[name]
 
-        for attr in ('name', 'color', 'description'):
-            if getattr(old_opt, attr) != getattr(new_opt, attr):
+        changed_attrs = {
+            'name': old_opt.name != new_opt.name,
+            'color': old_opt.color != new_opt.color,
+            'description': old_opt.description != new_opt.description,
+        }
+        for attr, changed in changed_attrs.items():
+            if changed:
                 updates.setdefault(name, []).append(attr)
     return updates

--- a/src/ultimate_notion/schema.py
+++ b/src/ultimate_notion/schema.py
@@ -804,9 +804,10 @@ class SchemaType(ABCMeta):
         props = cast(list[Property], namespace.setdefault('_props', []))
 
         for b in bases:
-            for prop in getattr(b, '_props', []):
-                prop = deepcopy(prop)
-                props.append(prop)
+            if isinstance(b, SchemaType):
+                for prop in b._props:
+                    prop = deepcopy(prop)
+                    props.append(prop)
 
         for attr, val in list(namespace.items()):
             if isinstance(val, Property):


### PR DESCRIPTION
## Description

Replaces two dynamic `getattr`-with-default patterns with static, type-checked attribute access. In `schema.py`, the `SchemaType` metaclass now narrows base classes with `isinstance(b, SchemaType)` before reading `_props`, so the type checker verifies the attribute instead of treating it as `Any`. In `option.py`, `check_for_updates` compares each `Option`'s `name`/`color`/`description` directly rather than iterating a string tuple via `getattr`. Behaviour is unchanged: schema inheritance still propagates properties from base classes, and `check_for_updates` still reports the same changed attributes. Verified offline since the change is purely a refactor with no API interaction.

### Types of change

Refactor / code-quality improvement (no behaviour change).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [ ] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
