### PR TITLE
test(vcr): dedup identical interactions when saving shared fixture cassettes (#388)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ from _pytest.fixtures import SubRequest
 from google.auth.exceptions import RefreshError
 from vcr import VCR  # type: ignore[import-untyped]
 from vcr import mode as vcr_mode
+from vcr.persisters.filesystem import FilesystemPersister  # type: ignore[import-untyped]
 
 import ultimate_notion as uno
 from ultimate_notion import Database, NumberFormat, Option, Page, Session, User, schema
@@ -485,6 +486,34 @@ def normalize_response(response: dict[str, Any]) -> dict[str, Any]:
     return response
 
 
+class DedupFilesystemPersister(FilesystemPersister):  # type: ignore[misc]  # vcr is untyped
+    """Collapse byte-identical interactions to one before writing the cassette (#388).
+
+    The shared module-fixture cassettes (`mod_*.yaml`) are a single cassette opened in `all`
+    mode once per test module that resolves the fixture. `all` mode loads the existing cassette
+    and *appends* the new recording rather than replacing it, so a full re-record accumulates one
+    identical copy of the same normalised request per module (~20x bloat). Replay is first-match-wins,
+    so every copy past the first is dead weight. Dropping exact `(request, response)` duplicates is
+    behaviour-preserving — a single interaction already serves every module on offline replay — and
+    keeps the re-record diff small and reviewable. Non-identical interactions (e.g. distinct requests,
+    or the same request with paginated/differing responses) keep separate signatures and are retained.
+    """
+
+    @staticmethod
+    def save_cassette(cassette_path: Any, cassette_dict: dict[str, Any], serializer: Any) -> None:
+        seen: set[str] = set()
+        requests, responses = [], []
+        for request, response in zip(cassette_dict['requests'], cassette_dict['responses'], strict=True):
+            signature = json.dumps([request._to_dict(), response], sort_keys=True, default=str)
+            if signature in seen:
+                continue
+            seen.add(signature)
+            requests.append(request)
+            responses.append(response)
+        deduped = {**cassette_dict, 'requests': requests, 'responses': responses}
+        FilesystemPersister.save_cassette(cassette_path, deduped, serializer)
+
+
 def build_vcr_config() -> dict[str, Any]:
     """Build the pytest-recording config (also reused when recording from module-level fixtures)."""
     return {
@@ -623,6 +652,9 @@ def vcr_fixture(
                     mode = 'none'
                 vcr = VCR(record_mode=vcr_mode(mode), **vcr_config)
                 register_notion_matchers(vcr)
+                # Dedup identical interactions on save so `all`-mode re-records of the shared
+                # module-fixture cassettes don't accumulate one redundant copy per module (#388).
+                vcr.register_persister(DedupFilesystemPersister)
 
             return vcr, cassette_name
 


### PR DESCRIPTION
Closes #388.

## Problem

After a full `vcr-rewrite`, each shared module-fixture cassette (`tests/cassettes/fixtures/mod_*.yaml`, `tests/obj_api/cassettes/fixtures/mod_*.yaml`) grows ~20x with **byte-for-byte identical** interactions (e.g. `mod_contacts_db`: 1 → 21 interactions). These `mod_*.yaml` files are a single cassette shared across test modules, and the re-record path forces vcrpy `all` mode, which loads the existing cassette and **appends** a fresh interaction every time the fixture is resolved (once per module). On replay it's first-match-wins, so the extra copies are dead weight — pure repo bloat and a ~70k-line unreviewable re-record diff.

## Fix

Register a `DedupFilesystemPersister` on the VCR used by the fixture-recording path. On save it drops exact `(request, response)` duplicates, keeping the first. This is behaviour-preserving (a single interaction already serves every module on offline replay) and complements #383's delete-before-record, which removes *stale*, non-identical interactions. Non-identical interactions (distinct requests, or the same request with paginated/differing responses) keep separate signatures and are retained.

## Verification

- Offline `vcr-only` stays green: **204 passed, 14 skipped**.
- `mypy`, `ty`, and `ruff` all pass on the change.
- Unit-checked the persister directly: 21 identical + 1 distinct interaction → 2 after dedup.
- Re-recorded `mod_*.yaml` fixtures will contain 1 interaction per distinct request, shrinking the re-record fixture diff by ~20x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)