### PR TITLE
refactor: replace getattr file.name duck-typing with type-safe access

### DIFF
--- a/src/ultimate_notion/file.py
+++ b/src/ultimate_notion/file.py
@@ -269,11 +269,15 @@ def get_mime_type(file: BinaryIO | str | Path) -> str:
         mime_type = _get_mime_type(file)
     elif isinstance(file, Path):
         mime_type = _get_mime_type(file.name)
-    elif file_name := getattr(file, 'name', None):  # BinaryIO has a 'name' unless it is e.g. a BytesIO
-        mime_type = _get_mime_type(file_name)
     else:
-        msg = 'Cannot determine MIME type without filename or file.name attribute.'
-        raise ValueError(msg)
+        try:
+            file_name = file.name  # BinaryIO has a 'name' unless it is e.g. a BytesIO
+        except AttributeError:
+            file_name = ''
+        if not file_name:
+            msg = 'Cannot determine MIME type without filename or file.name attribute.'
+            raise ValueError(msg)
+        mime_type = _get_mime_type(file_name)
 
     # correct some MIME types to match Notion's expectations
     mime_type_map = {

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -410,7 +410,11 @@ class Session:
 
     def upload(self, file: BinaryIO, *, file_name: str | None = None, mime_type: str | None = None) -> UploadedFile:
         """Upload a file to Notion."""
-        file_name = file_name if file_name is not None else os.path.basename(getattr(file, 'name', 'unknown_file'))
+        if file_name is None:
+            try:
+                file_name = os.path.basename(file.name)  # BinaryIO has a 'name' unless it is e.g. a BytesIO
+            except AttributeError:
+                file_name = 'unknown_file'
         mime_type = mime_type if mime_type is not None else get_mime_type(file)
         file_size = get_file_size(file)
         if mime_type == 'application/octet-stream':


### PR DESCRIPTION
## Description

The `getattr(file, 'name', ...)` calls in `get_mime_type` and `Session.upload` existed only as a runtime guard against `io.BytesIO`, which lacks a `name` attribute. Since typeshed declares `BinaryIO.name -> str`, direct `file.name` access is statically type-safe (verified with `ty`), whereas `getattr` discarded that type info and returned `Any`. This reads `file.name` directly, guarded by `try/except AttributeError`, preserving the existing fallback behaviour. Continues the type-safe attribute-access series (#391, #389).

### Types of change

Refactor (no behaviour change).

## Checklist
- [ ] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)