### PR TITLE
feat: Flesh out multi-source Database support

### DIFF
--- a/docs/usage/db_introduction.md
+++ b/docs/usage/db_introduction.md
@@ -172,8 +172,8 @@ keep in mind that some methods are just stubs.
 ## Databases: containers of data sources
 
 Since Notion API version 2025-09-03, a data source always lives inside a *database* container, and a
-single database can hold more than one data source. Ultimate Notion keeps that container transparent
-— a data source presents as a direct child of its page — but exposes it as a [Database] object
+single database can hold more than one data source. Ultimate Notion keeps that container transparent,
+so a data source presents as a direct child of its page, but exposes it as a [Database] object
 whenever you need to work with the container itself.
 
 Use [create_db] to create a database together with its first data source:

--- a/docs/usage/db_introduction.md
+++ b/docs/usage/db_introduction.md
@@ -169,6 +169,49 @@ To reload the view, i.e., re-execute the query that led to the view, use [reload
 Find out more about the functionality of [View] by reading the API references, but
 keep in mind that some methods are just stubs.
 
+## Databases: containers of data sources
+
+Since Notion API version 2025-09-03, a data source always lives inside a *database* container, and a
+single database can hold more than one data source. Ultimate Notion keeps that container transparent
+— a data source presents as a direct child of its page — but exposes it as a [Database] object
+whenever you need to work with the container itself.
+
+Use [create_db] to create a database together with its first data source:
+
+```python
+class Item(uno.Schema, db_title='Items'):
+    name = uno.PropType.Title('Name')
+
+class Customer(uno.Schema, db_title='Customers'):
+    name = uno.PropType.Title('Name')
+
+shop_db = notion.create_db(parent=root_page, schema=Item)
+assert len(shop_db.data_sources) == 1
+```
+
+Add further data sources with [add_ds] and remove them again with [delete_ds]:
+
+```python
+customers_ds = shop_db.create_ds(schema=Customer)
+assert {ds.title for ds in shop_db.data_sources} == {'Items', 'Customers'}
+
+shop_db.delete_ds(customers_ds)
+assert [ds.title for ds in shop_db.data_sources] == ['Items']
+```
+
+Given a data source, you can always retrieve its container database via its `database_id`:
+
+```python
+items_ds = shop_db.data_sources.item()
+assert notion.get_db(items_ds.database_id) == shop_db
+```
+
+Finally, delete the whole database (and all of its data sources) again:
+
+```python
+shop_db.delete()
+```
+
 [DataSource object]: ../../reference/ultimate_notion/database/#ultimate_notion.database.DataSource
 [get_all_pages]: ../../reference/ultimate_notion/database/#ultimate_notion.database.DataSource.get_all_pages
 [title]: ../../reference/ultimate_notion/database/#ultimate_notion.database.DataContainer.title
@@ -191,3 +234,7 @@ keep in mind that some methods are just stubs.
 [create_ds]: ../../reference/ultimate_notion/session/#ultimate_notion.session.Session.create_ds
 [create_page]: ../../reference/ultimate_notion/database/#ultimate_notion.database.DataSource.create_page
 [schema]: ../../reference/ultimate_notion/schema/#ultimate_notion.schema.Schema
+[Database]: ../../reference/ultimate_notion/database/#ultimate_notion.database.Database
+[create_db]: ../../reference/ultimate_notion/session/#ultimate_notion.session.Session.create_db
+[add_ds]: ../../reference/ultimate_notion/database/#ultimate_notion.database.Database.create_ds
+[delete_ds]: ../../reference/ultimate_notion/database/#ultimate_notion.database.Database.delete_ds

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -376,9 +376,14 @@ class Database(DataContainer[obj_blocks.Database], wraps=obj_blocks.Database):
 
     @property
     def data_sources(self) -> SList[DataSource]:
-        """Return all data sources in this database."""
+        """Return all data sources in this database.
+
+        Trashed data sources are excluded: Notion keeps them in the container's raw list even after
+        they are moved to the trash, so they are filtered out here (use `restore_ds()` to bring one
+        back).
+        """
         session = get_active_session()
-        return SList(session.get_ds(ds.id) for ds in self.obj_ref.data_sources)
+        return SList(ds for ds in (session.get_ds(ds.id) for ds in self.obj_ref.data_sources) if not ds.is_deleted)
 
     def create_ds(self, *, schema: type[Schema] | None = None, title: str | None = None) -> DataSource:
         """Add a new data source to this database.
@@ -405,7 +410,6 @@ class Database(DataContainer[obj_blocks.Database], wraps=obj_blocks.Database):
             msg = f'Data source `{ds.id}` does not belong to database `{self.id}`.'
             raise InvalidAPIUsageError(msg)
         session.api.data_sources.update(ds.obj_ref, in_trash=True)
-        self.obj_ref = session.api.databases.retrieve(self.id)  # refresh the `data_sources` list
         return ds
 
     def restore_ds(self, ds: DataSource) -> DataSource:
@@ -415,7 +419,6 @@ class Database(DataContainer[obj_blocks.Database], wraps=obj_blocks.Database):
             msg = f'Data source `{ds.id}` does not belong to database `{self.id}`.'
             raise InvalidAPIUsageError(msg)
         session.api.data_sources.update(ds.obj_ref, in_trash=False)
-        self.obj_ref = session.api.databases.retrieve(self.id)  # refresh the `data_sources` list
         return ds
 
     def reload(self) -> Self:

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -380,6 +380,69 @@ class Database(DataContainer[obj_blocks.Database], wraps=obj_blocks.Database):
         session = get_active_session()
         return SList(session.get_ds(ds.id) for ds in self.obj_ref.data_sources)
 
+    def create_ds(self, *, schema: type[Schema] | None = None, title: str | None = None) -> DataSource:
+        """Add a new data source to this database.
+
+        In case a title and a schema are provided, the title overrides the schema's `db_title`. If no
+        schema is given, a default single-title schema is used. Use `delete_ds()` to remove one again.
+        """
+        session = get_active_session()
+        title_obj, schema_dct, _ = session._build_ds_create_args(schema, title)
+        ds_obj = session.api.data_sources.create(parent=self.obj_ref, schema=schema_dct, title=title_obj)
+        ds = session._bind_new_ds(ds_obj, schema)
+        self.obj_ref = session.api.databases.retrieve(self.id)  # refresh the `data_sources` list
+        return ds
+
+    def delete_ds(self, ds: DataSource) -> DataSource:
+        """Remove (move to trash) a single data source from this database.
+
+        The data source's siblings and the database container itself are left untouched. To delete the
+        whole database (and all its data sources), use `delete()`. Restore a removed data source with
+        `restore_ds()`.
+        """
+        session = get_active_session()
+        if ds.database_id != self.id:
+            msg = f'Data source `{ds.id}` does not belong to database `{self.id}`.'
+            raise InvalidAPIUsageError(msg)
+        session.api.data_sources.update(ds.obj_ref, in_trash=True)
+        self.obj_ref = session.api.databases.retrieve(self.id)  # refresh the `data_sources` list
+        return ds
+
+    def restore_ds(self, ds: DataSource) -> DataSource:
+        """Restore a data source previously removed from this database with `delete_ds()`."""
+        session = get_active_session()
+        if ds.database_id != self.id:
+            msg = f'Data source `{ds.id}` does not belong to database `{self.id}`.'
+            raise InvalidAPIUsageError(msg)
+        session.api.data_sources.update(ds.obj_ref, in_trash=False)
+        self.obj_ref = session.api.databases.retrieve(self.id)  # refresh the `data_sources` list
+        return ds
+
+    def reload(self) -> Self:
+        """Reload this database from Notion, refreshing its data sources and metadata."""
+        session = get_active_session()
+        self.obj_ref = session.api.databases.retrieve(self.id)
+        return self
+
+    def delete(self) -> Self:
+        """Delete (move to trash) this database and all of its data sources."""
+        if not self.is_deleted:
+            session = get_active_session()
+            block_obj = session.api.blocks.delete(self.id)
+            self.obj_ref.archived = block_obj.archived  # ToDo: Remove when `archived` is completely deprecated
+            self.obj_ref.in_trash = block_obj.in_trash
+            self._delete_me_from_parent()
+        return self
+
+    def restore(self) -> Self:
+        """Restore this database from trash."""
+        if self.is_deleted:
+            session = get_active_session()
+            block_obj = session.api.blocks.restore(self.id)
+            self.obj_ref.archived = block_obj.archived  # ToDo: Remove when `archived` is completely deprecated
+            self.obj_ref.in_trash = block_obj.in_trash
+        return self
+
     @property
     def query(self) -> Query:
         """Return a Query object of the database if it has a single data source."""

--- a/src/ultimate_notion/obj_api/endpoints.py
+++ b/src/ultimate_notion/obj_api/endpoints.py
@@ -231,6 +231,7 @@ class DataSourcesEndpoint(Endpoint):
         title: list[RichTextBaseObject] | None = None,
         description: list[RichTextBaseObject] | None = None,
         inline: bool | None = None,
+        in_trash: bool | None = None,
     ) -> dict[str, Any]:
         """Build a request payload from the given items.
 
@@ -256,21 +257,29 @@ class DataSourcesEndpoint(Endpoint):
         if inline is not None:
             request['is_inline'] = inline
 
+        if in_trash is not None:
+            request['in_trash'] = in_trash
+
         return request
 
     # https://developers.notion.com/reference/create-a-data-source
     def create(
         self,
-        parent: Page,
+        parent: Database,
         schema: Mapping[str, Property],
         *,
         title: list[RichTextBaseObject] | None = None,
-        inline: bool = False,
     ) -> DataSource:
-        """Add a data source to the given Page parent."""
-        parent_ref = PageRef.build(parent)
-        _logger.debug(f'Creating new data source below page with id `{parent_ref.page_id}`.')
-        request = self._build_request(parent=parent_ref, schema=schema, title=title, inline=inline)
+        """Add an additional data source to an existing database container.
+
+        In API version 2025-09-03+ a data source's parent is always a database. To create the
+        *first* data source under a page, create the database via `DatabasesEndpoint.create`
+        (which seeds it with an initial data source); this endpoint only adds further data
+        sources to a database that already exists.
+        """
+        parent_ref = DatabaseRef.build(parent)
+        _logger.debug(f'Creating new data source in database with id `{parent_ref.database_id}`.')
+        request = self._build_request(parent=parent_ref, schema=schema, title=title)
         data = self.raw_api.create(**request)
         return DataSource.model_validate(data)
 
@@ -290,16 +299,21 @@ class DataSourcesEndpoint(Endpoint):
         description: list[RichTextBaseObject] | None = None,
         inline: bool | None = None,
         schema: Mapping[str, Property | RenameProp | None] | None = None,
+        in_trash: bool | None = None,
     ) -> None:
         """Update the DataSource object on the server.
 
-        The data source info will be updated to the latest version from the server.
+        The data source info will be updated to the latest version from the server. Pass
+        `in_trash=True`/`False` to trash or restore an individual data source (the data source's
+        containing database is left untouched).
 
         API reference: https://developers.notion.com/reference/update-a-data-source
         """
         _logger.debug(f'Updating info of data source with id `{ds.id}`.')
 
-        if request := self._build_request(schema=schema, title=title, description=description, inline=inline):
+        if request := self._build_request(
+            schema=schema, title=title, description=description, inline=inline, in_trash=in_trash
+        ):
             data = self._as_dict(self.raw_api.update(str(ds.id), **request))
             ds.update(**data)
 

--- a/src/ultimate_notion/session.py
+++ b/src/ultimate_notion/session.py
@@ -219,18 +219,9 @@ class Session:
         # 2. initialize self-referencing forward relations
         # 3. create properties with self-referencing forward relations using an update call
         # 4. update the backward references, i.e. two-way relations, using an update call
-        if title is not None:
-            title = Text(title)
-        elif schema is not None and schema._db_title is not None:
-            title = schema._db_title
-        else:
-            title = None  # Anonymous data source without a title.
-
-        ds_schema: type[Schema] = cast(type[Schema], DefaultSchema) if schema is None else schema
+        title_obj, schema_dct, ds_schema = self._build_ds_create_args(schema, title)
         _logger.info(f'Creating data source `{title or "<NoTitle>"}` in `{parent.title}` with schema:\n{ds_schema}')
 
-        title_obj = title.obj_ref if title is not None else None
-        schema_dct = {prop.name: prop.obj_ref for prop in ds_schema.get_props() if prop._is_init_ready}
         # The Create Database endpoint creates the container and its initial data source in one call.
         db_obj = self.api.databases.create(parent=parent.obj_ref, schema=schema_dct, title=title_obj, inline=inline)
         # `description` lives on the database container; set it before retrieving the data source so the
@@ -238,17 +229,54 @@ class Session:
         if schema and schema._db_desc:
             self.api.databases.update(db_obj, description=schema._db_desc.obj_ref)
         ds_obj = self.api.data_sources.retrieve(db_obj.data_sources[0].id)
+        return self._bind_new_ds(ds_obj, schema)
 
+    @staticmethod
+    def _build_ds_create_args(
+        schema: type[Schema] | None, title: str | None
+    ) -> tuple[Any, dict[str, Any], type[Schema]]:
+        """Resolve the serialized title, property schema and effective schema for a data-source create.
+
+        `title` (if given) overrides the schema's `db_title`; otherwise the schema's `db_title` is used,
+        falling back to an anonymous (untitled) data source. When no schema is given, the `DefaultSchema`
+        (a single title property) is used.
+        """
+        title_text: Text | None
+        if title is not None:
+            title_text = Text(title)
+        elif schema is not None and schema._db_title is not None:
+            title_text = schema._db_title
+        else:
+            title_text = None  # Anonymous data source without a title.
+
+        ds_schema: type[Schema] = cast(type[Schema], DefaultSchema) if schema is None else schema
+        title_obj = title_text.obj_ref if title_text is not None else None
+        schema_dct = {prop.name: prop.obj_ref for prop in ds_schema.get_props() if prop._is_init_ready}
+        return title_obj, schema_dct, ds_schema
+
+    def _bind_new_ds(self, ds_obj: obj_blocks.DataSource, schema: type[Schema] | None) -> DataSource:
+        """Wrap a freshly created data-source object, bind its schema and initialize relations."""
         ds: DataSource = DataSource.wrap_obj_ref(ds_obj)
-
         if schema:
             ds._set_schema(schema, during_init=True)  # schema is thus bound to the data source
             schema._init_self_refs()
             schema._init_self_ref_rollups()
             schema._update_bwd_rels()
-
         self.cache[ds.id] = ds
         return ds
+
+    def create_db(
+        self, parent: Page, *, schema: type[Schema] | None = None, title: str | None = None, inline: bool = False
+    ) -> Database:
+        """Create a new database (a container of data sources) within a page.
+
+        In API version 2025-09-03+ every data source lives inside a database container. This creates
+        that container together with its first data source (from `schema`, or a default single-title
+        schema) and returns the `Database`. Use `db.create_ds(...)` to add further data sources, and
+        `db.data_sources` to list them. Pass `inline=True` to display the database inline on the page.
+        """
+        ds = self.create_ds(parent, schema=schema, title=title, inline=inline)
+        return self.get_db(ds.database_id)
 
     def search_ds(
         self, name: str | None = None, *, exact: bool = True, reverse: bool = False, deleted: bool = False

--- a/tests/cassettes/test_database/test_create_db.yaml
+++ b/tests/cassettes/test_database/test_create_db.yaml
@@ -1,0 +1,474 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "title": [{"type": "text", "plain_text": "My Articles", "annotations": {"bold":
+      false, "italic": false, "strikethrough": false, "underline": false, "code":
+      false}, "text": {"content": "My Articles"}}], "is_inline": false, "initial_data_source":
+      {"properties": {"Name": {"type": "title", "title": {}}, "Cost": {"type": "number",
+      "number": {"format": "dollar"}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '407'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"d3113c7b-034d-42a7-8455-a750af96675d","title":[{"type":"text","text":{"content":"My
+      Articles","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"My
+      Articles","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:18:42.848+00:00","last_edited_time":"2026-06-27T08:18:42.848+00:00","data_sources":[{"id":"5773b9fd-5a64-4073-9e8a-4d126df2eb20","name":"My
+      Articles"}],"icon":null,"cover":null,"url":"https://www.notion.so/d3113c7b034d42a78455a750af96675d","public_url":null,"archived":false,"request_id":"1f9c88a0-4791-4462-97c8-4210b3d6872d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305c8b953ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 1f9c88a0-4791-4462-97c8-4210b3d6872d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/5773b9fd-5a64-4073-9e8a-4d126df2eb20
+  response:
+    content: '{"object":"data_source","id":"5773b9fd-5a64-4073-9e8a-4d126df2eb20","cover":null,"icon":null,"created_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:18:00.000Z","title":[{"type":"text","text":{"content":"My
+      Articles","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"My
+      Articles","href":null}],"description":[],"is_inline":false,"properties":{"Cost":{"id":"P_pn","name":"Cost","description":null,"type":"number","number":{"format":"dollar"}},"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"d3113c7b-034d-42a7-8455-a750af96675d"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/d3113c7b034d42a78455a750af96675d","public_url":null,"in_trash":false,"archived":false,"request_id":"4f29a67a-aeab-4de3-9479-ace88e18769d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305cdaa07ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 4f29a67a-aeab-4de3-9479-ace88e18769d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/d3113c7b-034d-42a7-8455-a750af96675d
+  response:
+    content: '{"object":"database","id":"d3113c7b-034d-42a7-8455-a750af96675d","title":[{"type":"text","text":{"content":"My
+      Articles","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"My
+      Articles","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:18:42.848+00:00","last_edited_time":"2026-06-27T08:18:42.848+00:00","data_sources":[{"id":"5773b9fd-5a64-4073-9e8a-4d126df2eb20","name":"My
+      Articles"}],"icon":null,"cover":null,"url":"https://www.notion.so/d3113c7b034d42a78455a750af96675d","public_url":null,"archived":false,"request_id":"a2c29f3d-c114-471f-84fe-7ea13909d61b"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305cf1ca7ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - a2c29f3d-c114-471f-84fe-7ea13909d61b
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/00000000-0000-4000-8000-000000000001
+  response:
+    content: '{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false,"request_id":"fc71f322-226f-4013-8e1a-91a48d7d0c09"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305d0c895ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - fc71f322-226f-4013-8e1a-91a48d7d0c09
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/d3113c7b-034d-42a7-8455-a750af96675d
+  response:
+    content: '{"object":"block","id":"d3113c7b-034d-42a7-8455-a750af96675d","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T08:18:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"My
+      Articles"},"archived":true,"request_id":"6dbaf1a8-8e73-4d66-8251-42a55ea1b8aa"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305d25bd4ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 6dbaf1a8-8e73-4d66-8251-42a55ea1b8aa
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"archived":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '18'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/blocks/d3113c7b-034d-42a7-8455-a750af96675d
+  response:
+    content: '{"object":"block","id":"d3113c7b-034d-42a7-8455-a750af96675d","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T08:18:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":false,"type":"child_database","child_database":{"title":"My
+      Articles"},"archived":false,"request_id":"a62c69cd-ec48-4f06-a872-f418b1ad5afa"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305d7fefcef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - a62c69cd-ec48-4f06-a872-f418b1ad5afa
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/d3113c7b-034d-42a7-8455-a750af96675d
+  response:
+    content: '{"object":"block","id":"d3113c7b-034d-42a7-8455-a750af96675d","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T08:18:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"My
+      Articles"},"archived":true,"request_id":"085fda5b-b9b9-44f6-a9db-9370b1d6238f"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305ddaa2bef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 085fda5b-b9b9-44f6-a9db-9370b1d6238f
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_database/test_db_add_remove_data_source.yaml
+++ b/tests/cassettes/test_database/test_db_add_remove_data_source.yaml
@@ -1,0 +1,601 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "title": [{"type": "text", "plain_text": "Items", "annotations": {"bold": false,
+      "italic": false, "strikethrough": false, "underline": false, "code": false},
+      "text": {"content": "Items"}}], "is_inline": false, "initial_data_source": {"properties":
+      {"Name": {"type": "title", "title": {}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '341'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:18:46.696+00:00","last_edited_time":"2026-06-27T08:18:46.696+00:00","data_sources":[{"id":"94b0a32b-f503-484b-9a8b-672e2e72592d","name":"Items"}],"icon":null,"cover":null,"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"archived":false,"request_id":"1a5283f1-9cf0-4de4-a21c-4e0db5fbb948"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305e0af7fef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 1a5283f1-9cf0-4de4-a21c-4e0db5fbb948
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/94b0a32b-f503-484b-9a8b-672e2e72592d
+  response:
+    content: '{"object":"data_source","id":"94b0a32b-f503-484b-9a8b-672e2e72592d","cover":null,"icon":null,"created_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:18:00.000Z","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"in_trash":false,"archived":false,"request_id":"a0b288c7-a367-4947-89ab-2d1f71d4f46d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305e8f891ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - a0b288c7-a367-4947-89ab-2d1f71d4f46d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad
+  response:
+    content: '{"object":"database","id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:18:46.696+00:00","last_edited_time":"2026-06-27T08:18:46.696+00:00","data_sources":[{"id":"94b0a32b-f503-484b-9a8b-672e2e72592d","name":"Items"}],"icon":null,"cover":null,"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"archived":false,"request_id":"6bf3642a-7365-4067-a5cf-9276c8c6d986"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305ea9d08ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 6bf3642a-7365-4067-a5cf-9276c8c6d986
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"parent": {"type": "database_id", "database_id": "4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad"},
+      "properties": {"Name": {"type": "title", "title": {}}}, "title": [{"type": "text",
+      "plain_text": "People", "annotations": {"bold": false, "italic": false, "strikethrough":
+      false, "underline": false, "code": false}, "text": {"content": "People"}}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '309'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/data_sources
+  response:
+    content: '{"object":"data_source","id":"38c9ce7b-60a4-8147-a479-000b39a80011","cover":null,"icon":null,"created_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:18:00.000Z","title":[{"type":"text","text":{"content":"People","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"People","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"in_trash":false,"archived":false,"request_id":"507a963e-95db-42ba-853e-d8f91b83788c"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305ec3fd0ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 507a963e-95db-42ba-853e-d8f91b83788c
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad
+  response:
+    content: '{"object":"database","id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:18:46.696+00:00","last_edited_time":"2026-06-27T08:18:46.696+00:00","data_sources":[{"id":"94b0a32b-f503-484b-9a8b-672e2e72592d","name":"Items"},{"id":"38c9ce7b-60a4-8147-a479-000b39a80011","name":"People"}],"icon":null,"cover":null,"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"archived":false,"request_id":"901d7804-72de-46cf-9cc7-43bf6ee9d89c"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305ee9c68ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 901d7804-72de-46cf-9cc7-43bf6ee9d89c
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"in_trash":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '17'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/data_sources/38c9ce7b-60a4-8147-a479-000b39a80011
+  response:
+    content: '{"object":"data_source","id":"38c9ce7b-60a4-8147-a479-000b39a80011","cover":null,"icon":null,"created_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:18:00.000Z","title":[{"type":"text","text":{"content":"People","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"People","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"in_trash":true,"archived":true,"request_id":"06ed32ef-5090-40df-8e3c-330a197547f3"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305f119a4ef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 06ed32ef-5090-40df-8e3c-330a197547f3
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"in_trash":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '18'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/data_sources/38c9ce7b-60a4-8147-a479-000b39a80011
+  response:
+    content: '{"object":"data_source","id":"38c9ce7b-60a4-8147-a479-000b39a80011","cover":null,"icon":null,"created_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:18:00.000Z","title":[{"type":"text","text":{"content":"People","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"People","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/4ec0d58c2a3a415aac7aeac030d6b7ad","public_url":null,"in_trash":false,"archived":false,"request_id":"1c3e4fa4-ab0f-4436-b75b-d3573a01a076"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305f67c4cef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 1c3e4fa4-ab0f-4436-b75b-d3573a01a076
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad
+  response:
+    content: '{"object":"block","id":"4ec0d58c-2a3a-415a-ac7a-eac030d6b7ad","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T08:18:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"Items"},"archived":true,"request_id":"7e2d9be3-9aa3-4dce-a9cd-79f3cae0c575"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12305fd1a5aef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 7e2d9be3-9aa3-4dce-a9cd-79f3cae0c575
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/00000000-0000-4000-8000-000000000001
+  response:
+    content: '{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false,"request_id":"d5bb002e-1858-4960-873e-9969a1f40fbf"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1230601cb2aef3c-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - d5bb002e-1858-4960-873e-9969a1f40fbf
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_docs_py_snippets/test_db_introduction.yaml
+++ b/tests/cassettes/test_docs_py_snippets/test_db_introduction.yaml
@@ -26,17 +26,11 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/search
   response:
-    content: "{\"object\":\"list\",\"results\":[{\"object\":\"data_source\",\"id\":\"2460222e-4d31-40b0-86c9-33a2e89e8415\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-27T05:52:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-27T05:52:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Customer
-      DB 42\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Customer
-      DB 42\",\"href\":null}],\"description\":[{\"type\":\"text\",\"text\":{\"content\":\"Database
-      of all our beloved customers.\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Database
-      of all our beloved customers.\",\"href\":null}],\"is_inline\":false,\"properties\":{\"Items
-      Purchased\":{\"id\":\"fahe\",\"name\":\"Items Purchased\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"ea2b04c4-6dd4-4315-93ea-3dda12fd770a\",\"data_source_id\":\"b2b43262-67a8-47c9-bd02-08a6e225311e\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Bought
-      by\",\"synced_property_id\":\"qC%7Cb\"}}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"94b48120-b815-4de5-8f47-4b8c0d4a74c3\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/94b48120b8154de58f474b8c0d4a74c3\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8168-ba4d-000b1ee50a86\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-25T16:54:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Formula
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8168-ba4d-000b1ee50a86\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-25T16:54:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Formula
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Formula
       DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Date
       Source\":{\"id\":\"CNpy\",\"name\":\"Date Source\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Tags\":{\"id\":\"DUnB\",\"name\":\"Tags\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"285007eb-456a-4eda-8ac6-64c70c57f39d\",\"name\":\"In
-      Progress\",\"color\":\"pink\",\"description\":null},{\"id\":\"f1d3aded-bb84-437e-9fa8-a6c7e24a2f29\",\"name\":\"Done\",\"color\":\"gray\",\"description\":null}]}},\"Date\":{\"id\":\"%5Ckxk\",\"name\":\"Date\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:CNpy:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}\"}},\"String\":{\"id\":\"dvYQ\",\"name\":\"String\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"format({{notion:block_property:title:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}})\"}},\"Checkbox\":{\"id\":\"hlGb\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}.includes(\\\"Done\\\")\"}},\"Number\":{\"id\":\"x%40zJ\",\"name\":\"Number\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}.length()\"}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000d\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000d\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T16:31:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T16:32:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Item
+      Progress\",\"color\":\"pink\",\"description\":null},{\"id\":\"f1d3aded-bb84-437e-9fa8-a6c7e24a2f29\",\"name\":\"Done\",\"color\":\"gray\",\"description\":null}]}},\"Date\":{\"id\":\"%5Ckxk\",\"name\":\"Date\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:CNpy:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}\"}},\"String\":{\"id\":\"dvYQ\",\"name\":\"String\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"format({{notion:block_property:title:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}})\"}},\"Checkbox\":{\"id\":\"hlGb\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}.includes(\\\"Done\\\")\"}},\"Number\":{\"id\":\"x%40zJ\",\"name\":\"Number\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}.length()\"}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000d\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000d\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T16:31:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T16:32:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Item
       DB for max relation items\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Item
       DB for max relation items\",\"href\":null}],\"description\":[{\"type\":\"text\",\"text\":{\"content\":\"Database
       of all items\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Database
@@ -50,7 +44,7 @@ interactions:
       Purchased\":{\"id\":\"r%7DaJ\",\"name\":\"Items Purchased\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"9528650b-a37a-41a9-8dc2-a8fd21525122\",\"data_source_id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Bought
       by\",\"synced_property_id\":\"F%3Ebg\"}}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"c05c7705-1005-46af-89f7-3f6d8b87049f\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/c05c7705100546af89f73f6d8b87049f\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"e0fffc4a-19d0-4886-8ff3-4b22a7977dd5\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T12:41:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T12:42:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"DB
       test with 110 pages\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"DB
-      test with 110 pages\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"f1803c3d-6886-42c9-b073-de3de89868e9\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/f1803c3d688642c9b073de3de89868e9\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8076-9982-000bc09a66e4\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T21:33:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-18T21:33:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Wiki
+      test with 110 pages\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"f1803c3d-6886-42c9-b073-de3de89868e9\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/f1803c3d688642c9b073de3de89868e9\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8076-9982-000bc09a66e4\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T21:33:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-18T21:33:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Wiki
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Wiki
       DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Tags\":{\"id\":\"dju%60\",\"name\":\"Tags\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"ffb414b1-7c94-4e2d-81bf-5dad675b029d\",\"name\":\"Onboarding\",\"color\":\"blue\",\"description\":null},{\"id\":\"a3b0e7d6-d0c6-4b60-abb3-e1e4e61c69ac\",\"name\":\"Design\",\"color\":\"green\",\"description\":null}]}},\"Last
       edited time\":{\"id\":\"nI%7Bq\",\"name\":\"Last edited time\",\"description\":null,\"type\":\"last_edited_time\",\"last_edited_time\":{}},\"Page\":{\"id\":\"title\",\"name\":\"Page\",\"description\":null,\"type\":\"title\",\"title\":{}},\"Verification\":{\"id\":\"verification\",\"name\":\"Verification\",\"description\":null,\"type\":\"verification\",\"verification\":{}},\"Owner\":{\"id\":\"verification_owner\",\"name\":\"Owner\",\"description\":null,\"type\":\"people\",\"people\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000a\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000a\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8148-99ed-000b1e2cf103\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-18T17:51:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Task
@@ -62,8 +56,8 @@ interactions:
       Medium\",\"color\":\"yellow\",\"description\":null},{\"id\":\"6b5dd9b7-709d-4fb1-8d74-dbd81fcafcea\",\"name\":\"\u2736
       Low\",\"color\":\"gray\",\"description\":null}]}},\"Status\":{\"id\":\"U%60%3BC\",\"name\":\"Status\",\"description\":null,\"type\":\"status\",\"status\":{\"options\":[{\"id\":\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"name\":\"Backlog\",\"color\":\"gray\",\"description\":null},{\"id\":\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"name\":\"Blocked\",\"color\":\"red\",\"description\":null},{\"id\":\"34495d82-92d4-431d-a41c-f276fe4ef684\",\"name\":\"In
       Progress\",\"color\":\"blue\",\"description\":null},{\"id\":\"c58aef64-2007-4f6f-8b2c-bc4a7fdbdba8\",\"name\":\"Done\",\"color\":\"green\",\"description\":null}],\"groups\":[{\"id\":\"110fecc9-b3e8-4216-817c-817dd0349707\",\"name\":\"To-do\",\"color\":\"gray\",\"option_ids\":[\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"34495d82-92d4-431d-a41c-f276fe4ef684\",\"c58aef64-2007-4f6f-8b2c-bc4a7fdbdba8\"]},{\"id\":\"2178bb7f-d1f8-46c3-b630-ecd1152a5605\",\"name\":\"In
-      progress\",\"color\":\"blue\",\"option_ids\":[]},{\"id\":\"e1d6813a-42a3-4134-8dad-070ed7607f4e\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[]}]}},\"Urgency\":{\"id\":\"jkwd\",\"name\":\"Urgency\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"if({{notion:block_property:U%60%3BC:3839ce7b-60a4-8148-99ed-000b1e2cf103:00000000-0000-4000-8000-0000000000f0}}
-      == \\\"Done\\\", \\\"\u2705\\\", if(empty({{notion:block_property:lwnn:3839ce7b-60a4-8148-99ed-000b1e2cf103:00000000-0000-4000-8000-0000000000f0}}),
+      progress\",\"color\":\"blue\",\"option_ids\":[]},{\"id\":\"e1d6813a-42a3-4134-8dad-070ed7607f4e\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[]}]}},\"Urgency\":{\"id\":\"jkwd\",\"name\":\"Urgency\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"if({{notion:block_property:U%60%3BC:3839ce7b-60a4-8148-99ed-000b1e2cf103:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}
+      == \\\"Done\\\", \\\"\u2705\\\", if(empty({{notion:block_property:lwnn:3839ce7b-60a4-8148-99ed-000b1e2cf103:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}),
       \\\"\\\", \\\"\U0001F558\\\"))\"}},\"Due Date\":{\"id\":\"lwnn\",\"name\":\"Due
       Date\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Task\":{\"id\":\"title\",\"name\":\"Task\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000c\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000c\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8180-9ad3-000ba3a62e53\",\"cover\":null,\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F91D\"},\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-18T17:51:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Contacts
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Contacts
@@ -81,7 +75,7 @@ interactions:
       Engineer\",\"color\":\"default\",\"description\":null},{\"id\":\"e10da52f-0244-480b-a82e-151d63f89dbe\",\"name\":\"Technical
       Writer\",\"color\":\"pink\",\"description\":null},{\"id\":\"b28bb506-d608-447b-a064-9a2fa95aa479\",\"name\":\"Business
       Analyst\",\"color\":\"purple\",\"description\":null},{\"id\":\"cf3c60e3-b15f-4730-845d-3c97108e53b2\",\"name\":\"IT
-      Support Specialist\",\"color\":\"yellow\",\"description\":null}]}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000b\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000b\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T16:50:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-18T17:11:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"All
+      Support Specialist\",\"color\":\"yellow\",\"description\":null}]}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000b\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000b\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T16:50:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-18T17:11:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"All
       Properties DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"All
       Properties DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Text\":{\"id\":\"%3FB%3AW\",\"name\":\"Text\",\"description\":null,\"type\":\"rich_text\",\"rich_text\":{}},\"Files\":{\"id\":\"%3FbAF\",\"name\":\"Files\",\"description\":null,\"type\":\"files\",\"files\":{}},\"Phone
       number\":{\"id\":\"%3F~%5Cw\",\"name\":\"Phone number\",\"description\":null,\"type\":\"phone_number\",\"phone_number\":{}},\"URL\":{\"id\":\"CWCZ\",\"name\":\"URL\",\"description\":null,\"type\":\"url\",\"url\":{}},\"Button\":{\"id\":\"ImzP\",\"name\":\"Button\",\"description\":null,\"type\":\"button\",\"button\":{}},\"Checkbox\":{\"id\":\"LGzq\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"checkbox\",\"checkbox\":{}},\"Multi-Select\":{\"id\":\"RIfI\",\"name\":\"Multi-Select\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"0a1263f2-e675-48f0-b60b-2cf6906cb64c\",\"name\":\"MultiOption1\",\"color\":\"purple\",\"description\":null},{\"id\":\"af12f1e2-a65a-402d-ad82-bf58c9fed1f8\",\"name\":\"MultiOption2\",\"color\":\"yellow\",\"description\":null}]}},\"AI
@@ -92,16 +86,16 @@ interactions:
       started\",\"color\":\"default\",\"description\":null},{\"id\":\"2f1c6db3-2259-4acb-829c-8cdc98d9913e\",\"name\":\"In
       progress\",\"color\":\"blue\",\"description\":null},{\"id\":\"25c77ace-e80e-4e12-98b8-3b765796e68b\",\"name\":\"Done\",\"color\":\"green\",\"description\":null}],\"groups\":[{\"id\":\"8b3ca9c2-089f-41da-a500-f448ad804a0e\",\"name\":\"To-do\",\"color\":\"gray\",\"option_ids\":[\"1c994aad-fc1f-46d0-b322-51b2b2cb7e6f\"]},{\"id\":\"9e5ecb96-f57e-465a-bff5-f851ecd7c2ca\",\"name\":\"In
       progress\",\"color\":\"blue\",\"option_ids\":[\"2f1c6db3-2259-4acb-829c-8cdc98d9913e\"]},{\"id\":\"9dc509c2-f12c-4c5d-ba00-43e099ba8f99\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[\"25c77ace-e80e-4e12-98b8-3b765796e68b\"]}]}},\"Relation
-      two-way\":{\"id\":\"iywx\",\"name\":\"Relation two-way\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation\",\"synced_property_id\":\"v_%5D%3C\"}}},\"Formula\":{\"id\":\"jeun\",\"name\":\"Formula\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"={{notion:block_property:dDR%3B:3839ce7b-60a4-802c-b152-000ba814957b:00000000-0000-4000-8000-0000000000f0}}*
+      two-way\":{\"id\":\"iywx\",\"name\":\"Relation two-way\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation\",\"synced_property_id\":\"v_%5D%3C\"}}},\"Formula\":{\"id\":\"jeun\",\"name\":\"Formula\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"={{notion:block_property:dDR%3B:3839ce7b-60a4-802c-b152-000ba814957b:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}*
       2\"}},\"Created time\":{\"id\":\"kRv%7B\",\"name\":\"Created time\",\"description\":null,\"type\":\"created_time\",\"created_time\":{}},\"Last
       edited time\":{\"id\":\"kX%3Fw\",\"name\":\"Last edited time\",\"description\":null,\"type\":\"last_edited_time\",\"last_edited_time\":{}},\"Place\":{\"id\":\"rulX\",\"name\":\"Place\",\"description\":null,\"type\":\"place\",\"place\":{}},\"Date\":{\"id\":\"uUxQ\",\"name\":\"Date\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Relation\":{\"id\":\"v_%5D%3C\",\"name\":\"Relation\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation
       two-way\",\"synced_property_id\":\"iywx\"}}},\"Email\":{\"id\":\"wua%3F\",\"name\":\"Email\",\"description\":null,\"type\":\"email\",\"email\":{}},\"People\":{\"id\":\"~ak%40\",\"name\":\"People\",\"description\":null,\"type\":\"people\",\"people\":{}},\"Last
-      edited by\":{\"id\":\"~e%3F%5E\",\"name\":\"Last edited by\",\"description\":null,\"type\":\"last_edited_by\",\"last_edited_by\":{}},\"Title\":{\"id\":\"title\",\"name\":\"Title\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-000000000009\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/00000000000040008000000000000009\",\"public_url\":null,\"in_trash\":false,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"975fbe43-8484-4bed-9058-818fe2eab52e\"}"
+      edited by\":{\"id\":\"~e%3F%5E\",\"name\":\"Last edited by\",\"description\":null,\"type\":\"last_edited_by\",\"last_edited_by\":{}},\"Title\":{\"id\":\"title\",\"name\":\"Title\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-000000000009\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/00000000000040008000000000000009\",\"public_url\":null,\"in_trash\":false,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"7d963b93-5990-4c8c-be14-53dfcdb70950\"}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a122308fb9f8261f-LHR
+      - a1230633bde3bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -131,7 +125,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 975fbe43-8484-4bed-9058-818fe2eab52e
+      - 7d963b93-5990-4c8c-be14-53dfcdb70950
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -165,11 +159,11 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/search
   response:
-    content: "{\"object\":\"list\",\"results\":[{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8168-ba4d-000b1ee50a86\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-25T16:54:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Formula
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8168-ba4d-000b1ee50a86\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-25T16:54:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Formula
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Formula
       DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Date
       Source\":{\"id\":\"CNpy\",\"name\":\"Date Source\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Tags\":{\"id\":\"DUnB\",\"name\":\"Tags\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"285007eb-456a-4eda-8ac6-64c70c57f39d\",\"name\":\"In
-      Progress\",\"color\":\"pink\",\"description\":null},{\"id\":\"f1d3aded-bb84-437e-9fa8-a6c7e24a2f29\",\"name\":\"Done\",\"color\":\"gray\",\"description\":null}]}},\"Date\":{\"id\":\"%5Ckxk\",\"name\":\"Date\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:CNpy:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}\"}},\"String\":{\"id\":\"dvYQ\",\"name\":\"String\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"format({{notion:block_property:title:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}})\"}},\"Checkbox\":{\"id\":\"hlGb\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}.includes(\\\"Done\\\")\"}},\"Number\":{\"id\":\"x%40zJ\",\"name\":\"Number\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}.length()\"}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000d\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000d\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T16:31:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T16:32:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Item
+      Progress\",\"color\":\"pink\",\"description\":null},{\"id\":\"f1d3aded-bb84-437e-9fa8-a6c7e24a2f29\",\"name\":\"Done\",\"color\":\"gray\",\"description\":null}]}},\"Date\":{\"id\":\"%5Ckxk\",\"name\":\"Date\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:CNpy:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}\"}},\"String\":{\"id\":\"dvYQ\",\"name\":\"String\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"format({{notion:block_property:title:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}})\"}},\"Checkbox\":{\"id\":\"hlGb\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}.includes(\\\"Done\\\")\"}},\"Number\":{\"id\":\"x%40zJ\",\"name\":\"Number\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}.length()\"}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000d\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000d\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T16:31:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T16:32:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Item
       DB for max relation items\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Item
       DB for max relation items\",\"href\":null}],\"description\":[{\"type\":\"text\",\"text\":{\"content\":\"Database
       of all items\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Database
@@ -183,7 +177,7 @@ interactions:
       Purchased\":{\"id\":\"r%7DaJ\",\"name\":\"Items Purchased\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"9528650b-a37a-41a9-8dc2-a8fd21525122\",\"data_source_id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Bought
       by\",\"synced_property_id\":\"F%3Ebg\"}}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"c05c7705-1005-46af-89f7-3f6d8b87049f\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/c05c7705100546af89f73f6d8b87049f\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"e0fffc4a-19d0-4886-8ff3-4b22a7977dd5\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T12:41:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T12:42:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"DB
       test with 110 pages\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"DB
-      test with 110 pages\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"f1803c3d-6886-42c9-b073-de3de89868e9\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/f1803c3d688642c9b073de3de89868e9\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8076-9982-000bc09a66e4\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T21:33:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-18T21:33:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Wiki
+      test with 110 pages\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"f1803c3d-6886-42c9-b073-de3de89868e9\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/f1803c3d688642c9b073de3de89868e9\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8076-9982-000bc09a66e4\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T21:33:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-18T21:33:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Wiki
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Wiki
       DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Tags\":{\"id\":\"dju%60\",\"name\":\"Tags\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"ffb414b1-7c94-4e2d-81bf-5dad675b029d\",\"name\":\"Onboarding\",\"color\":\"blue\",\"description\":null},{\"id\":\"a3b0e7d6-d0c6-4b60-abb3-e1e4e61c69ac\",\"name\":\"Design\",\"color\":\"green\",\"description\":null}]}},\"Last
       edited time\":{\"id\":\"nI%7Bq\",\"name\":\"Last edited time\",\"description\":null,\"type\":\"last_edited_time\",\"last_edited_time\":{}},\"Page\":{\"id\":\"title\",\"name\":\"Page\",\"description\":null,\"type\":\"title\",\"title\":{}},\"Verification\":{\"id\":\"verification\",\"name\":\"Verification\",\"description\":null,\"type\":\"verification\",\"verification\":{}},\"Owner\":{\"id\":\"verification_owner\",\"name\":\"Owner\",\"description\":null,\"type\":\"people\",\"people\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000a\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000a\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8148-99ed-000b1e2cf103\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-18T17:51:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Task
@@ -195,8 +189,8 @@ interactions:
       Medium\",\"color\":\"yellow\",\"description\":null},{\"id\":\"6b5dd9b7-709d-4fb1-8d74-dbd81fcafcea\",\"name\":\"\u2736
       Low\",\"color\":\"gray\",\"description\":null}]}},\"Status\":{\"id\":\"U%60%3BC\",\"name\":\"Status\",\"description\":null,\"type\":\"status\",\"status\":{\"options\":[{\"id\":\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"name\":\"Backlog\",\"color\":\"gray\",\"description\":null},{\"id\":\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"name\":\"Blocked\",\"color\":\"red\",\"description\":null},{\"id\":\"34495d82-92d4-431d-a41c-f276fe4ef684\",\"name\":\"In
       Progress\",\"color\":\"blue\",\"description\":null},{\"id\":\"c58aef64-2007-4f6f-8b2c-bc4a7fdbdba8\",\"name\":\"Done\",\"color\":\"green\",\"description\":null}],\"groups\":[{\"id\":\"110fecc9-b3e8-4216-817c-817dd0349707\",\"name\":\"To-do\",\"color\":\"gray\",\"option_ids\":[\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"34495d82-92d4-431d-a41c-f276fe4ef684\",\"c58aef64-2007-4f6f-8b2c-bc4a7fdbdba8\"]},{\"id\":\"2178bb7f-d1f8-46c3-b630-ecd1152a5605\",\"name\":\"In
-      progress\",\"color\":\"blue\",\"option_ids\":[]},{\"id\":\"e1d6813a-42a3-4134-8dad-070ed7607f4e\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[]}]}},\"Urgency\":{\"id\":\"jkwd\",\"name\":\"Urgency\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"if({{notion:block_property:U%60%3BC:3839ce7b-60a4-8148-99ed-000b1e2cf103:00000000-0000-4000-8000-0000000000f0}}
-      == \\\"Done\\\", \\\"\u2705\\\", if(empty({{notion:block_property:lwnn:3839ce7b-60a4-8148-99ed-000b1e2cf103:00000000-0000-4000-8000-0000000000f0}}),
+      progress\",\"color\":\"blue\",\"option_ids\":[]},{\"id\":\"e1d6813a-42a3-4134-8dad-070ed7607f4e\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[]}]}},\"Urgency\":{\"id\":\"jkwd\",\"name\":\"Urgency\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"if({{notion:block_property:U%60%3BC:3839ce7b-60a4-8148-99ed-000b1e2cf103:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}
+      == \\\"Done\\\", \\\"\u2705\\\", if(empty({{notion:block_property:lwnn:3839ce7b-60a4-8148-99ed-000b1e2cf103:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}),
       \\\"\\\", \\\"\U0001F558\\\"))\"}},\"Due Date\":{\"id\":\"lwnn\",\"name\":\"Due
       Date\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Task\":{\"id\":\"title\",\"name\":\"Task\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000c\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000c\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8180-9ad3-000ba3a62e53\",\"cover\":null,\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F91D\"},\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-18T17:51:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Contacts
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Contacts
@@ -214,7 +208,7 @@ interactions:
       Engineer\",\"color\":\"default\",\"description\":null},{\"id\":\"e10da52f-0244-480b-a82e-151d63f89dbe\",\"name\":\"Technical
       Writer\",\"color\":\"pink\",\"description\":null},{\"id\":\"b28bb506-d608-447b-a064-9a2fa95aa479\",\"name\":\"Business
       Analyst\",\"color\":\"purple\",\"description\":null},{\"id\":\"cf3c60e3-b15f-4730-845d-3c97108e53b2\",\"name\":\"IT
-      Support Specialist\",\"color\":\"yellow\",\"description\":null}]}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000b\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000b\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T16:50:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-18T17:11:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"All
+      Support Specialist\",\"color\":\"yellow\",\"description\":null}]}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000b\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000b\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T16:50:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-18T17:11:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"All
       Properties DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"All
       Properties DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Text\":{\"id\":\"%3FB%3AW\",\"name\":\"Text\",\"description\":null,\"type\":\"rich_text\",\"rich_text\":{}},\"Files\":{\"id\":\"%3FbAF\",\"name\":\"Files\",\"description\":null,\"type\":\"files\",\"files\":{}},\"Phone
       number\":{\"id\":\"%3F~%5Cw\",\"name\":\"Phone number\",\"description\":null,\"type\":\"phone_number\",\"phone_number\":{}},\"URL\":{\"id\":\"CWCZ\",\"name\":\"URL\",\"description\":null,\"type\":\"url\",\"url\":{}},\"Button\":{\"id\":\"ImzP\",\"name\":\"Button\",\"description\":null,\"type\":\"button\",\"button\":{}},\"Checkbox\":{\"id\":\"LGzq\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"checkbox\",\"checkbox\":{}},\"Multi-Select\":{\"id\":\"RIfI\",\"name\":\"Multi-Select\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"0a1263f2-e675-48f0-b60b-2cf6906cb64c\",\"name\":\"MultiOption1\",\"color\":\"purple\",\"description\":null},{\"id\":\"af12f1e2-a65a-402d-ad82-bf58c9fed1f8\",\"name\":\"MultiOption2\",\"color\":\"yellow\",\"description\":null}]}},\"AI
@@ -225,16 +219,16 @@ interactions:
       started\",\"color\":\"default\",\"description\":null},{\"id\":\"2f1c6db3-2259-4acb-829c-8cdc98d9913e\",\"name\":\"In
       progress\",\"color\":\"blue\",\"description\":null},{\"id\":\"25c77ace-e80e-4e12-98b8-3b765796e68b\",\"name\":\"Done\",\"color\":\"green\",\"description\":null}],\"groups\":[{\"id\":\"8b3ca9c2-089f-41da-a500-f448ad804a0e\",\"name\":\"To-do\",\"color\":\"gray\",\"option_ids\":[\"1c994aad-fc1f-46d0-b322-51b2b2cb7e6f\"]},{\"id\":\"9e5ecb96-f57e-465a-bff5-f851ecd7c2ca\",\"name\":\"In
       progress\",\"color\":\"blue\",\"option_ids\":[\"2f1c6db3-2259-4acb-829c-8cdc98d9913e\"]},{\"id\":\"9dc509c2-f12c-4c5d-ba00-43e099ba8f99\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[\"25c77ace-e80e-4e12-98b8-3b765796e68b\"]}]}},\"Relation
-      two-way\":{\"id\":\"iywx\",\"name\":\"Relation two-way\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation\",\"synced_property_id\":\"v_%5D%3C\"}}},\"Formula\":{\"id\":\"jeun\",\"name\":\"Formula\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"={{notion:block_property:dDR%3B:3839ce7b-60a4-802c-b152-000ba814957b:00000000-0000-4000-8000-0000000000f0}}*
+      two-way\":{\"id\":\"iywx\",\"name\":\"Relation two-way\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation\",\"synced_property_id\":\"v_%5D%3C\"}}},\"Formula\":{\"id\":\"jeun\",\"name\":\"Formula\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"={{notion:block_property:dDR%3B:3839ce7b-60a4-802c-b152-000ba814957b:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}*
       2\"}},\"Created time\":{\"id\":\"kRv%7B\",\"name\":\"Created time\",\"description\":null,\"type\":\"created_time\",\"created_time\":{}},\"Last
       edited time\":{\"id\":\"kX%3Fw\",\"name\":\"Last edited time\",\"description\":null,\"type\":\"last_edited_time\",\"last_edited_time\":{}},\"Place\":{\"id\":\"rulX\",\"name\":\"Place\",\"description\":null,\"type\":\"place\",\"place\":{}},\"Date\":{\"id\":\"uUxQ\",\"name\":\"Date\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Relation\":{\"id\":\"v_%5D%3C\",\"name\":\"Relation\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation
       two-way\",\"synced_property_id\":\"iywx\"}}},\"Email\":{\"id\":\"wua%3F\",\"name\":\"Email\",\"description\":null,\"type\":\"email\",\"email\":{}},\"People\":{\"id\":\"~ak%40\",\"name\":\"People\",\"description\":null,\"type\":\"people\",\"people\":{}},\"Last
-      edited by\":{\"id\":\"~e%3F%5E\",\"name\":\"Last edited by\",\"description\":null,\"type\":\"last_edited_by\",\"last_edited_by\":{}},\"Title\":{\"id\":\"title\",\"name\":\"Title\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-000000000009\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/00000000000040008000000000000009\",\"public_url\":null,\"in_trash\":false,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"78cc8221-4179-4134-bbb2-a657aab19859\"}"
+      edited by\":{\"id\":\"~e%3F%5E\",\"name\":\"Last edited by\",\"description\":null,\"type\":\"last_edited_by\",\"last_edited_by\":{}},\"Title\":{\"id\":\"title\",\"name\":\"Title\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-000000000009\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/00000000000040008000000000000009\",\"public_url\":null,\"in_trash\":false,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"e090f097-361d-41de-ae5d-739dc405157a\"}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a1223092bffa261f-LHR
+      - a12306366fd2bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -264,7 +258,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 78cc8221-4179-4134-bbb2-a657aab19859
+      - e090f097-361d-41de-ae5d-739dc405157a
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -298,18 +292,18 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/search
   response:
-    content: '{"object":"list","results":[{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T05:52:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false},{"object":"page","id":"00000000-0000-4000-8000-000000000003","created_time":"2026-06-18T17:51:00.000Z","last_edited_time":"2026-06-25T17:07:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Markdown
+    content: '{"object":"list","results":[{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T08:18:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false},{"object":"page","id":"00000000-0000-4000-8000-000000000003","created_time":"2026-06-18T17:51:00.000Z","last_edited_time":"2026-06-25T17:07:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Markdown
       Text Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Markdown
-      Text Test","href":null}]}},"url":"https://www.notion.so/Markdown-Text-Test-00000000000040008000000000000003","public_url":null,"archived":false},{"object":"page","id":"00000000-0000-4000-8000-000000000004","created_time":"2026-06-25T10:46:00.000Z","last_edited_time":"2026-06-25T10:51:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000fa"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Markdown
+      Text Test","href":null}]}},"url":"https://www.notion.so/Markdown-Text-Test-00000000000040008000000000000003","public_url":null,"archived":false},{"object":"page","id":"00000000-0000-4000-8000-000000000004","created_time":"2026-06-25T10:46:00.000Z","last_edited_time":"2026-06-25T10:51:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Markdown
       Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Markdown
       Test","href":null}]}},"url":"https://www.notion.so/Markdown-Test-00000000000040008000000000000004","public_url":null,"archived":false},{"object":"page","id":"00000000-0000-4000-8000-000000000005","created_time":"2026-06-25T10:47:00.000Z","last_edited_time":"2026-06-25T10:47:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000004"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Markdown
       SubPage Test","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Markdown
-      SubPage Test","href":null}]}},"url":"https://www.notion.so/Markdown-SubPage-Test-00000000000040008000000000000005","public_url":null,"archived":false}],"next_cursor":null,"has_more":false,"type":"page_or_data_source","page_or_data_source":{},"request_id":"f7e4cb1a-6094-486d-b9f5-379197e3fd6f"}'
+      SubPage Test","href":null}]}},"url":"https://www.notion.so/Markdown-SubPage-Test-00000000000040008000000000000005","public_url":null,"archived":false}],"next_cursor":null,"has_more":false,"type":"page_or_data_source","page_or_data_source":{},"request_id":"5aff2e72-2070-400a-9ea6-cc159856c5ea"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a1223096aec6261f-LHR
+      - a12306393a28bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -339,7 +333,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - f7e4cb1a-6094-486d-b9f5-379197e3fd6f
+      - 5aff2e72-2070-400a-9ea6-cc159856c5ea
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -374,15 +368,15 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/databases
   response:
-    content: '{"object":"database","id":"c817985a-dd9b-470b-88d9-a80e81a409db","title":[{"type":"text","text":{"content":"New
+    content: '{"object":"database","id":"654568bb-8e55-4717-931e-f68704505440","title":[{"type":"text","text":{"content":"New
       database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
-      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T05:53:10.628+00:00","last_edited_time":"2026-06-27T05:53:10.628+00:00","data_sources":[{"id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","name":"New
-      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/c817985add9b470b88d9a80e81a409db","public_url":null,"archived":false,"request_id":"3cad7d4a-0d19-40a2-8496-a9843682035d"}'
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:19:01.212+00:00","last_edited_time":"2026-06-27T08:19:01.212+00:00","data_sources":[{"id":"a0f37fa5-801c-4063-ac92-185aac22f76d","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/654568bb8e554717931ef68704505440","public_url":null,"archived":false,"request_id":"8d852d9c-76f9-461d-a6e2-6d66e4e4e964"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230986a34261f-LHR
+      - a123063b7be5bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -412,7 +406,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 3cad7d4a-0d19-40a2-8496-a9843682035d
+      - 8d852d9c-76f9-461d-a6e2-6d66e4e4e964
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -439,14 +433,14 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/data_sources/ec089eb7-67f3-451a-92d6-5c4556f2174e
+    uri: https://api.notion.com/v1/data_sources/a0f37fa5-801c-4063-ac92-185aac22f76d
   response:
-    content: '{"object":"data_source","id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","cover":null,"icon":null,"created_time":"2026-06-27T05:53:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T05:53:00.000Z","title":[],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"c817985a-dd9b-470b-88d9-a80e81a409db"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/c817985add9b470b88d9a80e81a409db","public_url":null,"in_trash":false,"archived":false,"request_id":"09ad3a67-ceef-46de-b5e6-5946485e3b01"}'
+    content: '{"object":"data_source","id":"a0f37fa5-801c-4063-ac92-185aac22f76d","cover":null,"icon":null,"created_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:19:00.000Z","title":[],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"654568bb-8e55-4717-931e-f68704505440"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/654568bb8e554717931ef68704505440","public_url":null,"in_trash":false,"archived":false,"request_id":"193c7333-f25a-4c5b-8ff1-f455f47d5830"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a122309e0c86261f-LHR
+      - a1230641a854bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -476,7 +470,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 09ad3a67-ceef-46de-b5e6-5946485e3b01
+      - 193c7333-f25a-4c5b-8ff1-f455f47d5830
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -508,16 +502,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/data_sources/ec089eb7-67f3-451a-92d6-5c4556f2174e
+    uri: https://api.notion.com/v1/data_sources/a0f37fa5-801c-4063-ac92-185aac22f76d
   response:
-    content: '{"object":"data_source","id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","cover":null,"icon":null,"created_time":"2026-06-27T05:53:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T05:53:00.000Z","title":[{"type":"text","text":{"content":"My
+    content: '{"object":"data_source","id":"a0f37fa5-801c-4063-ac92-185aac22f76d","cover":null,"icon":null,"created_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:19:00.000Z","title":[{"type":"text","text":{"content":"My
       DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"My
-      DB","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"c817985a-dd9b-470b-88d9-a80e81a409db"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/c817985add9b470b88d9a80e81a409db","public_url":null,"in_trash":false,"archived":false,"request_id":"736da162-a572-440c-b19f-05cd78375d69"}'
+      DB","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"654568bb-8e55-4717-931e-f68704505440"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/654568bb8e554717931ef68704505440","public_url":null,"in_trash":false,"archived":false,"request_id":"8ecc31e5-0916-48a3-a8a1-7e9f6be3e986"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a122309f8f30261f-LHR
+      - a12306436986bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -547,7 +541,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 736da162-a572-440c-b19f-05cd78375d69
+      - 8ecc31e5-0916-48a3-a8a1-7e9f6be3e986
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -580,19 +574,19 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/databases/c817985a-dd9b-470b-88d9-a80e81a409db
+    uri: https://api.notion.com/v1/databases/654568bb-8e55-4717-931e-f68704505440
   response:
-    content: '{"object":"database","id":"c817985a-dd9b-470b-88d9-a80e81a409db","title":[{"type":"text","text":{"content":"My
+    content: '{"object":"database","id":"654568bb-8e55-4717-931e-f68704505440","title":[{"type":"text","text":{"content":"My
       DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"My
       DB","href":null}],"description":[{"type":"text","text":{"content":"This is my
       data source for cool Python libraries!","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"This
-      is my data source for cool Python libraries!","href":null}],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T05:53:10.628+00:00","last_edited_time":"2026-06-27T05:53:11.763+00:00","data_sources":[{"id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","name":"My
-      DB"}],"icon":null,"cover":null,"url":"https://www.notion.so/c817985add9b470b88d9a80e81a409db","public_url":null,"archived":false,"request_id":"bab5b87d-01a2-484c-880d-6b2f949b0bc9"}'
+      is my data source for cool Python libraries!","href":null}],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:19:01.212+00:00","last_edited_time":"2026-06-27T08:19:02.485+00:00","data_sources":[{"id":"a0f37fa5-801c-4063-ac92-185aac22f76d","name":"My
+      DB"}],"icon":null,"cover":null,"url":"https://www.notion.so/654568bb8e554717931ef68704505440","public_url":null,"archived":false,"request_id":"edaf9d28-f895-4f5a-9959-b3714fd78dd6"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230ab4e80261f-LHR
+      - a12306470b9ebd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -622,7 +616,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - bab5b87d-01a2-484c-880d-6b2f949b0bc9
+      - edaf9d28-f895-4f5a-9959-b3714fd78dd6
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -649,18 +643,18 @@ interactions:
       user-agent:
       - secret...
     method: GET
-    uri: https://api.notion.com/v1/data_sources/ec089eb7-67f3-451a-92d6-5c4556f2174e
+    uri: https://api.notion.com/v1/data_sources/a0f37fa5-801c-4063-ac92-185aac22f76d
   response:
-    content: '{"object":"data_source","id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","cover":null,"icon":null,"created_time":"2026-06-27T05:53:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T05:53:00.000Z","title":[{"type":"text","text":{"content":"My
+    content: '{"object":"data_source","id":"a0f37fa5-801c-4063-ac92-185aac22f76d","cover":null,"icon":null,"created_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:19:00.000Z","title":[{"type":"text","text":{"content":"My
       DB","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"My
       DB","href":null}],"description":[{"type":"text","text":{"content":"This is my
       data source for cool Python libraries!","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"This
-      is my data source for cool Python libraries!","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"c817985a-dd9b-470b-88d9-a80e81a409db"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/c817985add9b470b88d9a80e81a409db","public_url":null,"in_trash":false,"archived":false,"request_id":"9d03db99-ebd3-4d8c-b3c7-6231ade9d2c5"}'
+      is my data source for cool Python libraries!","href":null}],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"654568bb-8e55-4717-931e-f68704505440"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/654568bb8e554717931ef68704505440","public_url":null,"in_trash":false,"archived":false,"request_id":"d9c41da0-204e-443c-a00b-ea580044e2bb"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230adcb9e261f-LHR
+      - a123064b0eaebd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -690,7 +684,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 9d03db99-ebd3-4d8c-b3c7-6231ade9d2c5
+      - d9c41da0-204e-443c-a00b-ea580044e2bb
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -698,7 +692,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "data_source_id", "data_source_id": "ec089eb7-67f3-451a-92d6-5c4556f2174e"},
+    body: '{"parent": {"type": "data_source_id", "data_source_id": "a0f37fa5-801c-4063-ac92-185aac22f76d"},
       "properties": {"Name": {"type": "title", "title": [{"type": "text", "plain_text":
       "Ultimate Notion", "annotations": {"bold": false, "italic": false, "strikethrough":
       false, "underline": false, "code": false}, "text": {"content": "Ultimate Notion"}}]}}}'
@@ -726,14 +720,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"38c9ce7b-60a4-81fc-961c-efb2063519ac","created_time":"2026-06-27T05:53:00.000Z","last_edited_time":"2026-06-27T05:53:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"data_source_id","data_source_id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","database_id":"c817985a-dd9b-470b-88d9-a80e81a409db"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Ultimate
+    content: '{"object":"page","id":"38c9ce7b-60a4-8111-8eec-e4d7d9438777","created_time":"2026-06-27T08:19:00.000Z","last_edited_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"data_source_id","data_source_id":"a0f37fa5-801c-4063-ac92-185aac22f76d","database_id":"654568bb-8e55-4717-931e-f68704505440"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Ultimate
       Notion","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Ultimate
-      Notion","href":null}]}},"url":"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481fc961cefb2063519ac","public_url":null,"archived":false,"request_id":"39cc6624-807d-4cf3-8b54-843e328c7303"}'
+      Notion","href":null}]}},"url":"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481118eece4d7d9438777","public_url":null,"archived":false,"request_id":"1ebeff4d-b403-4886-8fc8-b89f5b6efa6b"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230af6e9a261f-LHR
+      - a123064cafe1bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -763,7 +757,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 39cc6624-807d-4cf3-8b54-843e328c7303
+      - 1ebeff4d-b403-4886-8fc8-b89f5b6efa6b
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -794,16 +788,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/pages/38c9ce7b60a481fc961cefb2063519ac
+    uri: https://api.notion.com/v1/pages/38c9ce7b60a481118eece4d7d9438777
   response:
-    content: "{\"object\":\"page\",\"id\":\"38c9ce7b-60a4-81fc-961c-efb2063519ac\",\"created_time\":\"2026-06-27T05:53:00.000Z\",\"last_edited_time\":\"2026-06-27T05:53:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"cover\":null,\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F680\"},\"parent\":{\"type\":\"data_source_id\",\"data_source_id\":\"ec089eb7-67f3-451a-92d6-5c4556f2174e\",\"database_id\":\"c817985a-dd9b-470b-88d9-a80e81a409db\"},\"in_trash\":false,\"is_archived\":false,\"is_locked\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Ultimate
+    content: "{\"object\":\"page\",\"id\":\"38c9ce7b-60a4-8111-8eec-e4d7d9438777\",\"created_time\":\"2026-06-27T08:19:00.000Z\",\"last_edited_time\":\"2026-06-27T08:19:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"cover\":null,\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F680\"},\"parent\":{\"type\":\"data_source_id\",\"data_source_id\":\"a0f37fa5-801c-4063-ac92-185aac22f76d\",\"database_id\":\"654568bb-8e55-4717-931e-f68704505440\"},\"in_trash\":false,\"is_archived\":false,\"is_locked\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Ultimate
       Notion\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Ultimate
-      Notion\",\"href\":null}]}},\"url\":\"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481fc961cefb2063519ac\",\"public_url\":null,\"archived\":false,\"request_id\":\"704ac390-2b80-4ab2-994f-d142a6b722bf\"}"
+      Notion\",\"href\":null}]}},\"url\":\"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481118eece4d7d9438777\",\"public_url\":null,\"archived\":false,\"request_id\":\"fa8659fe-c42f-4726-98af-a0e1c34f2fa4\"}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230b19a2f261f-LHR
+      - a123064efa25bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -833,7 +827,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 704ac390-2b80-4ab2-994f-d142a6b722bf
+      - fa8659fe-c42f-4726-98af-a0e1c34f2fa4
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -864,16 +858,16 @@ interactions:
       user-agent:
       - secret...
     method: PATCH
-    uri: https://api.notion.com/v1/pages/38c9ce7b60a481fc961cefb2063519ac
+    uri: https://api.notion.com/v1/pages/38c9ce7b60a481118eece4d7d9438777
   response:
-    content: "{\"object\":\"page\",\"id\":\"38c9ce7b-60a4-81fc-961c-efb2063519ac\",\"created_time\":\"2026-06-27T05:53:00.000Z\",\"last_edited_time\":\"2026-06-27T05:53:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"cover\":{\"type\":\"external\",\"external\":{\"url\":\"https://www.notion.so/images/page-cover/woodcuts_2.jpg\"}},\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F680\"},\"parent\":{\"type\":\"data_source_id\",\"data_source_id\":\"ec089eb7-67f3-451a-92d6-5c4556f2174e\",\"database_id\":\"c817985a-dd9b-470b-88d9-a80e81a409db\"},\"in_trash\":false,\"is_archived\":false,\"is_locked\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Ultimate
+    content: "{\"object\":\"page\",\"id\":\"38c9ce7b-60a4-8111-8eec-e4d7d9438777\",\"created_time\":\"2026-06-27T08:19:00.000Z\",\"last_edited_time\":\"2026-06-27T08:19:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"cover\":{\"type\":\"external\",\"external\":{\"url\":\"https://www.notion.so/images/page-cover/woodcuts_2.jpg\"}},\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F680\"},\"parent\":{\"type\":\"data_source_id\",\"data_source_id\":\"a0f37fa5-801c-4063-ac92-185aac22f76d\",\"database_id\":\"654568bb-8e55-4717-931e-f68704505440\"},\"in_trash\":false,\"is_archived\":false,\"is_locked\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Ultimate
       Notion\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Ultimate
-      Notion\",\"href\":null}]}},\"url\":\"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481fc961cefb2063519ac\",\"public_url\":null,\"archived\":false,\"request_id\":\"bff91885-ee69-42ed-94bf-87f7ce2f7ab8\"}"
+      Notion\",\"href\":null}]}},\"url\":\"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481118eece4d7d9438777\",\"public_url\":null,\"archived\":false,\"request_id\":\"614ef68b-f1e9-4fc1-a69d-6c396b2f485d\"}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230b40ed1261f-LHR
+      - a1230651ac5ebd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -903,7 +897,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - bff91885-ee69-42ed-94bf-87f7ce2f7ab8
+      - 614ef68b-f1e9-4fc1-a69d-6c396b2f485d
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -911,7 +905,7 @@ interactions:
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"parent": {"type": "data_source_id", "data_source_id": "ec089eb7-67f3-451a-92d6-5c4556f2174e"},
+    body: '{"parent": {"type": "data_source_id", "data_source_id": "a0f37fa5-801c-4063-ac92-185aac22f76d"},
       "properties": {"Name": {"type": "title", "title": [{"type": "text", "plain_text":
       "Ultimate Notion", "annotations": {"bold": false, "italic": false, "strikethrough":
       false, "underline": false, "code": false}, "text": {"content": "Ultimate Notion"}}]}}}'
@@ -939,14 +933,14 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/pages
   response:
-    content: '{"object":"page","id":"38c9ce7b-60a4-81fb-8258-da7088eb2d2e","created_time":"2026-06-27T05:53:00.000Z","last_edited_time":"2026-06-27T05:53:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"data_source_id","data_source_id":"ec089eb7-67f3-451a-92d6-5c4556f2174e","database_id":"c817985a-dd9b-470b-88d9-a80e81a409db"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Ultimate
+    content: '{"object":"page","id":"38c9ce7b-60a4-8151-9af0-e17f6cac97c6","created_time":"2026-06-27T08:19:00.000Z","last_edited_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"data_source_id","data_source_id":"a0f37fa5-801c-4063-ac92-185aac22f76d","database_id":"654568bb-8e55-4717-931e-f68704505440"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"Name":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Ultimate
       Notion","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Ultimate
-      Notion","href":null}]}},"url":"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481fb8258da7088eb2d2e","public_url":null,"archived":false,"request_id":"74f5af77-fc43-4217-8204-ae1f6d619133"}'
+      Notion","href":null}]}},"url":"https://www.notion.so/Ultimate-Notion-38c9ce7b60a481519af0e17f6cac97c6","public_url":null,"archived":false,"request_id":"7225d2ff-b493-448e-9bf9-7eafacf96b2f"}'
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230c66975261f-LHR
+      - a123065749a5bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -976,7 +970,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 74f5af77-fc43-4217-8204-ae1f6d619133
+      - 7225d2ff-b493-448e-9bf9-7eafacf96b2f
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1010,17 +1004,11 @@ interactions:
     method: POST
     uri: https://api.notion.com/v1/search
   response:
-    content: "{\"object\":\"list\",\"results\":[{\"object\":\"data_source\",\"id\":\"b87c0ea0-bb9f-4a32-86c6-d6427ca4bdba\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-27T05:52:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-27T05:52:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Customer
-      DB 42\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Customer
-      DB 42\",\"href\":null}],\"description\":[{\"type\":\"text\",\"text\":{\"content\":\"Database
-      of all our beloved customers.\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Database
-      of all our beloved customers.\",\"href\":null}],\"is_inline\":false,\"properties\":{\"Items
-      Purchased\":{\"id\":\"%7Cez%5C\",\"name\":\"Items Purchased\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"ea2b04c4-6dd4-4315-93ea-3dda12fd770a\",\"data_source_id\":\"b2b43262-67a8-47c9-bd02-08a6e225311e\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Bought
-      by 1\",\"synced_property_id\":\"D%3A%3Az\"}}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"79d7bee6-c2af-43e6-beb0-1cd9670d2ae5\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/79d7bee6c2af43e6beb01cd9670d2ae5\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8168-ba4d-000b1ee50a86\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-25T16:54:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Formula
+    content: "{\"object\":\"list\",\"results\":[{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8168-ba4d-000b1ee50a86\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-25T16:54:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Formula
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Formula
       DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Date
       Source\":{\"id\":\"CNpy\",\"name\":\"Date Source\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Tags\":{\"id\":\"DUnB\",\"name\":\"Tags\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"285007eb-456a-4eda-8ac6-64c70c57f39d\",\"name\":\"In
-      Progress\",\"color\":\"pink\",\"description\":null},{\"id\":\"f1d3aded-bb84-437e-9fa8-a6c7e24a2f29\",\"name\":\"Done\",\"color\":\"gray\",\"description\":null}]}},\"Date\":{\"id\":\"%5Ckxk\",\"name\":\"Date\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:CNpy:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}\"}},\"String\":{\"id\":\"dvYQ\",\"name\":\"String\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"format({{notion:block_property:title:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}})\"}},\"Checkbox\":{\"id\":\"hlGb\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}.includes(\\\"Done\\\")\"}},\"Number\":{\"id\":\"x%40zJ\",\"name\":\"Number\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:00000000-0000-4000-8000-0000000000f0}}.length()\"}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000d\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000d\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T16:31:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T16:32:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Item
+      Progress\",\"color\":\"pink\",\"description\":null},{\"id\":\"f1d3aded-bb84-437e-9fa8-a6c7e24a2f29\",\"name\":\"Done\",\"color\":\"gray\",\"description\":null}]}},\"Date\":{\"id\":\"%5Ckxk\",\"name\":\"Date\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:CNpy:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}\"}},\"String\":{\"id\":\"dvYQ\",\"name\":\"String\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"format({{notion:block_property:title:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}})\"}},\"Checkbox\":{\"id\":\"hlGb\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}.includes(\\\"Done\\\")\"}},\"Number\":{\"id\":\"x%40zJ\",\"name\":\"Number\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"{{notion:block_property:DUnB:3839ce7b-60a4-8168-ba4d-000b1ee50a86:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}.length()\"}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000d\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000d\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T16:31:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T16:32:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Item
       DB for max relation items\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Item
       DB for max relation items\",\"href\":null}],\"description\":[{\"type\":\"text\",\"text\":{\"content\":\"Database
       of all items\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Database
@@ -1034,7 +1022,7 @@ interactions:
       Purchased\":{\"id\":\"r%7DaJ\",\"name\":\"Items Purchased\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"9528650b-a37a-41a9-8dc2-a8fd21525122\",\"data_source_id\":\"bcd70e03-7cdd-493e-9597-54d38ba4032c\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Bought
       by\",\"synced_property_id\":\"F%3Ebg\"}}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"c05c7705-1005-46af-89f7-3f6d8b87049f\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/c05c7705100546af89f73f6d8b87049f\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"e0fffc4a-19d0-4886-8ff3-4b22a7977dd5\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-24T12:41:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-24T12:42:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"DB
       test with 110 pages\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"DB
-      test with 110 pages\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"f1803c3d-6886-42c9-b073-de3de89868e9\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/f1803c3d688642c9b073de3de89868e9\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8076-9982-000bc09a66e4\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T21:33:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-18T21:33:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Wiki
+      test with 110 pages\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"f1803c3d-6886-42c9-b073-de3de89868e9\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/f1803c3d688642c9b073de3de89868e9\",\"public_url\":null,\"in_trash\":true,\"archived\":true},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8076-9982-000bc09a66e4\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T21:33:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-18T21:33:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Wiki
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Wiki
       DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Tags\":{\"id\":\"dju%60\",\"name\":\"Tags\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"ffb414b1-7c94-4e2d-81bf-5dad675b029d\",\"name\":\"Onboarding\",\"color\":\"blue\",\"description\":null},{\"id\":\"a3b0e7d6-d0c6-4b60-abb3-e1e4e61c69ac\",\"name\":\"Design\",\"color\":\"green\",\"description\":null}]}},\"Last
       edited time\":{\"id\":\"nI%7Bq\",\"name\":\"Last edited time\",\"description\":null,\"type\":\"last_edited_time\",\"last_edited_time\":{}},\"Page\":{\"id\":\"title\",\"name\":\"Page\",\"description\":null,\"type\":\"title\",\"title\":{}},\"Verification\":{\"id\":\"verification\",\"name\":\"Verification\",\"description\":null,\"type\":\"verification\",\"verification\":{}},\"Owner\":{\"id\":\"verification_owner\",\"name\":\"Owner\",\"description\":null,\"type\":\"people\",\"people\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000a\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000a\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8148-99ed-000b1e2cf103\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-18T17:51:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Task
@@ -1046,8 +1034,8 @@ interactions:
       Medium\",\"color\":\"yellow\",\"description\":null},{\"id\":\"6b5dd9b7-709d-4fb1-8d74-dbd81fcafcea\",\"name\":\"\u2736
       Low\",\"color\":\"gray\",\"description\":null}]}},\"Status\":{\"id\":\"U%60%3BC\",\"name\":\"Status\",\"description\":null,\"type\":\"status\",\"status\":{\"options\":[{\"id\":\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"name\":\"Backlog\",\"color\":\"gray\",\"description\":null},{\"id\":\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"name\":\"Blocked\",\"color\":\"red\",\"description\":null},{\"id\":\"34495d82-92d4-431d-a41c-f276fe4ef684\",\"name\":\"In
       Progress\",\"color\":\"blue\",\"description\":null},{\"id\":\"c58aef64-2007-4f6f-8b2c-bc4a7fdbdba8\",\"name\":\"Done\",\"color\":\"green\",\"description\":null}],\"groups\":[{\"id\":\"110fecc9-b3e8-4216-817c-817dd0349707\",\"name\":\"To-do\",\"color\":\"gray\",\"option_ids\":[\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"34495d82-92d4-431d-a41c-f276fe4ef684\",\"c58aef64-2007-4f6f-8b2c-bc4a7fdbdba8\"]},{\"id\":\"2178bb7f-d1f8-46c3-b630-ecd1152a5605\",\"name\":\"In
-      progress\",\"color\":\"blue\",\"option_ids\":[]},{\"id\":\"e1d6813a-42a3-4134-8dad-070ed7607f4e\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[]}]}},\"Urgency\":{\"id\":\"jkwd\",\"name\":\"Urgency\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"if({{notion:block_property:U%60%3BC:3839ce7b-60a4-8148-99ed-000b1e2cf103:00000000-0000-4000-8000-0000000000f0}}
-      == \\\"Done\\\", \\\"\u2705\\\", if(empty({{notion:block_property:lwnn:3839ce7b-60a4-8148-99ed-000b1e2cf103:00000000-0000-4000-8000-0000000000f0}}),
+      progress\",\"color\":\"blue\",\"option_ids\":[]},{\"id\":\"e1d6813a-42a3-4134-8dad-070ed7607f4e\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[]}]}},\"Urgency\":{\"id\":\"jkwd\",\"name\":\"Urgency\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"if({{notion:block_property:U%60%3BC:3839ce7b-60a4-8148-99ed-000b1e2cf103:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}
+      == \\\"Done\\\", \\\"\u2705\\\", if(empty({{notion:block_property:lwnn:3839ce7b-60a4-8148-99ed-000b1e2cf103:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}),
       \\\"\\\", \\\"\U0001F558\\\"))\"}},\"Due Date\":{\"id\":\"lwnn\",\"name\":\"Due
       Date\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Task\":{\"id\":\"title\",\"name\":\"Task\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000c\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000c\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-8180-9ad3-000ba3a62e53\",\"cover\":null,\"icon\":{\"type\":\"emoji\",\"emoji\":\"\U0001F91D\"},\"created_time\":\"2026-06-18T17:51:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_time\":\"2026-06-18T17:51:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Contacts
       DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Contacts
@@ -1065,7 +1053,7 @@ interactions:
       Engineer\",\"color\":\"default\",\"description\":null},{\"id\":\"e10da52f-0244-480b-a82e-151d63f89dbe\",\"name\":\"Technical
       Writer\",\"color\":\"pink\",\"description\":null},{\"id\":\"b28bb506-d608-447b-a064-9a2fa95aa479\",\"name\":\"Business
       Analyst\",\"color\":\"purple\",\"description\":null},{\"id\":\"cf3c60e3-b15f-4730-845d-3c97108e53b2\",\"name\":\"IT
-      Support Specialist\",\"color\":\"yellow\",\"description\":null}]}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000b\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000b\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T16:50:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000fa\"},\"last_edited_time\":\"2026-06-18T17:11:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"All
+      Support Specialist\",\"color\":\"yellow\",\"description\":null}]}},\"Name\":{\"id\":\"title\",\"name\":\"Name\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-00000000000b\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/0000000000004000800000000000000b\",\"public_url\":null,\"in_trash\":false,\"archived\":false},{\"object\":\"data_source\",\"id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"cover\":null,\"icon\":null,\"created_time\":\"2026-06-18T16:50:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"fc820d21-80ec-4d06-878c-f991bc8070d2\"},\"last_edited_time\":\"2026-06-18T17:11:00.000Z\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"All
       Properties DB\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"All
       Properties DB\",\"href\":null}],\"description\":[],\"is_inline\":false,\"properties\":{\"Text\":{\"id\":\"%3FB%3AW\",\"name\":\"Text\",\"description\":null,\"type\":\"rich_text\",\"rich_text\":{}},\"Files\":{\"id\":\"%3FbAF\",\"name\":\"Files\",\"description\":null,\"type\":\"files\",\"files\":{}},\"Phone
       number\":{\"id\":\"%3F~%5Cw\",\"name\":\"Phone number\",\"description\":null,\"type\":\"phone_number\",\"phone_number\":{}},\"URL\":{\"id\":\"CWCZ\",\"name\":\"URL\",\"description\":null,\"type\":\"url\",\"url\":{}},\"Button\":{\"id\":\"ImzP\",\"name\":\"Button\",\"description\":null,\"type\":\"button\",\"button\":{}},\"Checkbox\":{\"id\":\"LGzq\",\"name\":\"Checkbox\",\"description\":null,\"type\":\"checkbox\",\"checkbox\":{}},\"Multi-Select\":{\"id\":\"RIfI\",\"name\":\"Multi-Select\",\"description\":null,\"type\":\"multi_select\",\"multi_select\":{\"options\":[{\"id\":\"0a1263f2-e675-48f0-b60b-2cf6906cb64c\",\"name\":\"MultiOption1\",\"color\":\"purple\",\"description\":null},{\"id\":\"af12f1e2-a65a-402d-ad82-bf58c9fed1f8\",\"name\":\"MultiOption2\",\"color\":\"yellow\",\"description\":null}]}},\"AI
@@ -1076,16 +1064,16 @@ interactions:
       started\",\"color\":\"default\",\"description\":null},{\"id\":\"2f1c6db3-2259-4acb-829c-8cdc98d9913e\",\"name\":\"In
       progress\",\"color\":\"blue\",\"description\":null},{\"id\":\"25c77ace-e80e-4e12-98b8-3b765796e68b\",\"name\":\"Done\",\"color\":\"green\",\"description\":null}],\"groups\":[{\"id\":\"8b3ca9c2-089f-41da-a500-f448ad804a0e\",\"name\":\"To-do\",\"color\":\"gray\",\"option_ids\":[\"1c994aad-fc1f-46d0-b322-51b2b2cb7e6f\"]},{\"id\":\"9e5ecb96-f57e-465a-bff5-f851ecd7c2ca\",\"name\":\"In
       progress\",\"color\":\"blue\",\"option_ids\":[\"2f1c6db3-2259-4acb-829c-8cdc98d9913e\"]},{\"id\":\"9dc509c2-f12c-4c5d-ba00-43e099ba8f99\",\"name\":\"Complete\",\"color\":\"green\",\"option_ids\":[\"25c77ace-e80e-4e12-98b8-3b765796e68b\"]}]}},\"Relation
-      two-way\":{\"id\":\"iywx\",\"name\":\"Relation two-way\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation\",\"synced_property_id\":\"v_%5D%3C\"}}},\"Formula\":{\"id\":\"jeun\",\"name\":\"Formula\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"={{notion:block_property:dDR%3B:3839ce7b-60a4-802c-b152-000ba814957b:00000000-0000-4000-8000-0000000000f0}}*
+      two-way\":{\"id\":\"iywx\",\"name\":\"Relation two-way\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation\",\"synced_property_id\":\"v_%5D%3C\"}}},\"Formula\":{\"id\":\"jeun\",\"name\":\"Formula\",\"description\":null,\"type\":\"formula\",\"formula\":{\"expression\":\"={{notion:block_property:dDR%3B:3839ce7b-60a4-802c-b152-000ba814957b:4bb9ce7b-60a4-817c-8dc5-0003eac3b97a}}*
       2\"}},\"Created time\":{\"id\":\"kRv%7B\",\"name\":\"Created time\",\"description\":null,\"type\":\"created_time\",\"created_time\":{}},\"Last
       edited time\":{\"id\":\"kX%3Fw\",\"name\":\"Last edited time\",\"description\":null,\"type\":\"last_edited_time\",\"last_edited_time\":{}},\"Place\":{\"id\":\"rulX\",\"name\":\"Place\",\"description\":null,\"type\":\"place\",\"place\":{}},\"Date\":{\"id\":\"uUxQ\",\"name\":\"Date\",\"description\":null,\"type\":\"date\",\"date\":{}},\"Relation\":{\"id\":\"v_%5D%3C\",\"name\":\"Relation\",\"description\":null,\"type\":\"relation\",\"relation\":{\"database_id\":\"00000000-0000-4000-8000-000000000009\",\"data_source_id\":\"3839ce7b-60a4-802c-b152-000ba814957b\",\"type\":\"dual_property\",\"dual_property\":{\"synced_property_name\":\"Relation
       two-way\",\"synced_property_id\":\"iywx\"}}},\"Email\":{\"id\":\"wua%3F\",\"name\":\"Email\",\"description\":null,\"type\":\"email\",\"email\":{}},\"People\":{\"id\":\"~ak%40\",\"name\":\"People\",\"description\":null,\"type\":\"people\",\"people\":{}},\"Last
-      edited by\":{\"id\":\"~e%3F%5E\",\"name\":\"Last edited by\",\"description\":null,\"type\":\"last_edited_by\",\"last_edited_by\":{}},\"Title\":{\"id\":\"title\",\"name\":\"Title\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-000000000009\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/00000000000040008000000000000009\",\"public_url\":null,\"in_trash\":false,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"f98259ac-e2fd-4cc9-bdd9-2a3b9cd791b7\"}"
+      edited by\":{\"id\":\"~e%3F%5E\",\"name\":\"Last edited by\",\"description\":null,\"type\":\"last_edited_by\",\"last_edited_by\":{}},\"Title\":{\"id\":\"title\",\"name\":\"Title\",\"description\":null,\"type\":\"title\",\"title\":{}}},\"parent\":{\"type\":\"database_id\",\"database_id\":\"00000000-0000-4000-8000-000000000009\"},\"database_parent\":{\"type\":\"page_id\",\"page_id\":\"00000000-0000-4000-8000-000000000001\"},\"url\":\"https://www.notion.so/00000000000040008000000000000009\",\"public_url\":null,\"in_trash\":false,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"427d8644-e4a7-4bb2-ad99-8b8c740be9a1\"}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230c8be46261f-LHR
+      - a12306596b24bd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1115,7 +1103,7 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - f98259ac-e2fd-4cc9-bdd9-2a3b9cd791b7
+      - 427d8644-e4a7-4bb2-ad99-8b8c740be9a1
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:
@@ -1156,16 +1144,16 @@ interactions:
       Low\",\"color\":\"gray\"}},\"Status\":{\"id\":\"U%60%3BC\",\"type\":\"status\",\"status\":{\"id\":\"079c8b4b-c3bc-4fcd-b523-fcbb94b7911f\",\"name\":\"Backlog\",\"color\":\"gray\"}},\"Urgency\":{\"id\":\"jkwd\",\"type\":\"formula\",\"formula\":{\"type\":\"string\",\"string\":\"\U0001F558\"}},\"Due
       Date\":{\"id\":\"lwnn\",\"type\":\"date\",\"date\":{\"start\":\"2026-07-02T00:00:00.000+00:00\",\"end\":null,\"time_zone\":null}},\"Task\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Buy
       milk\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Buy
-      milk\",\"href\":null}]}},\"url\":\"https://www.notion.so/Buy-milk-3839ce7b60a481358cb7c6657a2dd0d5\",\"public_url\":null,\"archived\":false},{\"object\":\"page\",\"id\":\"3839ce7b-60a4-81c8-867a-f81fd71aa55c\",\"created_time\":\"2026-06-18T17:51:00.000Z\",\"last_edited_time\":\"2026-06-27T04:54:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"cover\":null,\"icon\":null,\"parent\":{\"type\":\"data_source_id\",\"data_source_id\":\"3839ce7b-60a4-8148-99ed-000b1e2cf103\",\"database_id\":\"00000000-0000-4000-8000-00000000000c\"},\"in_trash\":false,\"is_archived\":false,\"is_locked\":false,\"properties\":{\"Priority\":{\"id\":\"DcVz\",\"type\":\"select\",\"select\":{\"id\":\"a6fe934c-2289-481d-a66a-9b468999412d\",\"name\":\"\u2739
+      milk\",\"href\":null}]}},\"url\":\"https://www.notion.so/Buy-milk-3839ce7b60a481358cb7c6657a2dd0d5\",\"public_url\":null,\"archived\":false},{\"object\":\"page\",\"id\":\"3839ce7b-60a4-81c8-867a-f81fd71aa55c\",\"created_time\":\"2026-06-18T17:51:00.000Z\",\"last_edited_time\":\"2026-06-27T05:54:00.000Z\",\"created_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"last_edited_by\":{\"object\":\"user\",\"id\":\"00000000-0000-4000-8000-0000000000f1\"},\"cover\":null,\"icon\":null,\"parent\":{\"type\":\"data_source_id\",\"data_source_id\":\"3839ce7b-60a4-8148-99ed-000b1e2cf103\",\"database_id\":\"00000000-0000-4000-8000-00000000000c\"},\"in_trash\":false,\"is_archived\":false,\"is_locked\":false,\"properties\":{\"Priority\":{\"id\":\"DcVz\",\"type\":\"select\",\"select\":{\"id\":\"a6fe934c-2289-481d-a66a-9b468999412d\",\"name\":\"\u2739
       High\",\"color\":\"red\"}},\"Status\":{\"id\":\"U%60%3BC\",\"type\":\"status\",\"status\":{\"id\":\"f4b3a893-4b26-48db-b839-421daf1f1a25\",\"name\":\"Blocked\",\"color\":\"red\"}},\"Urgency\":{\"id\":\"jkwd\",\"type\":\"formula\",\"formula\":{\"type\":\"string\",\"string\":\"\U0001F558\"}},\"Due
       Date\":{\"id\":\"lwnn\",\"type\":\"date\",\"date\":{\"start\":\"2026-07-01\",\"end\":null,\"time_zone\":null}},\"Task\":{\"id\":\"title\",\"type\":\"title\",\"title\":[{\"type\":\"text\",\"text\":{\"content\":\"Run
       first Marathon\",\"link\":null},\"annotations\":{\"bold\":false,\"italic\":false,\"strikethrough\":false,\"underline\":false,\"code\":false,\"color\":\"default\"},\"plain_text\":\"Run
-      first Marathon\",\"href\":null}]}},\"url\":\"https://www.notion.so/Run-first-Marathon-3839ce7b60a481c8867af81fd71aa55c\",\"public_url\":null,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"515b5e7f-f8b4-4301-9fbc-7dff1b5d6950\"}"
+      first Marathon\",\"href\":null}]}},\"url\":\"https://www.notion.so/Run-first-Marathon-3839ce7b60a481c8867af81fd71aa55c\",\"public_url\":null,\"archived\":false}],\"next_cursor\":null,\"has_more\":false,\"type\":\"page_or_data_source\",\"page_or_data_source\":{},\"request_id\":\"79ee96a6-17a8-42e8-8625-d9bc95fdb9b5\"}"
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-Ray:
-      - a12230cbbc2e261f-LHR
+      - a123065d0ddcbd7b-LHR
       Connection:
       - keep-alive
       Content-Encoding:
@@ -1195,7 +1183,474 @@ interactions:
       x-frame-options:
       - SAMEORIGIN
       x-notion-request-id:
-      - 515b5e7f-f8b4-4301-9fbc-7dff1b5d6950
+      - 79ee96a6-17a8-42e8-8625-d9bc95fdb9b5
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "title": [{"type": "text", "plain_text": "Items", "annotations": {"bold": false,
+      "italic": false, "strikethrough": false, "underline": false, "code": false},
+      "text": {"content": "Items"}}], "is_inline": false, "initial_data_source": {"properties":
+      {"Name": {"type": "title", "title": {}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '341'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"c75ac774-fa68-4499-97f7-80190de5d3a9","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:19:06.942+00:00","last_edited_time":"2026-06-27T08:19:06.942+00:00","data_sources":[{"id":"a81de1b5-9c9b-40f6-aa5c-a8f43ba3ad2d","name":"Items"}],"icon":null,"cover":null,"url":"https://www.notion.so/c75ac774fa68449997f780190de5d3a9","public_url":null,"archived":false,"request_id":"b5a9fb57-f8f8-4010-9977-fb78bdccf60a"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a123065f2f16bd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - b5a9fb57-f8f8-4010-9977-fb78bdccf60a
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/a81de1b5-9c9b-40f6-aa5c-a8f43ba3ad2d
+  response:
+    content: '{"object":"data_source","id":"a81de1b5-9c9b-40f6-aa5c-a8f43ba3ad2d","cover":null,"icon":null,"created_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:19:00.000Z","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"c75ac774-fa68-4499-97f7-80190de5d3a9"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/c75ac774fa68449997f780190de5d3a9","public_url":null,"in_trash":false,"archived":false,"request_id":"72c750e4-9608-4ac5-a363-b0834175d264"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12306648b29bd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 72c750e4-9608-4ac5-a363-b0834175d264
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/c75ac774-fa68-4499-97f7-80190de5d3a9
+  response:
+    content: '{"object":"database","id":"c75ac774-fa68-4499-97f7-80190de5d3a9","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:19:06.942+00:00","last_edited_time":"2026-06-27T08:19:06.942+00:00","data_sources":[{"id":"a81de1b5-9c9b-40f6-aa5c-a8f43ba3ad2d","name":"Items"}],"icon":null,"cover":null,"url":"https://www.notion.so/c75ac774fa68449997f780190de5d3a9","public_url":null,"archived":false,"request_id":"89102971-3077-4aec-8592-f604a43ecbc4"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a12306664c3cbd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 89102971-3077-4aec-8592-f604a43ecbc4
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"parent": {"type": "database_id", "database_id": "c75ac774-fa68-4499-97f7-80190de5d3a9"},
+      "properties": {"Name": {"type": "title", "title": {}}}, "title": [{"type": "text",
+      "plain_text": "Customers", "annotations": {"bold": false, "italic": false, "strikethrough":
+      false, "underline": false, "code": false}, "text": {"content": "Customers"}}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '315'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/data_sources
+  response:
+    content: '{"object":"data_source","id":"38c9ce7b-60a4-81f3-8485-000b8f50a05b","cover":null,"icon":null,"created_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:19:00.000Z","title":[{"type":"text","text":{"content":"Customers","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Customers","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"c75ac774-fa68-4499-97f7-80190de5d3a9"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/c75ac774fa68449997f780190de5d3a9","public_url":null,"in_trash":false,"archived":false,"request_id":"94c20315-1277-4c7a-a7fd-1a22c3cfa11c"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1230667dd29bd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 94c20315-1277-4c7a-a7fd-1a22c3cfa11c
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/c75ac774-fa68-4499-97f7-80190de5d3a9
+  response:
+    content: '{"object":"database","id":"c75ac774-fa68-4499-97f7-80190de5d3a9","title":[{"type":"text","text":{"content":"Items","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Items","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T08:19:06.942+00:00","last_edited_time":"2026-06-27T08:19:06.942+00:00","data_sources":[{"id":"a81de1b5-9c9b-40f6-aa5c-a8f43ba3ad2d","name":"Items"},{"id":"38c9ce7b-60a4-81f3-8485-000b8f50a05b","name":"Customers"}],"icon":null,"cover":null,"url":"https://www.notion.so/c75ac774fa68449997f780190de5d3a9","public_url":null,"archived":false,"request_id":"d2bb3729-0268-4d8c-8c7f-7c73f3821762"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a123066a8f1dbd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - d2bb3729-0268-4d8c-8c7f-7c73f3821762
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"in_trash":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '17'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/data_sources/38c9ce7b-60a4-81f3-8485-000b8f50a05b
+  response:
+    content: '{"object":"data_source","id":"38c9ce7b-60a4-81f3-8485-000b8f50a05b","cover":null,"icon":null,"created_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T08:19:00.000Z","title":[{"type":"text","text":{"content":"Customers","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Customers","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"c75ac774-fa68-4499-97f7-80190de5d3a9"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/c75ac774fa68449997f780190de5d3a9","public_url":null,"in_trash":true,"archived":true,"request_id":"3d150535-b617-433d-b93c-9937a025946a"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a123066c4854bd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 3d150535-b617-433d-b93c-9937a025946a
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/c75ac774-fa68-4499-97f7-80190de5d3a9
+  response:
+    content: '{"object":"block","id":"c75ac774-fa68-4499-97f7-80190de5d3a9","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T08:19:00.000Z","last_edited_time":"2026-06-27T08:19:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"Items"},"archived":true,"request_id":"8bf043ce-e28b-4caf-818e-093131716eee"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1230671fc4cbd7b-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 8bf043ce-e28b-4caf-818e-093131716eee
       x-permitted-cross-domain-policies:
       - none
       x-xss-protection:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -273,3 +273,61 @@ def test_get_or_create_db(notion: uno.Session, root_page: uno.Page) -> None:  # 
 def test_new_task_db(new_task_db: uno.DataSource) -> None:
     # ToDo: Implement a proper test
     pass
+
+
+@pytest.mark.vcr()
+def test_create_db(notion: uno.Session, root_page: uno.Page) -> None:
+    """`create_db` creates a database container with a single initial data source."""
+
+    class Article(uno.Schema, db_title='My Articles'):
+        name = uno.PropType.Title('Name')
+        cost = uno.PropType.Number('Cost', format=uno.NumberFormat.DOLLAR)
+
+    db = notion.create_db(parent=root_page, schema=Article)
+    assert isinstance(db, uno.Database)
+    assert db.is_db
+    assert db.title == 'My Articles'
+
+    ds = db.data_sources.item()
+    assert isinstance(ds, uno.DataSource)
+    # The container is transparent: the data source presents as a child of the page, while its
+    # `database_id` points back to the container we just created.
+    assert ds.parent == root_page
+    assert ds.database_id == db.id
+    assert notion.get_db(ds.database_id).id == db.id
+
+    db.delete()
+    assert db.is_deleted
+    db.restore()
+    assert not db.is_deleted
+    db.delete()
+
+
+@pytest.mark.vcr()
+def test_db_add_remove_data_source(notion: uno.Session, root_page: uno.Page) -> None:
+    """A database can hold multiple data sources that can be added and removed individually."""
+
+    class Items(uno.Schema, db_title='Items'):
+        name = uno.PropType.Title('Name')
+
+    class People(uno.Schema, db_title='People'):
+        name = uno.PropType.Title('Name')
+
+    db = notion.create_db(parent=root_page, schema=Items)
+    assert len(db.data_sources) == 1
+
+    people_ds = db.create_ds(schema=People)
+    assert people_ds.database_id == db.id
+    assert len(db.data_sources) == 2
+    assert {ds.title for ds in db.data_sources} == {'Items', 'People'}
+
+    db.delete_ds(people_ds)
+    assert people_ds.is_deleted
+    assert len(db.data_sources) == 1
+    assert db.data_sources.item().title == 'Items'
+
+    db.restore_ds(people_ds)
+    assert not people_ds.is_deleted
+    assert len(db.data_sources) == 2
+
+    db.delete()


### PR DESCRIPTION
## Description

Implements #401. A `Database` is now a first-class container of data sources: `Session.create_db()` creates one (with its initial data source), `Database.create_ds()`/`delete_ds()`/`restore_ds()` add and remove individual data sources, `Database.data_sources` lists them, and `Database.delete()`/`restore()`/`reload()` operate on the container — all while keeping the container transparent in the page hierarchy. At the low level, `data_sources.create` was repurposed to take a `Database` parent (its only valid use under API 2025-09-03) and `data_sources.update` gained `in_trash` support. The shared schema-prep/bind logic was extracted from `create_ds` and reused. New tests (`test_create_db`, `test_db_add_remove_data_source`) and a docs section were added but their VCR cassettes still need recording against a live workspace.

### Types of change

Enhancement / new feature (plus docs).

## Checklist

- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.