### PR TITLE
feat: Move a data source between databases and lock/unlock objects (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.10, 2026-
 
+- New: Lock or unlock pages, data sources, and databases for editing via the writable `Page.is_locked`, `DataSource.is_locked`, and `Database.is_locked` properties, and move a data source to a different parent database with `DataSource.move()`. Enabled by the Notion API version 2025-09-03, issue #402.
 - New: Better logging of model validation errors, issue #152.
 - Breaking: Adopt the Notion API version 2025-09-03, which splits the former "database" into two concepts: a *data source* (holds the schema and pages) and a *database* (a container of one or more data sources), issue #118. This requires `notion-client~=2.7.0` and renames much of the high-level API. To migrate:
     - The former `Database` class (schema + pages) is now `DataSource`. The name `Database` now refers to the new container; access its data sources via `Database.data_sources`.

--- a/src/ultimate_notion/database.py
+++ b/src/ultimate_notion/database.py
@@ -189,6 +189,18 @@ class DataSource(DataContainer[obj_blocks.DataSource], wraps=obj_blocks.DataSour
             text = Text.from_plain_text(text)
         self._update_container_db(description=text.obj_ref)
 
+    # `is_locked` lives on the containing database, not the data source. The data-source response
+    # does not mirror it, so the getter reads it from the database and the setter writes it there.
+    @property
+    def is_locked(self) -> bool:
+        """Return whether this data source's database is locked for editing."""
+        return get_active_session().get_db(self.database_id, use_cache=False).is_locked
+
+    @is_locked.setter
+    def is_locked(self, locked: bool) -> None:
+        """Lock or unlock this data source's database for editing."""
+        self._update_container_db(is_locked=locked)
+
     def _update_container_db(self, **fields: Any) -> None:
         """Update the containing database (where `description`/`is_inline` live) and refresh self."""
         session = get_active_session()
@@ -198,6 +210,21 @@ class DataSource(DataContainer[obj_blocks.DataSource], wraps=obj_blocks.DataSour
         db_ref = obj_blocks.Database.model_construct(id=parent.database_id)
         session.api.databases.update(db_ref, **fields)
         self.obj_ref = session.api.data_sources.retrieve(self.id)
+
+    def move(self, database: Database) -> Self:
+        """Move this data source to a different parent database.
+
+        Reassigns the data source from its current container database to `database`. Cached
+        children of the old and new parent are invalidated so the hierarchy reflects the move.
+        """
+        session = get_active_session()
+        old_parent = self.parent
+        session.api.data_sources.update(self.obj_ref, parent=objs.DatabaseRef.build(database.id))
+        self.obj_ref = session.api.data_sources.retrieve(self.id)
+        for parent in (old_parent, database.parent):
+            if isinstance(parent, ChildrenMixin):
+                parent._children = None  # forces a new retrieval of children next time
+        return self
 
     def delete(self) -> Self:
         """Delete this data source."""
@@ -368,6 +395,20 @@ class Database(DataContainer[obj_blocks.Database], wraps=obj_blocks.Database):
             session = get_active_session()
             session.api.databases.update(self.obj_ref, inline=inline)
             self.obj_ref.is_inline = inline
+
+    @property
+    def is_locked(self) -> bool:
+        """Return whether the database is locked for editing."""
+        if is_unset(locked := self.obj_ref.is_locked):
+            raise UnsetError()
+        return locked
+
+    @is_locked.setter
+    def is_locked(self, locked: bool) -> None:
+        """Lock or unlock this database for editing."""
+        session = get_active_session()
+        session.api.databases.update(self.obj_ref, is_locked=locked)
+        self.obj_ref.is_locked = locked
 
     @property
     def is_db(self) -> bool:

--- a/src/ultimate_notion/obj_api/endpoints.py
+++ b/src/ultimate_notion/obj_api/endpoints.py
@@ -286,6 +286,7 @@ class DataSourcesEndpoint(Endpoint):
         self,
         ds: DataSource,
         *,
+        parent: SerializeAsAny[ParentRef] | None = None,
         title: list[RichTextBaseObject] | None = None,
         description: list[RichTextBaseObject] | None = None,
         inline: bool | None = None,
@@ -293,13 +294,16 @@ class DataSourcesEndpoint(Endpoint):
     ) -> None:
         """Update the DataSource object on the server.
 
-        The data source info will be updated to the latest version from the server.
+        The data source info will be updated to the latest version from the server. Passing a
+        `parent` (a `DatabaseRef`) reassigns the data source to a different parent database.
 
         API reference: https://developers.notion.com/reference/update-a-data-source
         """
         _logger.debug(f'Updating info of data source with id `{ds.id}`.')
 
-        if request := self._build_request(schema=schema, title=title, description=description, inline=inline):
+        if request := self._build_request(
+            parent=parent, schema=schema, title=title, description=description, inline=inline
+        ):
             data = self._as_dict(self.raw_api.update(str(ds.id), **request))
             ds.update(**data)
 
@@ -365,6 +369,7 @@ class DatabasesEndpoint(Endpoint):
         title: list[RichTextBaseObject] | None = None,
         description: list[RichTextBaseObject] | None = None,
         inline: bool | None = None,
+        is_locked: bool | None = None,
     ) -> dict[str, Any]:
         """Build a request payload from the given items.
 
@@ -384,6 +389,9 @@ class DatabasesEndpoint(Endpoint):
 
         if inline is not None:
             request['is_inline'] = inline
+
+        if is_locked is not None:
+            request['is_locked'] = is_locked
 
         return request
 
@@ -428,6 +436,7 @@ class DatabasesEndpoint(Endpoint):
         title: list[RichTextBaseObject] | None = None,
         description: list[RichTextBaseObject] | None = None,
         inline: bool | None = None,
+        is_locked: bool | None = None,
     ) -> None:
         """Update the Database object on the server.
 
@@ -437,7 +446,7 @@ class DatabasesEndpoint(Endpoint):
         """
         _logger.debug(f'Updating info of database with id `{db.id}`.')
 
-        if request := self._build_request(title=title, description=description, inline=inline):
+        if request := self._build_request(title=title, description=description, inline=inline, is_locked=is_locked):
             data = self._as_dict(self.raw_api.update(str(db.id), **request))
             db.update(**data)
 
@@ -559,6 +568,7 @@ class PagesEndpoint(Endpoint):
         cover: FileObject | UnsetType | None = Unset,
         icon: FileObject | EmojiObject | CustomEmojiObject | UnsetType | None = Unset,
         in_trash: bool | UnsetType = Unset,
+        is_locked: bool | UnsetType = Unset,
     ) -> None:
         """Update the Page object properties on the server."""
         if is_unset(page_id := page.id):
@@ -596,6 +606,10 @@ class PagesEndpoint(Endpoint):
                 _logger.debug(f'Restoring page with id `{page_id}`.')
                 request['archived'] = False
 
+        if not is_unset(is_locked):
+            _logger.debug(f'Setting `is_locked={is_locked}` on page with id `{page_id}`.')
+            request['is_locked'] = is_locked
+
         data = self._as_dict(self.raw_api.update(page_id.hex, **request))
         page.update(**data)
 
@@ -606,6 +620,7 @@ class PagesEndpoint(Endpoint):
         cover: FileObject | UnsetType | None = Unset,
         icon: FileObject | EmojiObject | CustomEmojiObject | UnsetType | None = Unset,
         in_trash: bool | UnsetType = Unset,
+        is_locked: bool | UnsetType = Unset,
     ) -> None:
         """Set specific page attributes (such as cover, icon, etc.) on the server.
 
@@ -639,6 +654,10 @@ class PagesEndpoint(Endpoint):
             else:
                 _logger.debug(f'Restoring page with id `{page_id}`.')
                 props['archived'] = False
+
+        if not is_unset(is_locked):
+            _logger.debug(f'Setting `is_locked={is_locked}` on page with id `{page_id}`.')
+            props['is_locked'] = is_locked
 
         data = self._as_dict(self.raw_api.update(page_id.hex, **props))
         page.update(**data)

--- a/src/ultimate_notion/page.py
+++ b/src/ultimate_notion/page.py
@@ -163,6 +163,12 @@ class Page(
             raise UnsetError()
         return is_locked
 
+    @is_locked.setter
+    def is_locked(self, locked: bool) -> None:
+        """Lock or unlock this page for editing."""
+        session = get_active_session()
+        session.api.pages.set_attr(self.obj_ref, is_locked=locked)
+
     @property
     def url(self) -> str:
         """Return the URL of this page."""

--- a/tests/cassettes/test_database/test_lock_unlock_db.yaml
+++ b/tests/cassettes/test_database/test_lock_unlock_db.yaml
@@ -1,0 +1,544 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "is_inline": false, "initial_data_source": {"properties": {"Name": {"type":
+      "title", "title": {}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:23:55.824+00:00","last_edited_time":"2026-06-27T12:23:55.824+00:00","data_sources":[{"id":"415cf832-a897-469a-8e0f-6655dbc3049a","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/5016ae66770a4e23ac0ddaf03a0b21c6","public_url":null,"archived":false,"request_id":"52f711e5-5295-4d9f-9d67-bc039dd3ebe0"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246cfccf81d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 52f711e5-5295-4d9f-9d67-bc039dd3ebe0
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/415cf832-a897-469a-8e0f-6655dbc3049a
+  response:
+    content: '{"object":"data_source","id":"415cf832-a897-469a-8e0f-6655dbc3049a","cover":null,"icon":null,"created_time":"2026-06-27T12:23:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:23:00.000Z","title":[],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/5016ae66770a4e23ac0ddaf03a0b21c6","public_url":null,"in_trash":false,"archived":false,"request_id":"57d8a434-e474-4f4e-a161-b258ee2e0c0d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d035878d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 57d8a434-e474-4f4e-a161-b258ee2e0c0d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/5016ae66-770a-4e23-ac0d-daf03a0b21c6
+  response:
+    content: '{"object":"database","id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:23:55.824+00:00","last_edited_time":"2026-06-27T12:23:55.824+00:00","data_sources":[{"id":"415cf832-a897-469a-8e0f-6655dbc3049a","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/5016ae66770a4e23ac0ddaf03a0b21c6","public_url":null,"archived":false,"request_id":"988c6130-5b7c-45af-8eb7-b2537cc52dd0"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d051d63d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 988c6130-5b7c-45af-8eb7-b2537cc52dd0
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"is_locked":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '18'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/databases/5016ae66-770a-4e23-ac0d-daf03a0b21c6
+  response:
+    content: '{"object":"database","id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":true,"created_time":"2026-06-27T12:23:55.824+00:00","last_edited_time":"2026-06-27T12:23:55.824+00:00","data_sources":[{"id":"415cf832-a897-469a-8e0f-6655dbc3049a","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/5016ae66770a4e23ac0ddaf03a0b21c6","public_url":null,"archived":false,"request_id":"a7ecc6af-95d3-458d-873d-e6992434817d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d06b9c1d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - a7ecc6af-95d3-458d-873d-e6992434817d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/5016ae66-770a-4e23-ac0d-daf03a0b21c6
+  response:
+    content: '{"object":"database","id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":true,"created_time":"2026-06-27T12:23:55.824+00:00","last_edited_time":"2026-06-27T12:23:55.824+00:00","data_sources":[{"id":"415cf832-a897-469a-8e0f-6655dbc3049a","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/5016ae66770a4e23ac0ddaf03a0b21c6","public_url":null,"archived":false,"request_id":"ba7e5657-6de9-49b7-bac3-ad767d58c84a"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d106be8d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - ba7e5657-6de9-49b7-bac3-ad767d58c84a
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"is_locked":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/databases/5016ae66-770a-4e23-ac0d-daf03a0b21c6
+  response:
+    content: '{"object":"database","id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:23:55.824+00:00","last_edited_time":"2026-06-27T12:23:55.824+00:00","data_sources":[{"id":"415cf832-a897-469a-8e0f-6655dbc3049a","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/5016ae66770a4e23ac0ddaf03a0b21c6","public_url":null,"archived":false,"request_id":"6a799b85-d828-4cc3-9499-38b83ce625e5"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d120805d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 6a799b85-d828-4cc3-9499-38b83ce625e5
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/5016ae66-770a-4e23-ac0d-daf03a0b21c6
+  response:
+    content: '{"object":"block","id":"5016ae66-770a-4e23-ac0d-daf03a0b21c6","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T12:23:00.000Z","last_edited_time":"2026-06-27T12:23:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"New
+      database"},"archived":true,"request_id":"aec3bab5-c7f0-4518-92e2-3199a83e0447"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d1578b7d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - aec3bab5-c7f0-4518-92e2-3199a83e0447
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/00000000-0000-4000-8000-000000000001
+  response:
+    content: '{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T12:23:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false,"request_id":"2abc6792-dba5-4740-9d32-ae8f517a18ad"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d1dd974d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 2abc6792-dba5-4740-9d32-ae8f517a18ad
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_database/test_lock_unlock_ds.yaml
+++ b/tests/cassettes/test_database/test_lock_unlock_ds.yaml
@@ -1,0 +1,739 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "is_inline": false, "initial_data_source": {"properties": {"Name": {"type":
+      "title", "title": {}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:01.359+00:00","last_edited_time":"2026-06-27T12:24:01.359+00:00","data_sources":[{"id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"archived":false,"request_id":"f69d37a8-bf1b-41c2-8226-2de40a5e8cef"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d1f6dd8d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f69d37a8-bf1b-41c2-8226-2de40a5e8cef
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/925350b7-c59d-49f0-8b60-5c96f6d5bc0b
+  response:
+    content: '{"object":"data_source","id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"40dfcb90-c58a-4b8a-8713-b994edf0f960"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"in_trash":false,"archived":false,"request_id":"0b3a5431-857e-4c11-ac9a-f94dc3651c28"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d297fced1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 0b3a5431-857e-4c11-ac9a-f94dc3651c28
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/40dfcb90-c58a-4b8a-8713-b994edf0f960
+  response:
+    content: '{"object":"database","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:01.359+00:00","last_edited_time":"2026-06-27T12:24:01.359+00:00","data_sources":[{"id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"archived":false,"request_id":"19943788-159c-41e6-acc3-dce3de15064d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d2b1c87d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 19943788-159c-41e6-acc3-dce3de15064d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"is_locked":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '18'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/databases/40dfcb90-c58a-4b8a-8713-b994edf0f960
+  response:
+    content: '{"object":"database","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":true,"created_time":"2026-06-27T12:24:01.359+00:00","last_edited_time":"2026-06-27T12:24:01.359+00:00","data_sources":[{"id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"archived":false,"request_id":"2a96c5c0-c7b8-4cde-a127-c9597a34b3e3"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d2cc942d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 2a96c5c0-c7b8-4cde-a127-c9597a34b3e3
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/925350b7-c59d-49f0-8b60-5c96f6d5bc0b
+  response:
+    content: '{"object":"data_source","id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"40dfcb90-c58a-4b8a-8713-b994edf0f960"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"in_trash":false,"archived":false,"request_id":"b320a357-62a7-435a-b76c-59226a6f28c6"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d318fd0d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - b320a357-62a7-435a-b76c-59226a6f28c6
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/40dfcb90-c58a-4b8a-8713-b994edf0f960
+  response:
+    content: '{"object":"database","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":true,"created_time":"2026-06-27T12:24:01.359+00:00","last_edited_time":"2026-06-27T12:24:01.359+00:00","data_sources":[{"id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"archived":false,"request_id":"9d19fb23-a3f6-43d6-a01a-1b6ebbed0bf7"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d330b62d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 9d19fb23-a3f6-43d6-a01a-1b6ebbed0bf7
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"is_locked":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/databases/40dfcb90-c58a-4b8a-8713-b994edf0f960
+  response:
+    content: '{"object":"database","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:01.359+00:00","last_edited_time":"2026-06-27T12:24:01.359+00:00","data_sources":[{"id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"archived":false,"request_id":"0411088c-87be-4cb0-a40c-40ffd60c212c"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d34af2ed1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 0411088c-87be-4cb0-a40c-40ffd60c212c
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/925350b7-c59d-49f0-8b60-5c96f6d5bc0b
+  response:
+    content: '{"object":"data_source","id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"40dfcb90-c58a-4b8a-8713-b994edf0f960"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"in_trash":false,"archived":false,"request_id":"34f0be30-adb2-4537-9834-215a11861fba"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d379e9ed1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 34f0be30-adb2-4537-9834-215a11861fba
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/40dfcb90-c58a-4b8a-8713-b994edf0f960
+  response:
+    content: '{"object":"database","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","title":[{"type":"text","text":{"content":"New
+      database","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"New
+      database","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:01.359+00:00","last_edited_time":"2026-06-27T12:24:01.359+00:00","data_sources":[{"id":"925350b7-c59d-49f0-8b60-5c96f6d5bc0b","name":"New
+      database"}],"icon":null,"cover":null,"url":"https://www.notion.so/40dfcb90c58a4b8a8713b994edf0f960","public_url":null,"archived":false,"request_id":"006cbd4a-4163-4a5f-b8cb-54ba25d9e3cb"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d39abbdd1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 006cbd4a-4163-4a5f-b8cb-54ba25d9e3cb
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/40dfcb90-c58a-4b8a-8713-b994edf0f960
+  response:
+    content: '{"object":"block","id":"40dfcb90-c58a-4b8a-8713-b994edf0f960","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"New
+      database"},"archived":true,"request_id":"db0720e2-7ba7-45bb-8c24-6acd1b01442d"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d3b68f5d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - db0720e2-7ba7-45bb-8c24-6acd1b01442d
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/00000000-0000-4000-8000-000000000001
+  response:
+    content: '{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false,"request_id":"054d73c8-51f2-4f4d-ae9b-b4f3dc330702"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d426b36d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 054d73c8-51f2-4f4d-ae9b-b4f3dc330702
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_database/test_move_ds.yaml
+++ b/tests/cassettes/test_database/test_move_ds.yaml
@@ -1,0 +1,683 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "title": [{"type": "text", "plain_text": "Movable DS", "annotations": {"bold":
+      false, "italic": false, "strikethrough": false, "underline": false, "code":
+      false}, "text": {"content": "Movable DS"}}], "is_inline": false, "initial_data_source":
+      {"properties": {"Name": {"type": "title", "title": {}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '351'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"78c56816-69e5-460f-a894-eadfc9921162","title":[{"type":"text","text":{"content":"Movable
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Movable
+      DS","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:07.263+00:00","last_edited_time":"2026-06-27T12:24:07.263+00:00","data_sources":[{"id":"009652d3-d7ce-4d32-add4-3ec027649bed","name":"Movable
+      DS"}],"icon":null,"cover":null,"url":"https://www.notion.so/78c5681669e5460fa894eadfc9921162","public_url":null,"archived":false,"request_id":"738890c4-bf6f-46a9-8d50-f336326f65b2"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d440f73d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 738890c4-bf6f-46a9-8d50-f336326f65b2
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/009652d3-d7ce-4d32-add4-3ec027649bed
+  response:
+    content: '{"object":"data_source","id":"009652d3-d7ce-4d32-add4-3ec027649bed","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[{"type":"text","text":{"content":"Movable
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Movable
+      DS","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"78c56816-69e5-460f-a894-eadfc9921162"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/78c5681669e5460fa894eadfc9921162","public_url":null,"in_trash":false,"archived":false,"request_id":"ee383f16-7cea-40a5-b586-ce30ec59d39f"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d4a1ef7d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - ee383f16-7cea-40a5-b586-ce30ec59d39f
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "title": [{"type": "text", "plain_text": "Target DS", "annotations": {"bold":
+      false, "italic": false, "strikethrough": false, "underline": false, "code":
+      false}, "text": {"content": "Target DS"}}], "is_inline": false, "initial_data_source":
+      {"properties": {"Name": {"type": "title", "title": {}}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '349'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/databases
+  response:
+    content: '{"object":"database","id":"297ebdec-1648-4349-bb64-053e14f1c4ab","title":[{"type":"text","text":{"content":"Target
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
+      DS","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:08.526+00:00","last_edited_time":"2026-06-27T12:24:08.526+00:00","data_sources":[{"id":"4ff11952-ffa6-465f-8739-478393e3fc3e","name":"Target
+      DS"}],"icon":null,"cover":null,"url":"https://www.notion.so/297ebdec16484349bb64053e14f1c4ab","public_url":null,"archived":false,"request_id":"a667667d-8119-46ce-800b-0b66bfa7f26f"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d4baac5d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - a667667d-8119-46ce-800b-0b66bfa7f26f
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/4ff11952-ffa6-465f-8739-478393e3fc3e
+  response:
+    content: '{"object":"data_source","id":"4ff11952-ffa6-465f-8739-478393e3fc3e","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[{"type":"text","text":{"content":"Target
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
+      DS","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"297ebdec-1648-4349-bb64-053e14f1c4ab"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/297ebdec16484349bb64053e14f1c4ab","public_url":null,"in_trash":false,"archived":false,"request_id":"b5f7ef03-a288-4920-89b4-b41f8b4b703f"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d56edd0d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - b5f7ef03-a288-4920-89b4-b41f8b4b703f
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/297ebdec-1648-4349-bb64-053e14f1c4ab
+  response:
+    content: '{"object":"database","id":"297ebdec-1648-4349-bb64-053e14f1c4ab","title":[{"type":"text","text":{"content":"Target
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
+      DS","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:08.526+00:00","last_edited_time":"2026-06-27T12:24:08.526+00:00","data_sources":[{"id":"4ff11952-ffa6-465f-8739-478393e3fc3e","name":"Target
+      DS"}],"icon":null,"cover":null,"url":"https://www.notion.so/297ebdec16484349bb64053e14f1c4ab","public_url":null,"archived":false,"request_id":"54ed6997-0e21-41a1-bf28-d48417a81126"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d588a7ed1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 54ed6997-0e21-41a1-bf28-d48417a81126
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/00000000-0000-4000-8000-000000000001
+  response:
+    content: '{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false,"request_id":"f3590ee0-2236-4254-8a9c-f8ab0af25fdb"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d5a1f06d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f3590ee0-2236-4254-8a9c-f8ab0af25fdb
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"parent":{"type":"database_id","database_id":"297ebdec-1648-4349-bb64-053e14f1c4ab"}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '86'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/data_sources/009652d3-d7ce-4d32-add4-3ec027649bed
+  response:
+    content: '{"object":"data_source","id":"009652d3-d7ce-4d32-add4-3ec027649bed","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[{"type":"text","text":{"content":"Movable
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Movable
+      DS","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"297ebdec-1648-4349-bb64-053e14f1c4ab"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/297ebdec16484349bb64053e14f1c4ab","public_url":null,"in_trash":false,"archived":false,"request_id":"da95c488-e98f-4be4-bf47-a692eda1a7cf"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d5c5c10d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - da95c488-e98f-4be4-bf47-a692eda1a7cf
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/data_sources/009652d3-d7ce-4d32-add4-3ec027649bed
+  response:
+    content: '{"object":"data_source","id":"009652d3-d7ce-4d32-add4-3ec027649bed","cover":null,"icon":null,"created_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_time":"2026-06-27T12:24:00.000Z","title":[{"type":"text","text":{"content":"Movable
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Movable
+      DS","href":null}],"description":[],"is_inline":false,"properties":{"Name":{"id":"title","name":"Name","description":null,"type":"title","title":{}}},"parent":{"type":"database_id","database_id":"297ebdec-1648-4349-bb64-053e14f1c4ab"},"database_parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"url":"https://www.notion.so/297ebdec16484349bb64053e14f1c4ab","public_url":null,"in_trash":false,"archived":false,"request_id":"06e17a18-d7b5-4675-bae3-bbed360212d4"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d62ff0dd1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 06e17a18-d7b5-4675-bae3-bbed360212d4
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/databases/297ebdec-1648-4349-bb64-053e14f1c4ab
+  response:
+    content: '{"object":"database","id":"297ebdec-1648-4349-bb64-053e14f1c4ab","title":[{"type":"text","text":{"content":"Target
+      DS","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Target
+      DS","href":null}],"description":[],"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"is_inline":false,"in_trash":false,"is_locked":false,"created_time":"2026-06-27T12:24:08.526+00:00","last_edited_time":"2026-06-27T12:24:08.526+00:00","data_sources":[{"id":"4ff11952-ffa6-465f-8739-478393e3fc3e","name":"Target
+      DS"},{"id":"009652d3-d7ce-4d32-add4-3ec027649bed","name":"Movable DS"}],"icon":null,"cover":null,"url":"https://www.notion.so/297ebdec16484349bb64053e14f1c4ab","public_url":null,"archived":false,"request_id":"f1e575ca-be40-4f88-b1ae-1b8e9fce3441"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d650ccfd1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - f1e575ca-be40-4f88-b1ae-1b8e9fce3441
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: DELETE
+    uri: https://api.notion.com/v1/blocks/297ebdec-1648-4349-bb64-053e14f1c4ab
+  response:
+    content: '{"object":"block","id":"297ebdec-1648-4349-bb64-053e14f1c4ab","parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"has_children":false,"in_trash":true,"type":"child_database","child_database":{"title":"Target
+      DS"},"archived":true,"request_id":"0498dd2c-9ac3-4ba3-b017-b8e42c17d21a"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246d67fbd8d1fb-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 0498dd2c-9ac3-4ba3-b017-b8e42c17d21a
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/cassettes/test_page/test_lock_unlock_page.yaml
+++ b/tests/cassettes/test_page/test_lock_unlock_page.yaml
@@ -1,0 +1,415 @@
+interactions:
+- request:
+    body: '{"parent": {"type": "page_id", "page_id": "00000000-0000-4000-8000-000000000001"},
+      "properties": {"title": {"type": "title", "title": [{"type": "text", "plain_text":
+      "Lockable page", "annotations": {"bold": false, "italic": false, "strikethrough":
+      false, "underline": false, "code": false}, "text": {"content": "Lockable page"}}]}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '305'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: POST
+    uri: https://api.notion.com/v1/pages
+  response:
+    content: '{"object":"page","id":"38c9ce7b-60a4-818b-bca1-ef1f61ca0b9c","created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Lockable
+      page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lockable
+      page","href":null}]}},"url":"https://www.notion.so/Lockable-page-38c9ce7b60a4818bbca1ef1f61ca0b9c","public_url":null,"archived":false,"request_id":"c583287c-31fb-477d-9613-97ad1c207c09"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246da6dea1ed0f-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - c583287c-31fb-477d-9613-97ad1c207c09
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/00000000-0000-4000-8000-000000000001
+  response:
+    content: '{"object":"page","id":"00000000-0000-4000-8000-000000000001","created_time":"2026-06-18T15:44:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"fc820d21-80ec-4d06-878c-f991bc8070d2"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"workspace","workspace":true},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Tests","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Tests","href":null}]}},"url":"https://www.notion.so/Tests-00000000000040008000000000000001","public_url":null,"archived":false,"request_id":"95a327c4-7888-4453-a500-cf899d27639e"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246da91bd5ed0f-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 95a327c4-7888-4453-a500-cf899d27639e
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"is_locked":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '18'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/pages/38c9ce7b60a4818bbca1ef1f61ca0b9c
+  response:
+    content: '{"object":"page","id":"38c9ce7b-60a4-818b-bca1-ef1f61ca0b9c","created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":true,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Lockable
+      page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lockable
+      page","href":null}]}},"url":"https://www.notion.so/Lockable-page-38c9ce7b60a4818bbca1ef1f61ca0b9c","public_url":null,"archived":false,"request_id":"e4a3b30f-588b-4dca-bd8c-938972966565"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246dab4913ed0f-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - e4a3b30f-588b-4dca-bd8c-938972966565
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: GET
+    uri: https://api.notion.com/v1/pages/38c9ce7b-60a4-818b-bca1-ef1f61ca0b9c
+  response:
+    content: '{"object":"page","id":"38c9ce7b-60a4-818b-bca1-ef1f61ca0b9c","created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":true,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Lockable
+      page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lockable
+      page","href":null}]}},"url":"https://www.notion.so/Lockable-page-38c9ce7b60a4818bbca1ef1f61ca0b9c","public_url":null,"archived":false,"request_id":"07f5ac5d-4910-4ef9-b247-70669a4bb315"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246db36bd9ed0f-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 07f5ac5d-4910-4ef9-b247-70669a4bb315
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"is_locked":false}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/pages/38c9ce7b60a4818bbca1ef1f61ca0b9c
+  response:
+    content: '{"object":"page","id":"38c9ce7b-60a4-818b-bca1-ef1f61ca0b9c","created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":false,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Lockable
+      page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lockable
+      page","href":null}]}},"url":"https://www.notion.so/Lockable-page-38c9ce7b60a4818bbca1ef1f61ca0b9c","public_url":null,"archived":false,"request_id":"bbc2fc22-db2b-4f29-b18b-028468fac202"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246db4ef4aed0f-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - bbc2fc22-db2b-4f29-b18b-028468fac202
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"archived":true}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - secret...
+      connection:
+      - keep-alive
+      content-length:
+      - '17'
+      content-type:
+      - application/json
+      cookie:
+      - secret...
+      host:
+      - api.notion.com
+      notion-version:
+      - '2025-09-03'
+      user-agent:
+      - secret...
+    method: PATCH
+    uri: https://api.notion.com/v1/pages/38c9ce7b60a4818bbca1ef1f61ca0b9c
+  response:
+    content: '{"object":"page","id":"38c9ce7b-60a4-818b-bca1-ef1f61ca0b9c","created_time":"2026-06-27T12:24:00.000Z","last_edited_time":"2026-06-27T12:24:00.000Z","created_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"last_edited_by":{"object":"user","id":"00000000-0000-4000-8000-0000000000f1"},"cover":null,"icon":null,"parent":{"type":"page_id","page_id":"00000000-0000-4000-8000-000000000001"},"in_trash":true,"is_archived":false,"is_locked":false,"properties":{"title":{"id":"title","type":"title","title":[{"type":"text","text":{"content":"Lockable
+      page","link":null},"annotations":{"bold":false,"italic":false,"strikethrough":false,"underline":false,"code":false,"color":"default"},"plain_text":"Lockable
+      page","href":null}]}},"url":"https://www.notion.so/Lockable-page-38c9ce7b60a4818bbca1ef1f61ca0b9c","public_url":null,"archived":true,"request_id":"5438573b-787c-481f-ade8-2be0eec650ec"}'
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - a1246db76db5ed0f-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-security-policy:
+      - default-src 'none'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      x-content-type-options:
+      - nosniff
+      x-dns-prefetch-control:
+      - 'off'
+      x-download-options:
+      - noopen
+      x-frame-options:
+      - SAMEORIGIN
+      x-notion-request-id:
+      - 5438573b-787c-481f-ade8-2be0eec650ec
+      x-permitted-cross-domain-policies:
+      - none
+      x-xss-protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ from _pytest.fixtures import SubRequest
 from google.auth.exceptions import RefreshError
 from vcr import VCR  # type: ignore[import-untyped]
 from vcr import mode as vcr_mode
+from vcr.errors import CannotOverwriteExistingCassetteException  # type: ignore[import-untyped]
 from vcr.persisters.filesystem import FilesystemPersister  # type: ignore[import-untyped]
 
 import ultimate_notion as uno
@@ -403,6 +404,21 @@ def pytest_exception_interact(node: pytest.Item, call: pytest.CallInfo[Any], rep
         input_errors = '\n'.join(str(e['input']) for e in exc_value.errors())
         msg = f'Following erroneous inputs to the pydantic model {exc_value.title}:\n{input_errors}'
         logging.error(msg)
+
+    elif isinstance(exc_value, CannotOverwriteExistingCassetteException):
+        # VCR's own message ("Can't overwrite existing cassette ... in record mode 'none'") is
+        # misleading: in pure-replay mode (CI's `vcr-only`) the usual cause is a *missing* or
+        # non-matching cassette for a new/changed test, not a write attempt. Surface an actionable
+        # hint as a report section (visible in the failure output, unlike a captured log line).
+        # See the "Add a new live (VCR) test" section in `CONTRIBUTING.md`.
+        msg = (
+            f'No matching cassette interaction for `{node.nodeid}` in offline-replay mode.\n'
+            'This usually means the test is new or its requests changed, so its cassette is missing '
+            'or out of date. Record it live against your Notion test workspace with:\n'
+            f'  hatch run vcr-rewrite -k {node.name}\n'
+            'then verify the replay with `hatch run vcr-only` and commit the new cassette(s).'
+        )
+        report.sections.append(('How to fix this VCR failure', msg))
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -163,6 +163,56 @@ def test_description_setter(notion: uno.Session, article_db: uno.DataSource) -> 
 
 
 @pytest.mark.vcr()
+def test_lock_unlock_db(notion: uno.Session, root_page: uno.Page) -> None:
+    ds = notion.create_ds(root_page)
+    db = notion.get_db(ds.database_id)
+    assert not db.is_locked
+
+    db.is_locked = True
+    assert db.is_locked
+    # clear the cache and retrieve again to be sure it was updated on the server side
+    db = notion.get_db(db.id, use_cache=False)
+    assert db.is_locked
+
+    db.is_locked = False
+    assert not db.is_locked
+    ds.delete()
+
+
+@pytest.mark.vcr()
+def test_lock_unlock_ds(notion: uno.Session, root_page: uno.Page) -> None:
+    ds = notion.create_ds(root_page)
+    assert not ds.is_locked
+
+    ds.is_locked = True
+    assert ds.is_locked
+
+    ds.is_locked = False
+    assert not ds.is_locked
+    ds.delete()
+
+
+@pytest.mark.vcr()
+def test_move_ds(notion: uno.Session, root_page: uno.Page) -> None:
+    ds = notion.create_ds(root_page, title='Movable DS')
+    target_ds = notion.create_ds(root_page, title='Target DS')
+    target_db = notion.get_db(target_ds.database_id)
+
+    assert ds.parent == root_page
+    assert ds.database_id != target_db.id
+
+    ds.move(target_db)
+    assert ds.database_id == target_db.id
+    assert ds.parent == root_page
+
+    # the target database now holds both data sources
+    target_db = notion.get_db(target_db.id, use_cache=False)
+    assert {member.id for member in target_db.data_sources} == {ds.id, target_ds.id}
+
+    ds.delete()
+
+
+@pytest.mark.vcr()
 def test_delete_restore_db(notion: uno.Session, root_page: uno.Page) -> None:
     db = notion.create_ds(root_page)
     assert not db.is_deleted

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -45,6 +45,22 @@ def test_delete_restore_page(notion: uno.Session, root_page: uno.Page) -> None:
 
 
 @pytest.mark.vcr()
+def test_lock_unlock_page(notion: uno.Session, root_page: uno.Page) -> None:
+    page = notion.create_page(root_page, title='Lockable page')
+    assert not page.is_locked
+
+    page.is_locked = True
+    assert page.is_locked
+    # clear the cache and retrieve again to be sure it was updated on the server side
+    page = notion.get_page(page.id, use_cache=False)
+    assert page.is_locked
+
+    page.is_locked = False
+    assert not page.is_locked
+    page.delete()
+
+
+@pytest.mark.vcr()
 def test_reload_page(notion: uno.Session, root_page: uno.Page) -> None:
     page = notion.create_page(root_page)
     old_obj_id = id(page.obj_ref)


### PR DESCRIPTION
## Description

Implements #402, enabled by the Notion API version 2025-09-03. Adds the writable `Page.is_locked`, `DataSource.is_locked`, and `Database.is_locked` properties to lock or unlock objects for editing, plus `DataSource.move()` to reassign a data source to a different parent database. Since the container database is transparent in the high-level API and carries the lock state, `DataSource.is_locked` delegates to its containing database. The low-level `pages`/`databases`/`data_sources` update endpoints gained the corresponding `is_locked`/`parent` parameters, and new tests cover each path. Note: the new tests are not yet recorded as VCR cassettes.

### Types of change

Enhancement / new feature.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)