### PR TITLE
Cut Version 0.10 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Version 0.10, 2026-
+## Unreleased
+
+## Version 0.10, 2026-06-27
 
 - New: Support tab blocks via the new `Tabs` block, which groups content into labeled tabs. Each tab is a `Paragraph` whose text is the tab label and whose children hold the tab content. Create tabs up front with `Tabs([...labels])` or add them later with `Tabs.add_tab()`, issue #188.
 - New: Support icons on tab labels (and paragraphs): read or write a paragraph's icon via the new `Paragraph.icon` property (mirroring `Page.icon`), pass an optional `icon` to `Tabs.add_tab()`, and render it in `Tabs.to_markdown()`, issue #421.


### PR DESCRIPTION
## Description

Prepare the 0.10 release by finalizing the changelog: set the release date on the `## Version 0.10` section to 2026-06-27 and restore an empty `## Unreleased` section for the next cycle. The release itself is git-tag-driven via hatch-vcs — once merged, tagging `v0.10` on `main` triggers the PyPI publish workflow. No code changes.

### Types of change

Documentation / release prep.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.