### PR TITLE
docs: Cut Version 0.10.1 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.10.1, 2026-06-28
+
 - Fix: Populate the high-level children cache when constructing `Tabs` or `Columns` directly, so an offline-built block exposes its tabs/columns (`.tabs`/`.columns`, `has_children`) and uploads its children instead of an empty container when pushed to Notion. Previously only the low-level `obj_ref` was filled, contradicting the documented offline build-then-push workflow, issue #424.
 
 ## Version 0.10, 2026-06-27


### PR DESCRIPTION
## Description

Cut **Version 0.10.1** in the changelog: the previously `Unreleased` section (the single fix for issue #424 — populating the high-level children cache when constructing `Tabs`/`Columns` directly) is now a dated release section (2026-06-28), with a fresh empty `Unreleased` section left at the top. This is the only commit since the 0.10 cut, so it is a patch release.

### Types of change

Documentation (changelog / release preparation).

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
