### PR TITLE
fix(obj_api): Default FileUpload.archived and in_trash (#427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Version 0.10.1, 2026-06-28
 
+- Fix: Default the undocumented read-only `archived` and `in_trash` fields on `FileUpload`, since the file-upload create endpoint omits `archived`, which previously raised a pydantic `ValidationError` and blocked every local-file upload via `Session.upload`, issue #427.
 - Fix: Populate the high-level children cache when constructing `Tabs` or `Columns` directly, so an offline-built block exposes its tabs/columns (`.tabs`/`.columns`, `has_children`) and uploads its children instead of an empty container when pushed to Notion. Previously only the low-level `obj_ref` was filled, contradicting the documented offline build-then-push workflow, issue #424.
 
 ## Version 0.10, 2026-06-27

--- a/src/ultimate_notion/obj_api/objects.py
+++ b/src/ultimate_notion/obj_api/objects.py
@@ -786,8 +786,8 @@ class FileUpload(NotionObject, object='file_upload'):
     upload_url: str | None = None
     complete_url: str | None = None
     file_import_result: FileImportResult | None = None
-    archived: bool  # undocumented but sent by the API
-    in_trash: bool  # undocumented but sent by the API
+    archived: bool = False  # undocumented and not sent by the create endpoint
+    in_trash: bool = False  # undocumented but sent by the API
     created_by: User  # undocumented but sent by the API
 
 

--- a/tests/obj_api/test_objects.py
+++ b/tests/obj_api/test_objects.py
@@ -100,3 +100,25 @@ def test_unsupported_block() -> None:
     }
     block = obj_blocks.UnsupportedBlock.model_validate(raw_block)
     assert block.unsupported.block_type == 'button'
+
+
+def test_file_upload_create_response_without_archived() -> None:
+    # The file-upload create endpoint does not return the undocumented read-only
+    # `archived` field. Validation must still succeed with a safe default,
+    # otherwise every local-file upload fails. See issue #427.
+    raw_upload = {
+        'object': 'file_upload',
+        'id': '00000000-0000-4000-8000-0000000004bc',
+        'created_time': '2026-06-18T17:19:00.000Z',
+        'last_edited_time': '2026-06-18T17:19:00.000Z',
+        'expiry_time': '2026-06-18T18:19:00.000Z',
+        'status': 'pending',
+        'filename': 'favicon.png',
+        'content_type': 'image/png',
+        'content_length': None,
+        'upload_url': 'https://api.notion.com/v1/file_uploads/x/send',
+        'in_trash': False,
+        'created_by': {'object': 'user', 'id': '00000000-0000-4000-8000-0000000000f1'},
+    }
+    upload = objs.FileUpload.model_validate(raw_upload)
+    assert upload.archived is False


### PR DESCRIPTION
## Summary

`Session.upload(...)` failed against the live Notion API because `FileUpload` declared `archived` as a required field, but the file-upload **create** endpoint's response does not include `archived`. Every local-file upload therefore raised a `ValidationError`, blocking uploads of any page containing a local image/video/audio/PDF/file block.

This mirrors the earlier `in_trash` problem (#299, fixed by #303) — the same class of bug for `archived`.

## Changes

- Default the undocumented read-only fields on `FileUpload` that the create endpoint may omit: `archived: bool = False` and `in_trash: bool = False` (a freshly created upload is neither archived nor trashed). `created_by` is left required, since it is present on observed create responses.
- Add an offline regression test validating a create-endpoint response that omits `archived`.
- Changelog entry (under the still-unreleased 0.10.1).

Fixes #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)