### PR TITLE
docs(blocks): clarify has_children behavior

### DIFF
--- a/src/ultimate_notion/blocks.py
+++ b/src/ultimate_notion/blocks.py
@@ -123,7 +123,12 @@ class DataObject(NotionEntity[DO_co], wraps=obj_blocks.DataObject):
 
     @property
     def has_children(self) -> bool:
-        """Return whether the object has children."""
+        """Return whether the object has children without fetching them.
+
+        This value comes from metadata included in the object's Notion API response. In contrast,
+        accessing `children` (including through `len(obj.children)`) can make an API call when the
+        children have not been cached yet.
+        """
         return self.obj_ref.has_children
 
     def _delete_me_from_parent(self) -> None:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description

Clarify that `has_children` reads metadata already included in the Notion API response without fetching child objects. Document that accessing `children`, including through `len(obj.children)`, can make an API call when the child cache is empty. Fixes #175.

Testing: `hatch run vcr-only` (220 passed, 14 skipped), `hatch run lint:ruff check src/ultimate_notion/blocks.py`, and `hatch run docs:build`.

### Types of change

Documentation.

## Checklist

- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [ ] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and only the new & modified tests fail since they are not yet recorded.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
