### PR TITLE
feat: Configure notion-client request retries

### DIFF
--- a/src/ultimate_notion/obj_api/__init__.py
+++ b/src/ultimate_notion/obj_api/__init__.py
@@ -64,6 +64,9 @@ def create_notion_client(cfg: Config, **kwargs: Any) -> notion_client.Client:
     kwargs.setdefault('logger', logging.getLogger('notion_client'))
     kwargs.setdefault('log_level', logging.NOTSET)
     kwargs.setdefault('notion_version', NOTION_API_VERSION)
+    # Retry transient API failures (rate limits and idempotent requests that receive 5xx responses) using the
+    # SDK's exponential backoff. Configure this explicitly even though the SDK currently enables it by default.
+    kwargs.setdefault('retry', notion_client.RetryOptions())
 
     def log_request(request: httpx.Request) -> None:
         msg = f'Request: {request.method} {request.url}'

--- a/tests/obj_api/test_client.py
+++ b/tests/obj_api/test_client.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import notion_client
+import pytest
+
+from ultimate_notion.config import Config, UNOCfg
+from ultimate_notion.obj_api import create_notion_client
+
+
+@pytest.fixture(autouse=True)
+def notion_cleanups() -> None:
+    """Disable the live Notion cleanup fixture for these isolated client tests."""
+
+
+def _test_config() -> Config:
+    return Config(ultimate_notion=UNOCfg(token='secret', cfg_path=Path(__file__)))
+
+
+def test_create_notion_client_configures_sdk_retry() -> None:
+    with patch.object(notion_client, 'Client', autospec=True) as sdk_client:
+        create_notion_client(_test_config())
+
+    retry = sdk_client.call_args.kwargs['retry']
+    assert retry == notion_client.RetryOptions(
+        max_retries=2,
+        initial_retry_delay_ms=1000,
+        max_retry_delay_ms=60000,
+    )
+    sdk_client.call_args.kwargs['client'].close()
+
+
+def test_create_notion_client_preserves_retry_override() -> None:
+    retry = notion_client.RetryOptions(max_retries=4, initial_retry_delay_ms=10, max_retry_delay_ms=100)
+    with patch.object(notion_client, 'Client', autospec=True) as sdk_client:
+        create_notion_client(_test_config(), retry=retry)
+
+    assert sdk_client.call_args.kwargs['retry'] is retry
+    sdk_client.call_args.kwargs['client'].close()
+
+
+def test_notion_client_retries_rate_limit_response() -> None:
+    requests: list[httpx.Request] = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(
+                429,
+                headers={'Retry-After': '0'},
+                json={
+                    'object': 'error',
+                    'status': 429,
+                    'code': 'rate_limited',
+                    'message': 'slow down',
+                    'request_id': 'request-id',
+                },
+            )
+        return httpx.Response(200, json={'ok': True})
+
+    client = create_notion_client(_test_config())
+    client.client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    try:
+        response = client.request(path='users/me', method='GET')
+    finally:
+        client.close()
+
+    assert response == {'ok': True}
+    assert len(requests) == 2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
our contribution guidelines: https://ultimate-notion.com/dev/contributing/

Provide a general summary of your changes in the title.
-->

## Description
Explicitly configure notion-client RetryOptions so transient rate limits and safe server errors use its built-in exponential backoff, while preserving caller overrides and the existing HTTPX connection retries.
Adds isolated coverage for the SDK defaults, custom overrides, and a rate-limited request that succeeds on retry; `hatch run vcr-only --no-cov` passed with 227 tests and 14 skips.
Fixes #413.

### Types of change
Enhancement.

## Checklist
- [x] The "Allow edits from maintainers" checkbox is checked on this pull request.
      This allows the maintainers to make minor adjustments or fixes and update the VCR cassettes.
- [x] I confirm that I have the right to submit this contribution under the projects MIT license.
- [x] I ran the tests with at least `hatch run vcr-only`, and all recorded and new tests pass.
- [x] My changes do not require a change to the documentation.